### PR TITLE
feat(util): ConfigSchema validator with per-process schemas (#69)

### DIFF
--- a/common/util/include/util/config_validator.h
+++ b/common/util/include/util/config_validator.h
@@ -1,0 +1,362 @@
+// common/util/include/util/config_validator.h
+// Startup-time JSON config validation using a programmatic schema.
+//
+// Usage:
+//   auto schema = ConfigSchema()
+//       .required<int>("slam.vio_rate_hz").range(1, 10000)
+//       .required<double>("mission_planner.takeoff_altitude_m").range(0.5, 500.0)
+//       .optional<std::string>("log_level").one_of({"trace","debug","info","warn","error","critical"})
+//       .required_section("video_capture");
+//
+//   auto result = validate(cfg, schema);
+//   if (result.is_err()) {
+//       for (auto& msg : result.error()) spdlog::error("{}", msg);
+//       return EXIT_FAILURE;
+//   }
+#pragma once
+#include <cmath>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "util/config.h"
+#include "util/result.h"
+
+namespace drone::util {
+
+// ── Validation rule (type-erased) ───────────────────────────
+// Each rule checks one aspect of the config and appends errors to a list.
+using ValidationRule = std::function<void(const Config&, std::vector<std::string>&)>;
+
+// ── Helper: walk a dot-separated key to a JSON node ─────────
+inline const nlohmann::json* walk_key(const nlohmann::json& root, const std::string& key) {
+    const auto* node  = &root;
+    size_t      start = 0;
+    while (start < key.size()) {
+        size_t      dot  = key.find('.', start);
+        std::string part = key.substr(start, dot - start);
+        if (!node->contains(part)) return nullptr;
+        node = &(*node)[part];
+        if (dot == std::string::npos) break;
+        start = dot + 1;
+    }
+    return node;
+}
+
+// ── Abstract base for type-erased field rules ──────────────
+// Uses virtual dispatch (vtable) instead of shared_ptr to avoid
+// atomic refcount overhead — critical for real-time drone software.
+
+class IFieldRuleBase {
+public:
+    virtual ~IFieldRuleBase() = default;
+    [[nodiscard]] virtual ValidationRule build() const = 0;
+};
+
+// ── Builder for a single field rule ─────────────────────────
+// Fluent API: schema.required<int>("key").range(1, 100)
+//             schema.optional<std::string>("key").one_of({"a","b"})
+
+class ConfigSchema;  // forward
+
+template<typename T>
+class FieldRule : public IFieldRuleBase {
+public:
+    FieldRule(ConfigSchema& schema, std::string key, bool required)
+        : schema_(schema), key_(std::move(key)), required_(required) {}
+
+    /// Value must be in [lo, hi].
+    FieldRule& range(T lo, T hi) {
+        range_lo_ = lo;
+        range_hi_ = hi;
+        has_range_ = true;
+        return *this;
+    }
+
+    /// Value must be one of the given set (string / integral types).
+    FieldRule& one_of(std::initializer_list<T> values) {
+        allowed_ = std::set<T>(values);
+        return *this;
+    }
+
+    /// Value must satisfy a custom predicate.
+    FieldRule& satisfies(std::function<bool(const T&)> pred, std::string description) {
+        custom_pred_        = std::move(pred);
+        custom_description_ = std::move(description);
+        return *this;
+    }
+
+    /// Finalize and return the schema (for continued chaining on the next field).
+    ConfigSchema& done() { return schema_; }
+
+    // Build the actual validation rule (called internally by ConfigSchema).
+    [[nodiscard]] ValidationRule build() const override {
+        // Copy captures for the lambda
+        auto key              = key_;
+        auto required         = required_;
+        auto has_range        = has_range_;
+        auto range_lo         = range_lo_;
+        auto range_hi         = range_hi_;
+        auto allowed          = allowed_;
+        auto custom_pred      = custom_pred_;
+        auto custom_desc      = custom_description_;
+
+        return [=](const Config& cfg, std::vector<std::string>& errors) {
+            const auto* node = walk_key(cfg.raw(), key);
+
+            // 1. Presence check
+            if (node == nullptr) {
+                if (required) {
+                    errors.push_back("Missing required key: " + key);
+                }
+                return;  // Optional + missing → OK, skip further checks
+            }
+
+            // 2. Type check
+            T val{};
+            try {
+                val = node->get<T>();
+            } catch (...) {
+                errors.push_back("Type mismatch for key '" + key + "': expected " +
+                                 type_name() + ", got " + node->type_name());
+                return;
+            }
+
+            // 3. Range check
+            if (has_range) {
+                if (val < range_lo || val > range_hi) {
+                    std::ostringstream oss;
+                    oss << "Out of range for '" << key << "': " << val
+                        << " (expected [" << range_lo << ", " << range_hi << "])";
+                    errors.push_back(oss.str());
+                }
+            }
+
+            // 4. one_of check
+            if (!allowed.empty()) {
+                if (allowed.find(val) == allowed.end()) {
+                    std::ostringstream oss;
+                    oss << "Invalid value for '" << key << "': ";
+                    oss << val << " (expected one of: ";
+                    bool first = true;
+                    for (const auto& a : allowed) {
+                        if (!first) oss << ", ";
+                        oss << a;
+                        first = false;
+                    }
+                    oss << ")";
+                    errors.push_back(oss.str());
+                }
+            }
+
+            // 5. Custom predicate
+            if (custom_pred && !custom_pred(val)) {
+                errors.push_back("Validation failed for '" + key + "': " + custom_desc);
+            }
+        };
+    }
+
+private:
+    static std::string type_name() {
+        if constexpr (std::is_same_v<T, int>)         return "integer";
+        if constexpr (std::is_same_v<T, double>)      return "number";
+        if constexpr (std::is_same_v<T, float>)       return "number";
+        if constexpr (std::is_same_v<T, bool>)        return "boolean";
+        if constexpr (std::is_same_v<T, std::string>) return "string";
+        return "unknown";
+    }
+
+    ConfigSchema&                 schema_;
+    std::string                   key_;
+    bool                          required_ = false;
+    bool                          has_range_ = false;
+    T                             range_lo_{};
+    T                             range_hi_{};
+    std::set<T>                   allowed_;
+    std::function<bool(const T&)> custom_pred_;
+    std::string                   custom_description_;
+};
+
+// ── ConfigSchema ────────────────────────────────────────────
+// Builder-pattern schema definition.  Collects field rules and section
+// presence checks.
+
+class ConfigSchema {
+public:
+    /// Declare a required field with type T.
+    template<typename T>
+    FieldRule<T>& required(const std::string& key) {
+        auto uptr = std::make_unique<FieldRule<T>>(*this, key, true);
+        auto& ref = *uptr;
+        field_rules_.push_back(std::move(uptr));
+        return ref;
+    }
+
+    /// Declare an optional field with type T (validated if present).
+    template<typename T>
+    FieldRule<T>& optional(const std::string& key) {
+        auto uptr = std::make_unique<FieldRule<T>>(*this, key, false);
+        auto& ref = *uptr;
+        field_rules_.push_back(std::move(uptr));
+        return ref;
+    }
+
+    /// Require that a JSON section (object) exists.
+    ConfigSchema& required_section(const std::string& key) {
+        auto k = key;
+        extra_rules_.emplace_back([k](const Config& cfg, std::vector<std::string>& errors) {
+            if (!cfg.has(k)) {
+                errors.push_back("Missing required section: " + k);
+            }
+        });
+        return *this;
+    }
+
+    /// Add a fully custom validation rule.
+    ConfigSchema& custom(ValidationRule rule) {
+        extra_rules_.push_back(std::move(rule));
+        return *this;
+    }
+
+    /// Build all rules into a flat list.
+    [[nodiscard]] std::vector<ValidationRule> build() const {
+        std::vector<ValidationRule> rules;
+        rules.reserve(field_rules_.size() + extra_rules_.size());
+        for (const auto& fr : field_rules_) {
+            rules.push_back(fr->build());
+        }
+        for (const auto& r : extra_rules_) {
+            rules.push_back(r);
+        }
+        return rules;
+    }
+
+private:
+    // Owning storage for type-erased field rules.  unique_ptr gives
+    // stable heap addresses so returned references remain valid even
+    // when the vector reallocates.
+    std::vector<std::unique_ptr<IFieldRuleBase>> field_rules_;
+    std::vector<ValidationRule>                  extra_rules_;
+};
+
+// ── validate() — run a schema against a Config ──────────────
+// Returns ok() if all rules pass, or err(vector of messages).
+
+[[nodiscard]] inline Result<void, std::vector<std::string>>
+validate(const Config& cfg, const ConfigSchema& schema) {
+    std::vector<std::string> errors;
+    auto rules = schema.build();
+    for (auto& rule : rules) {
+        rule(cfg, errors);
+    }
+    if (errors.empty()) {
+        return Result<void, std::vector<std::string>>::ok();
+    }
+    return Result<void, std::vector<std::string>>::err(std::move(errors));
+}
+
+// ── Common schemas ──────────────────────────────────────────
+// Pre-built schemas for each process.  Call drone::util::common_schema()
+// to get the shared rules, then add process-specific ones.
+
+inline ConfigSchema common_schema() {
+    ConfigSchema s;
+    s.optional<std::string>("log_level")
+        .one_of({"trace", "debug", "info", "warn", "error", "critical"});
+    s.optional<std::string>("ipc_backend").one_of({"shm", "zenoh"});
+    return s;
+}
+
+inline ConfigSchema video_capture_schema() {
+    auto s = common_schema();
+    s.required_section("video_capture");
+    s.required<int>("video_capture.mission_cam.width").range(1, 7680);
+    s.required<int>("video_capture.mission_cam.height").range(1, 4320);
+    s.required<int>("video_capture.mission_cam.fps").range(1, 240);
+    s.optional<int>("video_capture.stereo_cam.width").range(1, 7680);
+    s.optional<int>("video_capture.stereo_cam.height").range(1, 4320);
+    s.optional<int>("video_capture.stereo_cam.fps").range(1, 240);
+    return s;
+}
+
+inline ConfigSchema perception_schema() {
+    auto s = common_schema();
+    s.required_section("perception");
+    s.optional<double>("perception.detector.confidence_threshold").range(0.0, 1.0);
+    s.optional<double>("perception.detector.nms_threshold").range(0.0, 1.0);
+    s.optional<int>("perception.detector.max_detections").range(1, 10000);
+    s.optional<int>("perception.tracker.max_age").range(1, 1000);
+    s.optional<int>("perception.tracker.min_hits").range(1, 100);
+    s.optional<double>("perception.tracker.max_association_cost").range(0.0, 10000.0);
+    return s;
+}
+
+inline ConfigSchema slam_schema() {
+    auto s = common_schema();
+    s.required_section("slam");
+    s.required<int>("slam.vio_rate_hz").range(1, 10000);
+    s.optional<int>("slam.visual_frontend_rate_hz").range(1, 1000);
+    s.optional<int>("slam.imu_rate_hz").range(1, 10000);
+    s.optional<double>("slam.keyframe.min_parallax_px").range(0.0, 1000.0);
+    s.optional<double>("slam.keyframe.min_tracked_ratio").range(0.0, 1.0);
+    s.optional<double>("slam.keyframe.max_time_sec").range(0.001, 60.0);
+    return s;
+}
+
+inline ConfigSchema mission_planner_schema() {
+    auto s = common_schema();
+    s.required_section("mission_planner");
+    s.required<int>("mission_planner.update_rate_hz").range(1, 1000);
+    s.required<double>("mission_planner.takeoff_altitude_m").range(0.5, 500.0);
+    s.optional<double>("mission_planner.acceptance_radius_m").range(0.1, 100.0);
+    s.optional<double>("mission_planner.cruise_speed_mps").range(0.1, 50.0);
+    s.optional<double>("mission_planner.obstacle_avoidance.min_distance_m").range(0.1, 100.0);
+    // fault_manager section
+    s.optional<int>("fault_manager.pose_stale_timeout_ms").range(1, 60000);
+    s.optional<double>("fault_manager.battery_warn_percent").range(1.0, 100.0);
+    s.optional<double>("fault_manager.battery_crit_percent").range(0.0, 100.0);
+    return s;
+}
+
+inline ConfigSchema comms_schema() {
+    auto s = common_schema();
+    s.required_section("comms");
+    s.optional<int>("comms.mavlink.heartbeat_rate_hz").range(1, 100);
+    s.optional<int>("comms.mavlink.tx_rate_hz").range(1, 1000);
+    s.optional<int>("comms.mavlink.rx_rate_hz").range(1, 1000);
+    s.optional<int>("comms.gcs.udp_port").range(1, 65535);
+    s.optional<int>("comms.gcs.telemetry_rate_hz").range(1, 100);
+    return s;
+}
+
+inline ConfigSchema payload_manager_schema() {
+    auto s = common_schema();
+    s.required_section("payload_manager");
+    s.required<int>("payload_manager.update_rate_hz").range(1, 1000);
+    s.optional<double>("payload_manager.gimbal.max_slew_rate_dps").range(0.1, 1000.0);
+    s.optional<double>("payload_manager.gimbal.pitch_min_deg").range(-180.0, 0.0);
+    s.optional<double>("payload_manager.gimbal.pitch_max_deg").range(0.0, 180.0);
+    return s;
+}
+
+inline ConfigSchema system_monitor_schema() {
+    auto s = common_schema();
+    s.required_section("system_monitor");
+    s.required<int>("system_monitor.update_rate_hz").range(1, 100);
+    s.optional<double>("system_monitor.thresholds.cpu_warn_percent").range(0.0, 100.0);
+    s.optional<double>("system_monitor.thresholds.mem_warn_percent").range(0.0, 100.0);
+    s.optional<double>("system_monitor.thresholds.temp_warn_c").range(0.0, 200.0);
+    s.optional<double>("system_monitor.thresholds.temp_crit_c").range(0.0, 200.0);
+    s.optional<double>("system_monitor.thresholds.battery_warn_percent").range(0.0, 100.0);
+    s.optional<double>("system_monitor.thresholds.battery_crit_percent").range(0.0, 100.0);
+    return s;
+}
+
+}  // namespace drone::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,9 @@ add_drone_test(test_fusion_engine   test_fusion_engine.cpp
 # ── Config system tests ──────────────────────────────────────
 add_drone_test(test_config          test_config.cpp)
 
+# ── Config validator tests ───────────────────────────────────
+add_drone_test(test_config_validator test_config_validator.cpp)
+
 # ── Result<T,E> type tests ───────────────────────────────────
 add_drone_test(test_result          test_result.cpp)
 

--- a/tests/test_config_validator.cpp
+++ b/tests/test_config_validator.cpp
@@ -1,0 +1,338 @@
+// tests/test_config_validator.cpp
+// Unit tests for ConfigSchema / validate().
+#include "util/config_validator.h"
+
+#include <cstdio>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+using drone::util::ConfigSchema;
+using drone::util::validate;
+
+class ConfigValidatorTest : public ::testing::Test {
+protected:
+    std::string tmp_path_;
+    drone::Config cfg_;
+
+    void load_json(const std::string& content) {
+        tmp_path_ = "/tmp/drone_test_validator_" + std::to_string(::getpid()) + ".json";
+        std::ofstream ofs(tmp_path_);
+        ofs << content;
+        ofs.close();
+        ASSERT_TRUE(cfg_.load(tmp_path_));
+    }
+
+    void TearDown() override {
+        if (!tmp_path_.empty()) std::remove(tmp_path_.c_str());
+    }
+};
+
+// ─── Valid config passes ─────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, ValidConfigPasses) {
+    load_json(R"({
+        "log_level": "info",
+        "slam": { "vio_rate_hz": 100 }
+    })");
+
+    ConfigSchema s;
+    s.required<int>("slam.vio_rate_hz").range(1, 10000);
+    s.optional<std::string>("log_level").one_of({"trace", "debug", "info", "warn", "error"});
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+// ─── Missing required key ────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, MissingRequiredKey) {
+    load_json(R"({})");
+
+    ConfigSchema s;
+    s.required<int>("slam.vio_rate_hz");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Missing required key"), std::string::npos);
+    EXPECT_NE(r.error()[0].find("slam.vio_rate_hz"), std::string::npos);
+}
+
+// ─── Missing optional key → OK ───────────────────────────────
+
+TEST_F(ConfigValidatorTest, MissingOptionalKeyOk) {
+    load_json(R"({})");
+
+    ConfigSchema s;
+    s.optional<int>("nonexistent_key").range(1, 100);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+// ─── Out of range ────────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, OutOfRange) {
+    load_json(R"({"rate": 0})");
+
+    ConfigSchema s;
+    s.required<int>("rate").range(1, 1000);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Out of range"), std::string::npos);
+}
+
+TEST_F(ConfigValidatorTest, OutOfRangeAbove) {
+    load_json(R"({"rate": 99999})");
+
+    ConfigSchema s;
+    s.required<int>("rate").range(1, 1000);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Out of range"), std::string::npos);
+}
+
+TEST_F(ConfigValidatorTest, InRangeBoundary) {
+    load_json(R"({"rate": 1})");
+
+    ConfigSchema s;
+    s.required<int>("rate").range(1, 1000);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+// ─── Wrong type ──────────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, TypeMismatch) {
+    load_json(R"({"rate": "fast"})");
+
+    ConfigSchema s;
+    s.required<int>("rate");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Type mismatch"), std::string::npos);
+}
+
+// ─── one_of check ────────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, OneOfValid) {
+    load_json(R"({"log_level": "debug"})");
+
+    ConfigSchema s;
+    s.required<std::string>("log_level").one_of({"trace", "debug", "info"});
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, OneOfInvalid) {
+    load_json(R"({"log_level": "verbose"})");
+
+    ConfigSchema s;
+    s.required<std::string>("log_level").one_of({"trace", "debug", "info"});
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Invalid value"), std::string::npos);
+    EXPECT_NE(r.error()[0].find("verbose"), std::string::npos);
+}
+
+// ─── required_section ────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, RequiredSectionPresent) {
+    load_json(R"({"slam": {"vio_rate_hz": 100}})");
+
+    ConfigSchema s;
+    s.required_section("slam");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, RequiredSectionMissing) {
+    load_json(R"({})");
+
+    ConfigSchema s;
+    s.required_section("slam");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("Missing required section"), std::string::npos);
+}
+
+// ─── Multiple errors collected ───────────────────────────────
+
+TEST_F(ConfigValidatorTest, MultipleErrors) {
+    load_json(R"({"log_level": "verbose"})");
+
+    ConfigSchema s;
+    s.required<int>("rate").range(1, 100);
+    s.required<std::string>("log_level").one_of({"info", "debug"});
+    s.required_section("slam");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    // Should collect all 3 errors: missing rate, invalid log_level, missing slam
+    EXPECT_EQ(r.error().size(), 3u);
+}
+
+// ─── Custom predicate ────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, CustomPredicatePass) {
+    load_json(R"({"port": 8080})");
+
+    ConfigSchema s;
+    s.required<int>("port").satisfies(
+        [](const int& p) { return p > 1024; }, "port must be > 1024");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, CustomPredicateFail) {
+    load_json(R"({"port": 80})");
+
+    ConfigSchema s;
+    s.required<int>("port").satisfies(
+        [](const int& p) { return p > 1024; }, "port must be > 1024");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("port must be > 1024"), std::string::npos);
+}
+
+// ─── Double range ────────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, DoubleRange) {
+    load_json(R"({"gain": 0.5})");
+
+    ConfigSchema s;
+    s.required<double>("gain").range(0.0, 1.0);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, DoubleOutOfRange) {
+    load_json(R"({"gain": 1.5})");
+
+    ConfigSchema s;
+    s.required<double>("gain").range(0.0, 1.0);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+}
+
+// ─── Pre-built process schemas ───────────────────────────────
+
+TEST_F(ConfigValidatorTest, DefaultConfigPassesAllSchemas) {
+    // Load the actual default.json — it should pass all schemas
+    drone::Config cfg;
+    bool loaded = cfg.load("config/default.json");
+    if (!loaded) {
+        GTEST_SKIP() << "config/default.json not available (CWD-dependent)";
+    }
+
+    auto check = [&](const char* name, ConfigSchema schema) {
+        auto r = validate(cfg, schema);
+        if (r.is_err()) {
+            for (const auto& e : r.error()) {
+                ADD_FAILURE() << name << ": " << e;
+            }
+        }
+    };
+
+    check("video_capture",    drone::util::video_capture_schema());
+    check("perception",       drone::util::perception_schema());
+    check("slam",             drone::util::slam_schema());
+    check("mission_planner",  drone::util::mission_planner_schema());
+    check("comms",            drone::util::comms_schema());
+    check("payload_manager",  drone::util::payload_manager_schema());
+    check("system_monitor",   drone::util::system_monitor_schema());
+}
+
+// ─── Bool field ──────────────────────────────────────────────
+
+TEST_F(ConfigValidatorTest, BoolField) {
+    load_json(R"({"enabled": true})");
+
+    ConfigSchema s;
+    s.required<bool>("enabled");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, BoolFieldTypeMismatch) {
+    load_json(R"({"enabled": "yes"})");
+
+    ConfigSchema s;
+    s.required<bool>("enabled");
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    EXPECT_NE(r.error()[0].find("Type mismatch"), std::string::npos);
+}
+
+// ─── Nested key validation ───────────────────────────────────
+
+TEST_F(ConfigValidatorTest, DeeplyNestedKey) {
+    load_json(R"({"a": {"b": {"c": 42}}})");
+
+    ConfigSchema s;
+    s.required<int>("a.b.c").range(0, 100);
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+// ─── Custom rule on schema ───────────────────────────────────
+
+TEST_F(ConfigValidatorTest, CustomRuleOnSchema) {
+    load_json(R"({"battery_warn": 20, "battery_crit": 10})");
+
+    ConfigSchema s;
+    s.required<int>("battery_warn");
+    s.required<int>("battery_crit");
+    s.custom([](const drone::Config& cfg, std::vector<std::string>& errors) {
+        auto warn = cfg.get<int>("battery_warn", 0);
+        auto crit = cfg.get<int>("battery_crit", 0);
+        if (crit >= warn) {
+            errors.push_back("battery_crit must be less than battery_warn");
+        }
+    });
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, CustomRuleFails) {
+    load_json(R"({"battery_warn": 10, "battery_crit": 20})");
+
+    ConfigSchema s;
+    s.required<int>("battery_warn");
+    s.required<int>("battery_crit");
+    s.custom([](const drone::Config& cfg, std::vector<std::string>& errors) {
+        auto warn = cfg.get<int>("battery_warn", 0);
+        auto crit = cfg.get<int>("battery_crit", 0);
+        if (crit >= warn) {
+            errors.push_back("battery_crit must be less than battery_warn");
+        }
+    });
+
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    EXPECT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("battery_crit must be less than battery_warn"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Implements **Issue #69 — Config schema validation** with a programmatic `ConfigSchema` builder that validates JSON configs at startup.

Depends on PR #75 (`infra/issue-68-result-type`) for `Result<T,E>`.

## What's New

### `config_validator.h`
- **`ConfigSchema`** builder pattern with fluent API:
  - `.required<T>(key)` / `.optional<T>(key)` — typed field declarations
  - `.range(lo, hi)` — numeric bounds checking
  - `.one_of({...})` — enumerated value validation
  - `.satisfies(pred, desc)` — custom predicate with error description
  - `.required_section(key)` — JSON object presence check
  - `.custom(rule)` — arbitrary validation lambda
- **`validate(cfg, schema)`** → `Result<void, vector<string>>` — collects all errors in one pass
- **Pre-built schemas** for all 7 processes + common schema
- **Type erasure via virtual base class + `unique_ptr`** — zero atomic refcount overhead (no `shared_ptr`), suitable for real-time drone software

### Design Decisions
- Virtual dispatch (vtable) over `shared_ptr` for type erasure — avoids atomic reference counting overhead critical in real-time systems
- All errors collected in a single pass (no fail-fast) — operator sees every issue at once
- `FieldRule<T>` inherits from `IFieldRuleBase` with `build()` override
- `unique_ptr<IFieldRuleBase>` stored in vector for stable reference addresses

## Tests

22 new tests in `test_config_validator.cpp`:
- Valid config, missing required/optional keys, out-of-range (above/below/boundary)
- Type mismatch, one_of valid/invalid, required section present/missing
- Multiple errors collected, custom predicates pass/fail
- Double range validation, bool fields, deeply nested keys
- Pre-built schemas validated against `default.json`
- Custom schema rules

## Verification

- 464/464 tests pass
- Zero warnings
- No `shared_ptr` usage

Closes #69