### PR TITLE
fix: replace memcpy with std::copy, heap-allocate validation temp for large IPC types

### DIFF
--- a/common/ipc/include/ipc/zenoh_publisher.h
+++ b/common/ipc/include/ipc/zenoh_publisher.h
@@ -13,8 +13,8 @@
 #include "ipc/ipublisher.h"
 #include "ipc/zenoh_session.h"
 
+#include <algorithm>
 #include <atomic>
-#include <cstring>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -83,7 +83,7 @@ private:
         publisher_->put(zenoh::Bytes(std::move(buf)));
     }
 
-    /// Large-message path: allocate SHM buffer, memcpy, publish zero-copy.
+    /// Large-message path: allocate SHM buffer, copy, publish zero-copy.
     void publish_shm(const T& msg) {
         auto* provider = ZenohSession::instance().shm_provider();
         if (!provider) {
@@ -102,8 +102,9 @@ private:
             return;
         }
 
-        // Zero-copy write: memcpy directly into shared memory
-        std::memcpy(buf->data(), &msg, sizeof(T));
+        // Zero-copy write: copy directly into shared memory
+        const auto* src = reinterpret_cast<const uint8_t*>(&msg);
+        std::copy(src, src + sizeof(T), buf->data());
 
         // Move SHM buffer into Bytes and publish — only a descriptor
         // is sent over the transport; local subscribers receive a

--- a/common/ipc/include/ipc/zenoh_subscriber.h
+++ b/common/ipc/include/ipc/zenoh_subscriber.h
@@ -13,9 +13,10 @@
 #include "ipc/zenoh_session.h"
 #include "util/latency_tracker.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cstring>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -68,7 +69,7 @@ public:
         uint64_t msg_ts = 0;
         {
             std::lock_guard<std::mutex> lock(data_mutex_);
-            std::memcpy(&out, &latest_msg_, sizeof(T));
+            out    = latest_msg_;
             msg_ts = timestamp_ns_;
         }
         if (timestamp_ns) {
@@ -115,26 +116,30 @@ private:
             return;
         }
 
-        // Validate into a temporary before committing to latest_msg_,
-        // so a failed validation never overwrites a previously good value.
+        // Validate into a heap-allocated temporary before committing to
+        // latest_msg_, so a failed validation never overwrites a previously
+        // good value.  Heap allocation avoids stack overflow for large types
+        // (e.g. VideoFrame ~6.2 MB) on Zenoh's callback thread.
         if constexpr (has_validate<T>::value) {
-            T temp{};
-            std::memcpy(&temp, bytes.data(), sizeof(T));
-            if (!temp.validate()) {
+            auto  temp = std::make_unique<T>();
+            auto* dst  = reinterpret_cast<uint8_t*>(temp.get());
+            std::copy(bytes.begin(), bytes.end(), dst);
+            if (!temp->validate()) {
                 spdlog::warn("[ZenohSubscriber] Validation failed on '{}' — "
                              "dropping message",
                              key_expr_);
                 return;
             }
             std::lock_guard<std::mutex> lock(data_mutex_);
-            latest_msg_ = temp;
+            latest_msg_ = *temp;
             timestamp_ns_ =
                 static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
                                           std::chrono::steady_clock::now().time_since_epoch())
                                           .count());
         } else {
             std::lock_guard<std::mutex> lock(data_mutex_);
-            std::memcpy(&latest_msg_, bytes.data(), sizeof(T));
+            auto*                       dst = reinterpret_cast<uint8_t*>(&latest_msg_);
+            std::copy(bytes.begin(), bytes.end(), dst);
             timestamp_ns_ =
                 static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
                                           std::chrono::steady_clock::now().time_since_epoch())


### PR DESCRIPTION
## Summary

- Replaced all `std::memcpy` with `std::copy` and value assignment in `ZenohSubscriber` and `ZenohPublisher` (per safety-critical code guidelines)
- Heap-allocate the validation temporary via `std::make_unique<T>()` instead of stack `T temp{}` — fixes SEGFAULT on Zenoh callback thread for `VideoFrame` (~6.2 MB)

**Root cause:** The validation-before-commit change in PR #187 introduced a stack-allocated `T temp{}` in `on_sample()`. For `VideoFrame`, this 6.2 MB allocation overflowed the Zenoh callback thread's limited stack, causing SEGFAULT in 3 tests.

## Files changed
- `common/ipc/include/ipc/zenoh_subscriber.h` — `std::copy` + `std::make_unique`, removed `<cstring>`
- `common/ipc/include/ipc/zenoh_publisher.h` — `std::copy` for SHM write, removed `<cstring>`

## Test plan
- [x] `ZenohPubSub.LargeVideoFrameRoundTrip` — previously SEGFAULT, now passes
- [x] `ZenohShmPublish.LargeVideoFrameUsesShmPath` — previously SEGFAULT, now passes
- [x] `ZenohShmPublish.SustainedVideoPublish` — previously SEGFAULT, now passes
- [x] Full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)