### PR TITLE
fix(#172): address PR #173 Copilot review comments

### DIFF
--- a/deploy/DEPLOY_USAGE.md
+++ b/deploy/DEPLOY_USAGE.md
@@ -110,21 +110,19 @@ CONFIG_FILE=config/gazebo.json bash deploy/launch_all.sh
 Starts PX4 SITL + Gazebo + the companion stack:
 
 ```bash
-bash deploy/launch_gazebo.sh              # Headless, SHM backend
+bash deploy/launch_gazebo.sh              # Headless
 bash deploy/launch_gazebo.sh --gui        # With 3-D visualisation
 ```
 
-Set `CONFIG_FILE` to choose the IPC backend config:
+Set `CONFIG_FILE` to select a Gazebo/SITL config profile:
 
 ```bash
-CONFIG_FILE=config/gazebo.json       bash deploy/launch_gazebo.sh --gui   # SHM
-CONFIG_FILE=config/gazebo_zenoh.json bash deploy/launch_gazebo.sh --gui   # Zenoh
-CONFIG_FILE=config/gazebo_sitl.json  bash deploy/launch_gazebo.sh --gui   # Zenoh (scenario default)
+CONFIG_FILE=config/gazebo_sitl.json  bash deploy/launch_gazebo.sh --gui   # Scenario default
 ```
 
 | Environment Variable | Default | Description |
 |---------------------|---------|-------------|
-| `CONFIG_FILE` | `config/gazebo.json` | JSON config for IPC backend + process settings |
+| `CONFIG_FILE` | `config/gazebo_sitl.json` | JSON config for Gazebo/SITL profile + process settings |
 | `PX4_DIR` | `~/PX4-Autopilot` | Path to PX4-Autopilot source |
 | `GZ_WORLD` | `sim/worlds/test_world.sdf` | Gazebo SDF world file |
 | `LOG_DIR` | `drone_logs/` | Log output directory |

--- a/deploy/clean_build_and_run.sh
+++ b/deploy/clean_build_and_run.sh
@@ -16,7 +16,7 @@
 #   1. Kill leftover PX4/Gazebo/companion processes
 #   2. Clean-build (Release by default, Debug if sanitizer/coverage)
 #   3. Run unit tests
-#   4. Launch Gazebo SITL flight with config/gazebo.json
+#   4. Launch Gazebo SITL flight with config/gazebo_sitl.json
 #
 # Prerequisites:
 #   - zenohc ≥ 1.0 installed  (apt: libzenohc libzenohc-dev)

--- a/docs/sim_debugging_workflow.md
+++ b/docs/sim_debugging_workflow.md
@@ -229,13 +229,20 @@ python3 -m json.tool "${LOG_DIR}/merged_config.json" | head -80
 python3 -c "
 import json, sys
 cfg = json.load(open(sys.argv[1]))
-print('VIO backend:      ', cfg.get('slam',{}).get('vio',{}).get('backend','NOT SET'))
-print('IMU backend:      ', cfg.get('slam',{}).get('imu',{}).get('backend','NOT SET'))
-print('FC backend:       ', cfg.get('comms',{}).get('mavlink',{}).get('backend','NOT SET'))
-print('Detector backend: ', cfg.get('perception',{}).get('detector',{}).get('backend','NOT SET'))
-print('Planner backend:  ', cfg.get('mission_planner',{}).get('path_planner',{}).get('backend','NOT SET'))
-print('Avoider backend:  ', cfg.get('mission_planner',{}).get('obstacle_avoider',{}).get('backend','NOT SET'))
-print('IPC backend:      ', cfg.get('ipc_backend','NOT SET'))
+def walk(d, *keys):
+    for k in keys:
+        v = d.get(k, {}) if isinstance(d, dict) else 'MISSING'
+        if v == 'MISSING':
+            return v
+        d = v
+    return d if d != {} else 'NOT SET'
+print('VIO backend:      ', walk(cfg, 'slam', 'vio', 'backend'))
+print('IMU backend:      ', walk(cfg, 'slam', 'imu', 'backend'))
+print('FC backend:       ', walk(cfg, 'comms', 'mavlink', 'backend'))
+print('Detector backend: ', walk(cfg, 'perception', 'detector', 'backend'))
+print('Planner backend:  ', walk(cfg, 'mission_planner', 'path_planner', 'backend'))
+print('Avoider backend:  ', walk(cfg, 'mission_planner', 'obstacle_avoider', 'backend'))
+print('IPC backend:      ', walk(cfg, 'ipc_backend'))
 " "${LOG_DIR}/merged_config.json"
 
 # 3. Compare base configs for drift (gazebo.json vs gazebo_sitl.json)

--- a/tests/test_gazebo_integration.sh
+++ b/tests/test_gazebo_integration.sh
@@ -9,7 +9,7 @@
 # expected IPC / log output.
 #
 # This is NOT a closed-loop waypoint mission test — it verifies
-# that all processes start correctly and communicate via SHM,
+# that all processes start correctly and communicate via Zenoh,
 # gz-transport, and MAVLink.
 #
 # Usage:


### PR DESCRIPTION
## Summary

Addresses 4 Copilot review comments from PR #173:

- **`deploy/DEPLOY_USAGE.md`**: Remove stale SHM backend references; describe `CONFIG_FILE` as selecting a Gazebo/SITL config profile (IPC is now Zenoh-only)
- **`tests/test_gazebo_integration.sh`**: Update header comment from "SHM" to "Zenoh"
- **`docs/sim_debugging_workflow.md`**: Add `isinstance(val, dict)` guard in Python key-walk so it reports "MISSING" instead of crashing if a config section has the wrong type
- **`deploy/clean_build_and_run.sh`**: Update step-4 header comment from `config/gazebo.json` to `config/gazebo_sitl.json`

Closes #172

## Test plan

- [ ] Verify no C++ files were touched (shell/md/docs only)
- [ ] Verify Python key-walk snippet handles non-dict config values gracefully
- [ ] Confirm all SHM references in touched files are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)