### PR TITLE
fix(#389): HD-map proximity suppression for radar promotion

### DIFF
--- a/config/scenarios/02_obstacle_avoidance.json
+++ b/config/scenarios/02_obstacle_avoidance.json
@@ -33,7 +33,7 @@
                 "promotion_hits": 0,
                 "min_promotion_depth_confidence": 0.8,
                 "max_static_cells": 0,
-                "_comment": "2m grid, 2m inflation, 1.0s TTL. promotion_hits=0: HD-map has all 4 obstacles pre-mapped, no runtime promotion needed. min_promotion_depth_confidence=0.8: blocks camera-only ground features (Tier 1-4: 0.01-0.7) while allowing radar-confirmed (1.0) to promote if promotion_hits were enabled. Dynamic detections still create temporary cells (TTL=1s) for real-time avoidance."
+                "_comment": "2m grid, 2m inflation, 1.0s TTL. promotion_hits=0: disables camera-only hit-count promotion. Radar-confirmed objects can still promote, but HD-map proximity suppression (Issue #389) prevents radar from duplicating cells near pre-mapped obstacles — only genuinely new obstacles promote. max_static_cells=0 (unlimited) is safe with HD-map suppression active."
             },
             "static_obstacles": [
                 {"x": 3,  "y": 15, "radius_m": 1.0, "height_m": 5.0, "_color": "RED"},

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -132,7 +132,7 @@ public:
         hit_count_.clear();
     }
 
-    /// Clear only the static HD-map obstacle layer.
+    /// Clear all static obstacles (both HD-map and runtime-promoted).
     void clear_static() {
         static_occupied_.clear();
         hd_map_cells_.clear();
@@ -150,7 +150,7 @@ public:
         GridCell base    = world_to_grid(wx, wy, 0.0f);
         int      r_cells = static_cast<int>(std::ceil(radius_m / resolution_)) + inflation_cells_;
         int      h_cells = static_cast<int>(std::ceil(height_m / resolution_)) + inflation_cells_;
-        size_t   before  = static_occupied_.size();
+        const size_t before = static_occupied_.size();
         for (int dz = -inflation_cells_; dz <= h_cells; ++dz)
             for (int dy = -r_cells; dy <= r_cells; ++dy)
                 for (int dx = -r_cells; dx <= r_cells; ++dx) {
@@ -166,7 +166,9 @@ public:
                     }
                 }
         const size_t added = static_occupied_.size() - before;
-        hd_map_static_count_ += added;
+        // Derive HD-map count from hd_map_cells_ (authoritative) so the
+        // two can never diverge — even if overlapping HD-map obstacles share cells.
+        hd_map_static_count_ = hd_map_cells_.size();
         spdlog::info("[HD-map] Static obstacle at ({:.1f},{:.1f}) r={:.1f}m h={:.1f}m "
                      "-> {} new cells (total static: {})",
                      wx, wy, radius_m, height_m, added, static_occupied_.size());

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -135,6 +135,7 @@ public:
     /// Clear only the static HD-map obstacle layer.
     void clear_static() {
         static_occupied_.clear();
+        hd_map_cells_.clear();
         hd_map_static_count_ = 0;
     }
 
@@ -160,6 +161,7 @@ public:
                             if (inserted) {
                                 changed_cells_.push_back({c, true});
                             }
+                            hd_map_cells_.insert(c);
                         }
                     }
                 }
@@ -198,11 +200,20 @@ public:
             // Known-obstacle suppression: split into two behaviours.
             // 1. Dynamic cells are ALWAYS created (close-range detections
             //    during navigation are more accurate than survey positions).
-            // 2. Promotion is SUPPRESSED near existing static cells to
-            //    prevent parallax from growing runaway walls of promoted
-            //    cells that block D* Lite paths (Issue #237).
+            // 2. Promotion is SUPPRESSED near known obstacles to prevent
+            //    runaway walls of promoted cells that block D* Lite paths.
+            //
+            // Two suppression checks (Issue #389):
+            //  a) Near HD-map cells — always suppress (both radar and camera
+            //     promotion). Radar-confirmed detections near known obstacles
+            //     are redundant confirmations that saturate the grid.
+            //  b) Near any static cell — suppress camera-only promotion
+            //     (original Issue #237 behaviour).
             bool skip_promotion = false;
-            if (promotion_hits_ > 0 && near_static_cell_(center)) {
+            if (!hd_map_cells_.empty() && near_hd_map_cell_(center)) {
+                ++suppressed;
+                skip_promotion = true;
+            } else if (promotion_hits_ > 0 && near_static_cell_(center)) {
                 ++suppressed;
                 skip_promotion = true;
             }
@@ -350,6 +361,7 @@ public:
     [[nodiscard]] int    promoted_count() const { return promoted_count_; }
     [[nodiscard]] int    max_static_cells() const { return max_static_cells_; }
     [[nodiscard]] size_t hd_map_static_count() const { return hd_map_static_count_; }
+    [[nodiscard]] size_t hd_map_cell_count() const { return hd_map_cells_.size(); }
     /// Cumulative count of objects that had velocity-based prediction applied
     /// across all calls to update_from_objects() (lifetime counter, never reset).
     [[nodiscard]] int  total_predictions_applied() const { return total_predictions_applied_; }
@@ -384,6 +396,20 @@ private:
         for (int dy = -1; dy <= 1; ++dy) {
             for (int dx = -1; dx <= 1; ++dx) {
                 if (static_occupied_.count({center.x + dx, center.y + dy, center.z}) > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// Check if a cell is near an HD-map (pre-loaded) static obstacle.
+    /// Used to suppress radar promotion near known obstacles — those detections
+    /// are redundant confirmations that would otherwise saturate the grid (Issue #389).
+    [[nodiscard]] bool near_hd_map_cell_(const GridCell& center) const {
+        for (int dy = -1; dy <= 1; ++dy) {
+            for (int dx = -1; dx <= 1; ++dx) {
+                if (hd_map_cells_.count({center.x + dx, center.y + dy, center.z}) > 0) {
                     return true;
                 }
             }
@@ -491,6 +517,9 @@ private:
     // HD-map layer: permanent cells loaded from scenario config at startup.
     // Never expire — represent known world geometry.
     std::unordered_set<GridCell, GridCellHash> static_occupied_;
+    // Subset of static_occupied_ that came from add_static_obstacle() (HD-map).
+    // Used to suppress radar promotion near known obstacles (Issue #389).
+    std::unordered_set<GridCell, GridCellHash> hd_map_cells_;
     // Camera-confirmation layer: cells observed by perception, expire after TTL.
     // Refreshed each detection cycle; also catches unexpected/dynamic obstacles.
     std::unordered_map<GridCell, uint64_t, GridCellHash> occupied_;

--- a/tests/lib_scenario_logging.sh
+++ b/tests/lib_scenario_logging.sh
@@ -687,13 +687,22 @@ _report_vio_stats() {
     stereo_frames=$(grep -ac "StereoMatcher: num_matches" "$log" 2>/dev/null | tail -1)
     imu_frames=$(grep -ac "ImuPreintegrator: total_dt" "$log" 2>/dev/null | tail -1)
 
+    # GazeboVIOBackend uses ground-truth odometry and emits HealthCheck lines
+    # instead of Frame diagnostics — count those as pose updates
+    local healthcheck_frames
+    healthcheck_frames=$(grep -ac "HealthCheck.*VIO pose" "$log" 2>/dev/null | tail -1)
+
     local imu_warnings
     imu_warnings=$(grep -ac "ImuPreintegrator.*WARN" "$log" 2>/dev/null | tail -1)
     local imu_gaps
     imu_gaps=$(grep -ac "IMU data gap" "$log" 2>/dev/null | tail -1)
 
     echo "  Backend             : ${vio_backend}"
-    echo "  VIO frames          : ${total_frames}"
+    if [[ "$vio_backend" == "GazeboVIOBackend" ]] || grep -qa "GazeboVIOBackend" "$log" 2>/dev/null; then
+        echo "  Pose updates (1Hz)  : ${healthcheck_frames}"
+    else
+        echo "  VIO frames          : ${total_frames}"
+    fi
     echo "  Feature extraction  : ${feature_frames} frames"
     echo "  Stereo matching     : ${stereo_frames} frames"
     echo "  IMU pre-integration : ${imu_frames} frames"
@@ -702,7 +711,13 @@ _report_vio_stats() {
     echo ""
     echo "  Observations:"
 
-    if (( total_frames == 0 )); then
+    if [[ "$vio_backend" == "GazeboVIOBackend" ]] || grep -qa "GazeboVIOBackend" "$log" 2>/dev/null; then
+        if (( healthcheck_frames > 0 )); then
+            echo "  - Gazebo ground-truth odometry active (${healthcheck_frames} health checks)"
+        else
+            echo "  - Gazebo ground-truth backend configured but no health checks — pipeline may not be running"
+        fi
+    elif (( total_frames == 0 )); then
         echo "  - No VIO frames processed — pipeline may not be running"
     else
         if (( feature_frames > 0 )); then

--- a/tests/lib_scenario_logging.sh
+++ b/tests/lib_scenario_logging.sh
@@ -676,7 +676,7 @@ _report_vio_stats() {
 
     # Only report if VIO pipeline logs are present
     local vio_backend
-    vio_backend=$(grep -aoP 'GazeboFullVIOBackend|VIOBackend' "$log" 2>/dev/null | head -1)
+    vio_backend=$(grep -aoP 'GazeboFullVIOBackend|GazeboVIOBackend|VIOBackend' "$log" 2>/dev/null | head -1)
     [[ -z "$vio_backend" ]] && return  # no VIO data — skip section
 
     echo "VIO Pipeline"

--- a/tests/test_dstar_lite_planner.cpp
+++ b/tests/test_dstar_lite_planner.cpp
@@ -226,8 +226,10 @@ TEST(OccupancyGrid3DTest, SuppressionDisabledWhenPromotionOff) {
 // ═════════════════════════════════════════════════════════════
 
 TEST(OccupancyGrid3DTest, HdMapSuppressesRadarPromotion) {
-    // HD-map obstacle at (5,5), radar-confirmed detection at same location.
-    // Promotion should be suppressed — HD-map already covers it.
+    // HD-map obstacle at (5,5) r=1.0m. With resolution=1.0m and inflation=0.5m,
+    // r_cells = ceil(1.0/1.0) + 1 = 2, so footprint covers (3,3)→(7,7) in XY.
+    // Place radar detection at (8,5) — just OUTSIDE the footprint but adjacent
+    // to hd_map_cell (7,5). This exercises near_hd_map_cell_() specifically.
     OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
                          /*min_conf=*/0.3f, /*promotion_hits=*/0,
                          /*radar_promo=*/3);
@@ -235,10 +237,10 @@ TEST(OccupancyGrid3DTest, HdMapSuppressesRadarPromotion) {
     size_t static_after_hdmap = grid.static_count();
     EXPECT_GT(grid.hd_map_cell_count(), 0u);
 
-    // Radar-confirmed object at same position (radar_update_count >= 3)
+    // Radar-confirmed object just outside HD-map footprint (grid cell 8,5)
     drone::ipc::DetectedObjectList objects{};
     objects.num_objects                   = 1;
-    objects.objects[0].position_x         = 5.0f;
+    objects.objects[0].position_x         = 8.0f;
     objects.objects[0].position_y         = 5.0f;
     objects.objects[0].position_z         = 2.0f;
     objects.objects[0].confidence         = 0.9f;
@@ -250,10 +252,7 @@ TEST(OccupancyGrid3DTest, HdMapSuppressesRadarPromotion) {
     for (int i = 0; i < 20; ++i) {
         grid.update_from_objects(objects, pose);
     }
-    // Static count should NOT have grown — radar promotion suppressed near HD-map.
-    // Dynamic count may be 0 if all inflated cells overlap with existing HD-map
-    // static cells (static layer takes priority). The key assertion is that
-    // static_count did NOT grow from radar promotion.
+    // Static count should NOT have grown — near_hd_map_cell_() suppressed promotion.
     EXPECT_EQ(grid.static_count(), static_after_hdmap);
 }
 
@@ -308,19 +307,22 @@ TEST(OccupancyGrid3DTest, NoHdMapRadarPromotionUnchanged) {
 }
 
 TEST(OccupancyGrid3DTest, HdMapAdjacentCellAlsoSuppressed) {
-    // Detection 1 cell away from HD-map obstacle should also be suppressed.
-    // The near_hd_map_cell_ check uses a 3x3 neighborhood.
+    // HD-map obstacle at (5,5) r=0.5m. With resolution=1.0m and inflation=0.5m,
+    // r_cells = ceil(0.5/1.0) + 1 = 2, so footprint covers (3,3)→(7,7) in XY.
+    // Place detection at (8,6) — outside the footprint but diagonally adjacent
+    // to hd_map_cell (7,5). near_hd_map_cell_() checks ±1 in x and y, so
+    // (7,5) is at dx=-1,dy=-1 from (8,6) — within the 3x3 neighborhood.
     OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
                          /*min_conf=*/0.3f, /*promotion_hits=*/0,
                          /*radar_promo=*/3);
     grid.add_static_obstacle(5.0f, 5.0f, 0.5f, 3.0f);
     size_t static_after_hdmap = grid.static_count();
 
-    // Detection 1m away (1 grid cell on 1m grid) — parallax offset
+    // Detection at (8,6) — outside footprint, diagonally adjacent to HD-map edge
     drone::ipc::DetectedObjectList objects{};
     objects.num_objects                   = 1;
-    objects.objects[0].position_x         = 6.0f;
-    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_x         = 8.0f;
+    objects.objects[0].position_y         = 6.0f;
     objects.objects[0].position_z         = 2.0f;
     objects.objects[0].confidence         = 0.9f;
     objects.objects[0].depth_confidence   = 1.0f;
@@ -331,7 +333,7 @@ TEST(OccupancyGrid3DTest, HdMapAdjacentCellAlsoSuppressed) {
     for (int i = 0; i < 10; ++i) {
         grid.update_from_objects(objects, pose);
     }
-    // Promotion suppressed — adjacent to HD-map cell
+    // Promotion suppressed — near_hd_map_cell_() catches diagonal adjacency
     EXPECT_EQ(grid.static_count(), static_after_hdmap);
 }
 

--- a/tests/test_dstar_lite_planner.cpp
+++ b/tests/test_dstar_lite_planner.cpp
@@ -221,6 +221,135 @@ TEST(OccupancyGrid3DTest, SuppressionDisabledWhenPromotionOff) {
 }
 
 // ═════════════════════════════════════════════════════════════
+// HD-map proximity suppression (Issue #389)
+// Radar-confirmed detections near HD-map obstacles must NOT promote.
+// ═════════════════════════════════════════════════════════════
+
+TEST(OccupancyGrid3DTest, HdMapSuppressesRadarPromotion) {
+    // HD-map obstacle at (5,5), radar-confirmed detection at same location.
+    // Promotion should be suppressed — HD-map already covers it.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/0,
+                         /*radar_promo=*/3);
+    grid.add_static_obstacle(5.0f, 5.0f, 1.0f, 3.0f);
+    size_t static_after_hdmap = grid.static_count();
+    EXPECT_GT(grid.hd_map_cell_count(), 0u);
+
+    // Radar-confirmed object at same position (radar_update_count >= 3)
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 5.0f;
+    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_z         = 2.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 1.0f;
+    objects.objects[0].radar_update_count = 10;
+    objects.objects[0].estimated_radius_m = 0.0f;
+    drone::ipc::Pose pose{};
+
+    for (int i = 0; i < 20; ++i) {
+        grid.update_from_objects(objects, pose);
+    }
+    // Static count should NOT have grown — radar promotion suppressed near HD-map.
+    // Dynamic count may be 0 if all inflated cells overlap with existing HD-map
+    // static cells (static layer takes priority). The key assertion is that
+    // static_count did NOT grow from radar promotion.
+    EXPECT_EQ(grid.static_count(), static_after_hdmap);
+}
+
+TEST(OccupancyGrid3DTest, HdMapAllowsRadarPromotionFarAway) {
+    // HD-map obstacle at (5,5), radar-confirmed detection at (15,15) — far away.
+    // Promotion should proceed normally — this is a genuinely new obstacle.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/0,
+                         /*radar_promo=*/3);
+    grid.add_static_obstacle(5.0f, 5.0f, 1.0f, 3.0f);
+    size_t static_after_hdmap = grid.static_count();
+
+    // Radar-confirmed object far from HD-map
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 15.0f;
+    objects.objects[0].position_y         = 15.0f;
+    objects.objects[0].position_z         = 2.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 1.0f;
+    objects.objects[0].radar_update_count = 10;
+    objects.objects[0].estimated_radius_m = 0.0f;
+    drone::ipc::Pose pose{};
+
+    grid.update_from_objects(objects, pose);
+    // Static count should grow — new obstacle promoted via radar
+    EXPECT_GT(grid.static_count(), static_after_hdmap);
+}
+
+TEST(OccupancyGrid3DTest, NoHdMapRadarPromotionUnchanged) {
+    // No HD-map — radar-confirmed detections should promote as before.
+    // Regression test: ensure the HD-map check doesn't break normal flow.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/0,
+                         /*radar_promo=*/3);
+    EXPECT_EQ(grid.hd_map_cell_count(), 0u);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 5.0f;
+    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_z         = 2.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 1.0f;
+    objects.objects[0].radar_update_count = 10;
+    objects.objects[0].estimated_radius_m = 0.0f;
+    drone::ipc::Pose pose{};
+
+    grid.update_from_objects(objects, pose);
+    // Should promote — no HD-map to suppress it
+    EXPECT_GT(grid.static_count(), 0u);
+}
+
+TEST(OccupancyGrid3DTest, HdMapAdjacentCellAlsoSuppressed) {
+    // Detection 1 cell away from HD-map obstacle should also be suppressed.
+    // The near_hd_map_cell_ check uses a 3x3 neighborhood.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/0,
+                         /*radar_promo=*/3);
+    grid.add_static_obstacle(5.0f, 5.0f, 0.5f, 3.0f);
+    size_t static_after_hdmap = grid.static_count();
+
+    // Detection 1m away (1 grid cell on 1m grid) — parallax offset
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 6.0f;
+    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_z         = 2.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 1.0f;
+    objects.objects[0].radar_update_count = 10;
+    objects.objects[0].estimated_radius_m = 0.0f;
+    drone::ipc::Pose pose{};
+
+    for (int i = 0; i < 10; ++i) {
+        grid.update_from_objects(objects, pose);
+    }
+    // Promotion suppressed — adjacent to HD-map cell
+    EXPECT_EQ(grid.static_count(), static_after_hdmap);
+}
+
+TEST(OccupancyGrid3DTest, HdMapCellCountMatchesStaticCount) {
+    // hd_map_cell_count() should match hd_map_static_count() after loading.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.5f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/0);
+    grid.add_static_obstacle(5.0f, 5.0f, 1.0f, 3.0f);
+    EXPECT_EQ(grid.hd_map_cell_count(), grid.hd_map_static_count());
+    EXPECT_EQ(grid.hd_map_cell_count(), grid.static_count());
+
+    // After clear_static(), both should be zero
+    grid.clear_static();
+    EXPECT_EQ(grid.hd_map_cell_count(), 0u);
+    EXPECT_EQ(grid.hd_map_static_count(), 0u);
+}
+
+// ═════════════════════════════════════════════════════════════
 // GridCellHash + factory tests (ported from test_astar_planner.cpp)
 // ═════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

- Radar-confirmed detections near HD-map static obstacles were bypassing suppression and promoting duplicate cells, causing grid saturation and D* Lite path degradation in scenario 02
- Root cause: `near_static_cell_()` suppression only fired when `promotion_hits_ > 0` (camera-only path) — radar promotion had no proximity check
- Fix: Track HD-map cells in `hd_map_cells_` set, check `near_hd_map_cell_()` before radar promotion regardless of `promotion_hits` setting
- Also fixes VIO reporting gap in scenario logs (GazeboVIOBackend not detected)

## Changes

| File | Change |
|------|--------|
| `occupancy_grid_3d.h` | Added `hd_map_cells_` tracking set, `near_hd_map_cell_()` method, radar suppression logic |
| `test_dstar_lite_planner.cpp` | 5 new tests for HD-map suppression (suppress, allow far, no-hdmap regression, adjacent, accessor) |
| `02_obstacle_avoidance.json` | Reverted `max_static_cells` workaround, updated comments |
| `lib_scenario_logging.sh` | Detect GazeboVIOBackend + report HealthCheck count |

## Test plan

- [x] 1291/1291 tests pass (`ctest --output-on-failure -j$(nproc)`)
- [x] Zero compiler warnings (`-Werror -Wall -Wextra`)
- [x] Format clean (`clang-format-18 --dry-run --Werror`)
- [ ] Scenario 02 Gazebo SITL run (grid no longer saturates)
- [ ] Review by memory-safety, concurrency, and fault-recovery agents

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)