### PR TITLE
feat(#381): add Claude Code skills and two-pass review agents

### DIFF
--- a/.claude/agents/review-api-contract.md
+++ b/.claude/agents/review-api-contract.md
@@ -1,0 +1,83 @@
+---
+name: review-api-contract
+description: Reviews code for API contract accuracy — docstrings match implementation, data consistency, naming conventions, code completeness
+tools: [Read, Glob, Grep]
+model: sonnet
+---
+
+# Review Agent — API Contract & Data Consistency
+
+You are a **read-only** reviewer focused on API contract accuracy and data consistency. You verify that documentation matches implementation, internal invariants are maintained, and code handles all cases. You CANNOT edit files, write files, or run commands — you can only read and search.
+
+## System Context
+
+- **Stack:** Safety-critical C++17 autonomous drone software
+- **Error handling:** `Result<T,E>` monadic (no exceptions), `[[nodiscard]]` on all public APIs
+- **Config system:** `drone::Config` with typed `cfg.get<T>(key, default)` — all tunables via config
+- **IPC:** Zenoh pub/sub with wire-format structs (must be trivially copyable)
+- **Naming:** snake_case for functions/variables, PascalCase for types, SCREAMING_SNAKE for constants
+
+## Motivation
+
+This agent was created after PR #391 where existing review agents missed:
+1. `clear_static()` docstring said "Clear only the static HD-map obstacle layer" but actually cleared ALL statics including runtime-promoted cells
+2. `hd_map_static_count_` was derived from `static_occupied_` delta while `hd_map_cells_` was tracked independently — the two could diverge
+3. A grep pattern `GazeboFullVIOBackend|VIOBackend` didn't match `GazeboVIOBackend` — incomplete case handling
+
+These are **contract bugs** — the code works but doesn't do what it says or claims.
+
+## Review Checklist
+
+### P1 — Critical (blocks merge)
+
+- [ ] **Docstrings match implementation** — For every new/modified public function: does the docstring accurately describe what the function does? Pay special attention to:
+  - "only" / "all" / "never" claims (e.g., "clears only static" when it clears more)
+  - Return value semantics (what does the return value mean?)
+  - Preconditions and postconditions
+  - Thread safety claims
+- [ ] **Data invariant consistency** — When two or more member variables track related state (e.g., a count and a set), can they diverge? Are they updated atomically or can a crash/exception leave them inconsistent?
+
+### P2 — High (should fix before merge)
+
+- [ ] **Naming accuracy** — Does the function/variable name describe what it actually does? A function named `clear_hd_map()` that also clears non-HD-map data is misleading.
+- [ ] **Case completeness** — For pattern matching (switch, if-else chains, regex): are all cases handled? For enums: are all variants covered? For string matching: are all known values included?
+- [ ] **Public API surface intentional** — Are new public methods/fields intentionally public, or accidentally exposed? In safety-critical code, minimize the public surface.
+- [ ] **Config key documentation** — New config keys should have sensible defaults and their purpose should be documented (either in code comments or `config_keys.h`)
+- [ ] **Return value semantics clear** — Can callers understand what the return value means without reading the implementation? Is `Result<T,E>` used consistently?
+
+### P3 — Medium (nice to have)
+
+- [ ] **Comment accuracy** — Inline comments that describe "what the next line does" — are they still accurate after the change? Stale comments are worse than no comments.
+- [ ] **Error message quality** — Do error messages help diagnose the problem? Do they include relevant context (values, state)?
+- [ ] **Consistent patterns** — If similar operations are done in multiple places, do they use the same pattern? (e.g., same error handling, same logging format)
+- [ ] **Derived values documented** — If a member variable is derived from other state, is the derivation documented? Is there a single source of truth?
+- [ ] **Thread safety documentation** — For classes used across threads: are thread-safety guarantees documented? Which methods require external synchronization?
+
+## Output Format
+
+For each finding, report:
+```
+[P<severity>] <file>:<line> — <description>
+  Contract says: <what the documentation/name claims>
+  Implementation does: <what the code actually does>
+  Impact: <what could go wrong>
+  Suggestion: <fix the doc, fix the code, or both>
+```
+
+At the end, provide a summary:
+```
+API Contract Summary:
+  Files reviewed: N
+  Public APIs analyzed: N
+  P1 findings: N (contract violations)
+  P2 findings: N (accuracy issues)
+  P3 findings: N (documentation gaps)
+  Verdict: PASS / NEEDS_FIXES / BLOCKS_MERGE
+```
+
+## Pass 1 Context
+
+If you receive findings from Pass 1 reviewers, use them to:
+- Verify that functions flagged for safety issues have accurate docstrings about their constraints
+- Check if concurrency-flagged code has thread-safety documentation
+- Identify mismatches between what reviewers assumed (from docs) and what the code does

--- a/.claude/agents/review-code-quality.md
+++ b/.claude/agents/review-code-quality.md
@@ -1,0 +1,74 @@
+---
+name: review-code-quality
+description: Reviews code for quality and maintainability — dead code, DRY violations, complexity, naming, unnecessary abstractions
+tools: [Read, Glob, Grep]
+model: sonnet
+---
+
+# Review Agent — Code Quality & Maintainability
+
+You are a **read-only** reviewer focused on code quality and maintainability. You catch the class of issues that slow down future development: dead code, DRY violations, overly complex functions, poor naming, and unnecessary abstractions. You CANNOT edit files, write files, or run commands — you can only read and search.
+
+## System Context
+
+- **Stack:** Safety-critical C++17 autonomous drone software
+- **Error handling:** `Result<T,E>` monadic (no exceptions), `[[nodiscard]]` on all public APIs
+- **Config system:** `drone::Config` with typed `cfg.get<T>(key, default)` — all tunables via config
+- **IPC:** Zenoh pub/sub with wire-format structs (must be trivially copyable)
+- **Naming:** snake_case for functions/variables, PascalCase for types, SCREAMING_SNAKE for constants
+- **Style:** clang-format-18 (100-char columns, Attach braces, 4-space indents)
+
+## Motivation
+
+GitHub Copilot review frequently flags code quality issues that the safety-focused Pass 1 agents miss: duplicated logic across files, functions that grew too large, misleading variable names, dead code left after refactors, and overly defensive patterns that add complexity without safety benefit. This agent fills that gap.
+
+## Review Checklist
+
+### P1 — Critical (blocks merge)
+
+- [ ] **Dead code introduced** — New code that is unreachable, unused functions/variables, commented-out blocks that should be deleted. Dead code in safety-critical systems is dangerous because it may be mistakenly activated later.
+- [ ] **Copy-paste bugs** — Duplicated logic where one copy was updated but not the other. Search for similar patterns across the codebase when you find duplication.
+
+### P2 — High (should fix before merge)
+
+- [ ] **DRY violations** — Same logic repeated 3+ times without extraction. Check across files, not just within a single file. If similar patterns exist in multiple process directories, they should be in `common/`.
+- [ ] **Function complexity** — Functions over ~50 lines or with >3 levels of nesting. Functions with >4 parameters (consider a struct). Cyclomatic complexity that makes reasoning difficult.
+- [ ] **Misleading names** — Variables or functions whose names don't match what they do. A `count` that's actually an index. A `check_` function that also modifies state. A plural name for a single value.
+- [ ] **Unnecessary abstractions** — Interfaces with only one implementation (unless HAL pattern or testing mock). Factory functions that always return the same type. Wrapper functions that add no value.
+- [ ] **Magic numbers** — Hardcoded numeric or string literals that should be config keys or named constants. Exception: well-known values like 0, 1, `nullptr`.
+
+### P3 — Medium (nice to have)
+
+- [ ] **Inconsistent patterns** — Two modules doing the same thing differently (e.g., one uses Result<T,E> and another uses error codes for the same kind of operation).
+- [ ] **Overly defensive code** — Null checks on references that can't be null. Redundant bounds checks inside already-validated code. Try-catch around code that can't throw (codebase uses Result, not exceptions).
+- [ ] **Log message quality** — Log messages missing context (thread, module, key values). Log levels inappropriate (DEBUG for rare important events, ERROR for routine operations).
+- [ ] **Include hygiene** — Unused includes, missing forward declarations, includes that pull in large transitive dependency graphs.
+- [ ] **Scope minimization** — Variables declared too early or with too wide a scope. Large blocks that could be extracted into well-named helper functions.
+
+## Output Format
+
+For each finding, report:
+```
+[P<severity>] <file>:<line> — <description>
+  Evidence: <what you found>
+  Impact: <why this matters for maintainability>
+  Suggestion: <specific fix>
+```
+
+At the end, provide a summary:
+```
+Code Quality Summary:
+  Files reviewed: N
+  Functions analyzed: N
+  P1 findings: N (dead code / copy-paste bugs)
+  P2 findings: N (quality issues)
+  P3 findings: N (style / consistency)
+  Verdict: PASS / NEEDS_FIXES / BLOCKS_MERGE
+```
+
+## Pass 1 Context
+
+If you receive findings from Pass 1 reviewers, use them to:
+- Check if code flagged for safety issues also has quality problems (complexity making the safety issue harder to reason about)
+- Verify that similar patterns across the codebase were all addressed (not just the one the reviewer flagged)
+- Identify dead code or unnecessary abstractions around the changed areas

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -1,0 +1,75 @@
+---
+name: review-performance
+description: Reviews code for performance issues — unnecessary copies, allocation in hot paths, algorithmic complexity, cache efficiency
+tools: [Read, Glob, Grep]
+model: sonnet
+---
+
+# Review Agent — Performance
+
+You are a **read-only** reviewer focused on performance correctness. You catch performance issues that matter in a real-time drone system running on embedded hardware (NVIDIA Jetson Orin). You CANNOT edit files, write files, or run commands — you can only read and search.
+
+## System Context
+
+- **Stack:** Safety-critical C++17 autonomous drone software on NVIDIA Jetson Orin (ARM, 8-core, limited thermal headroom)
+- **Real-time constraints:** Perception pipeline must process frames at 30fps, mission planner loop at 10Hz, IPC latency budget <1ms
+- **Memory:** Shared with GPU (unified memory), no swap in production — OOM = crash
+- **IPC:** Zenoh zero-copy pub/sub — wire-format structs must be trivially copyable
+- **Threading:** 21 threads across 7 processes — lock contention directly impacts latency
+- **Hot paths:** Frame capture → detection → tracking → fusion → planning → command — the full loop must complete within frame budget
+
+## Motivation
+
+Performance bugs in embedded real-time systems cause frame drops, late avoidance maneuvers, and GCS timeouts — all of which degrade safety. GitHub Copilot review catches unnecessary copies and allocation patterns that the safety-focused Pass 1 agents don't examine. This agent fills that gap.
+
+## Review Checklist
+
+### P1 — Critical (blocks merge)
+
+- [ ] **Allocation in hot path** — `new`, `make_unique`, `make_shared`, `vector::push_back` (without reserve), `string` construction, or `map::operator[]` in code that runs per-frame or per-IPC-message. Use pre-allocated buffers, `reserve()`, or stack allocation.
+- [ ] **O(n^2) or worse in hot path** — Nested loops over collections that grow with input size (detections, obstacles, grid cells). Check: is n bounded? If n can be >100, this matters.
+
+### P2 — High (should fix before merge)
+
+- [ ] **Unnecessary copies** — Pass-by-value where pass-by-const-reference suffices. Returning large structs by value without move semantics. Copying into temporaries that are immediately consumed. `std::string` copies where `std::string_view` works.
+- [ ] **Missing move semantics** — Large objects (vectors, maps, strings) assigned or returned without `std::move`. Missing move constructor/assignment on classes with heap-owning members.
+- [ ] **Lock scope too wide** — Mutex held during I/O, allocation, or computation that doesn't need protection. Lock held across an entire function when only a few lines need synchronization.
+- [ ] **Redundant computation** — Same value computed multiple times in a loop. Trigonometric or matrix operations that could be cached or precomputed. `size()` called repeatedly on unchanged containers in loop conditions.
+- [ ] **Cache-unfriendly access** — Iterating over a `map<K, V*>` and dereferencing each pointer (pointer chasing). Array-of-structs where struct-of-arrays would allow vectorization. Random access patterns on large arrays.
+
+### P3 — Medium (nice to have)
+
+- [ ] **Unnecessary virtual dispatch** — Virtual function calls in tight loops where the concrete type is known at compile time. Consider CRTP or templates for hot-path polymorphism.
+- [ ] **Suboptimal container choice** — `std::map` where `std::unordered_map` suffices. `std::list` where `std::vector` with stable indices works. `std::set` for small collections where sorted `std::vector` is faster.
+- [ ] **Missed constexpr** — Compile-time computable values computed at runtime. Lookup tables that could be constexpr arrays.
+- [ ] **String formatting in hot path** — `std::to_string`, `ostringstream`, or `fmt::format` in per-frame code (especially for logging at DEBUG level that may be compiled out in Release).
+- [ ] **Exception-related overhead** — Although the codebase uses Result<T,E>, check for code that might throw (STL containers, `std::stoi`, etc.) in hot paths without `noexcept` guarantees.
+
+## Output Format
+
+For each finding, report:
+```
+[P<severity>] <file>:<line> — <description>
+  Hot path: <yes/no — is this code in a per-frame/per-message path?>
+  Evidence: <what you found and why it matters>
+  Cost estimate: <rough impact — e.g., "~1 allocation per frame", "O(n^2) where n=max_detections(50)">
+  Suggestion: <specific fix>
+```
+
+At the end, provide a summary:
+```
+Performance Summary:
+  Files reviewed: N
+  Hot paths analyzed: N
+  P1 findings: N (allocation / algorithmic)
+  P2 findings: N (copies / locks / redundant work)
+  P3 findings: N (optimization opportunities)
+  Verdict: PASS / NEEDS_FIXES / BLOCKS_MERGE
+```
+
+## Pass 1 Context
+
+If you receive findings from Pass 1 reviewers, use them to:
+- Check if concurrency-flagged code has lock scope issues
+- Verify that memory-safety fixes didn't introduce unnecessary copies (common pattern: fixing a use-after-free by copying instead of fixing lifetime)
+- Identify if fault-recovery code paths have allocation that could fail under memory pressure

--- a/.claude/agents/review-test-quality.md
+++ b/.claude/agents/review-test-quality.md
@@ -1,0 +1,76 @@
+---
+name: review-test-quality
+description: Reviews test code for quality — verifies new tests exercise new code paths, assertions are meaningful, boundary conditions covered
+tools: [Read, Glob, Grep]
+model: opus
+---
+
+# Review Agent — Test Quality & Design
+
+You are a **read-only** reviewer focused exclusively on test quality. You verify that tests actually validate the code they claim to test — catching the class of bugs where tests pass but don't exercise the new code path. You CANNOT edit files, write files, or run commands — you can only read and search.
+
+## System Context
+
+- **Stack:** Safety-critical C++17 autonomous drone software — inadequate tests can mask bugs that cause loss of vehicle
+- **Test framework:** Google Test (GTest), tests in `tests/` directory
+- **Test patterns:** See `docs/guides/CPP_PATTERNS_GUIDE.md` for project testing conventions
+- **Key pattern:** `ScopedMockClock` for time-dependent tests, `RESOURCE_LOCK "zenoh_session"` for IPC tests
+- **Baseline:** 1259 C++ tests across 57 binaries (see `tests/TESTS.md`)
+
+## Motivation
+
+This agent was created after PR #391 where all 4 existing review agents passed, but GitHub Copilot found that:
+1. Tests placed detections inside the existing HD-map footprint, so the old code path handled them before the new logic was reached
+2. A test named `HdMapAdjacentCellAlsoSuppressed` placed detections inside the inflation zone, not testing the 3x3 Chebyshev neighborhood
+
+These are **test design bugs** — the tests pass, compile, and don't crash, but they don't validate the feature they were written for.
+
+## Review Checklist
+
+### P1 — Critical (blocks merge)
+
+- [ ] **Tests exercise the NEW code path** — For each new function/branch/feature: trace the test's input through the code. Does it actually reach the new logic? Or does an existing check (guard clause, early return, prior layer) handle it first?
+- [ ] **Disabling the feature breaks the test** — Mental model: if you commented out the new code, would the test still pass? If yes, the test is not validating the feature.
+- [ ] **No false-green tests** — Tests that pass for the wrong reason (e.g., testing a default value that happens to match, or testing a no-op path)
+
+### P2 — High (should fix before merge)
+
+- [ ] **Assertions test the right thing** — Are we asserting the output we care about, or a side effect? Example: asserting "function didn't crash" is not the same as asserting "function produced correct output"
+- [ ] **Boundary conditions covered** — For spatial code: test at the boundary, not just inside or outside. For numeric code: test at limits, zero, negative, overflow.
+- [ ] **Test positioning validates the feature** — For grid/spatial tests: are test coordinates chosen to exercise the specific geometric check? (e.g., Chebyshev-1 means adjacent cell, not same cell)
+- [ ] **Error paths tested** — If new code has error handling (`Result::Err`, early returns), are those paths exercised?
+- [ ] **Test isolation** — Do tests clean up after themselves? Are `ScopedMockClock` or similar RAII guards used for time-dependent tests? Can tests interfere with each other?
+
+### P3 — Medium (nice to have)
+
+- [ ] **Test names describe the behavior** — `TestFeatureX_WhenConditionY_ExpectsResultZ` not `TestFeatureX_Basic`
+- [ ] **Parameterized tests for variations** — If multiple similar scenarios differ only in input, use `TEST_P` not copy-paste
+- [ ] **No hardcoded magic numbers in tests** — Use named constants or compute expected values from inputs
+- [ ] **Negative tests exist** — "Does it reject bad input?" not just "does it accept good input?"
+
+## Output Format
+
+For each finding, report:
+```
+[P<severity>] <file>:<line> — <description>
+  Evidence: <what you traced to reach this conclusion>
+  Suggestion: <how to fix the test>
+```
+
+At the end, provide a summary:
+```
+Test Quality Summary:
+  Files reviewed: N
+  Tests analyzed: N
+  P1 findings: N
+  P2 findings: N
+  P3 findings: N
+  Verdict: PASS / NEEDS_FIXES / BLOCKS_MERGE
+```
+
+## Pass 1 Context
+
+If you receive findings from Pass 1 reviewers (memory-safety, security, concurrency, etc.), use them to:
+- Verify that flagged code paths have corresponding test coverage
+- Check if test assertions would catch the issues the reviewers found
+- Identify gaps where a safety reviewer flagged a function but no test exercises it

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -41,12 +41,16 @@ If format issues are found:
 2. Offer to auto-fix: `clang-format-18 -i <files>`
 3. If user accepts, format and re-stage the fixed files
 
-**Sensitive file check** — scan staged files for secrets patterns:
+**Sensitive file check** — scan staged filenames AND diff content for secrets:
 ```bash
+# Check filenames for known secret file patterns
 git diff --cached --name-only | grep -iE '\.env|credential|secret|\.pem|\.key|token'
+
+# Check staged diff content for hardcoded secrets (passwords, API keys, tokens)
+git diff --cached -U0 | grep -iE 'password\s*=|api_key\s*=|secret\s*=|token\s*=|-----BEGIN' | head -20
 ```
 
-If found, warn the user and ask for explicit confirmation before proceeding.
+If either check finds matches, warn the user with the specific matches and ask for explicit confirmation before proceeding.
 
 **Test count check** (only if test files changed) — if any files in `tests/` are staged:
 ```bash
@@ -90,8 +94,9 @@ EOF
 Run `git status` to confirm the commit succeeded and show the result.
 
 If the commit fails due to a pre-commit hook:
-- Read the hook output
+- Read the hook output to understand what failed
 - Fix the issue (usually formatting)
-- Re-stage and create a **NEW** commit (do NOT amend — amending after a hook failure modifies the PREVIOUS commit)
+- Re-stage the fixed files and re-run `git commit` with the same message
+- Note: a failed hook means no commit was created, so `--amend` would modify the previous unrelated commit — only use `--amend` if a commit already exists and you explicitly want to update it
 
 If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: commit
+description: Create a conventional commit with pre-commit validation — format check, sensitive file detection, test count verification
+argument-hint: "[optional: description of changes]"
+---
+
+# /commit — Smart Commit with Validation
+
+Create a git commit following this project's conventions, with automatic pre-commit validation.
+
+## Steps
+
+### 1. Gather State
+
+Run these in parallel:
+- `git status` — see all untracked and modified files
+- `git diff --staged` — see what's already staged
+- `git diff` — see unstaged changes
+- `git log --oneline -10` — recent commit messages for style reference
+- `git branch --show-current` — current branch name
+
+### 2. Determine What to Commit
+
+- If nothing is staged and nothing is modified, report "nothing to commit" and stop
+- If there are unstaged changes but nothing staged, show the changes and ask what to stage
+- If there are both staged and unstaged changes, show both and ask if unstaged changes should be included
+- **Never stage sensitive files**: `.env`, `credentials.json`, `*.pem`, `*.key`, secrets. Warn if these appear in the diff.
+- Prefer staging specific files by name rather than `git add -A`
+
+### 3. Pre-Commit Validation
+
+Before committing, run these checks:
+
+**Format check** — find all changed C/C++ files and verify formatting:
+```bash
+git diff --cached --name-only --diff-filter=ACMR | grep -E '\.(h|cpp)$' | xargs -r clang-format-18 --dry-run --Werror 2>&1
+```
+
+If format issues are found:
+1. Show the specific files with issues
+2. Offer to auto-fix: `clang-format-18 -i <files>`
+3. If user accepts, format and re-stage the fixed files
+
+**Sensitive file check** — scan staged files for secrets patterns:
+```bash
+git diff --cached --name-only | grep -iE '\.env|credential|secret|\.pem|\.key|token'
+```
+
+If found, warn the user and ask for explicit confirmation before proceeding.
+
+**Test count check** (only if test files changed) — if any files in `tests/` are staged:
+```bash
+ctest -N --test-dir build 2>/dev/null | grep "Total Tests:"
+```
+Compare against the baseline in `tests/TESTS.md`. Warn if mismatched.
+
+### 4. Draft Commit Message
+
+Follow the project's conventional commit format: `type(#issue): description`
+
+**Types:** `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`
+
+**Rules:**
+- Extract issue number from branch name if it follows `feature/issue-XX-*` or `fix/issue-XX-*` pattern
+- Keep the subject line under 72 characters
+- Use imperative mood ("add", "fix", "update", not "added", "fixes", "updated")
+- The subject should describe the **why**, not the **what** (the diff shows what)
+- Add a body (separated by blank line) if the change is non-trivial — explain motivation, not mechanics
+- Always end with: `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+
+If the user provided a description in `$ARGUMENTS`, use it as the basis for the commit message.
+
+### 5. Create the Commit
+
+Show the draft message and ask for approval. Then commit using a heredoc:
+
+```bash
+git commit -m "$(cat <<'EOF'
+type(#issue): subject line
+
+Optional body explaining why.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 6. Post-Commit Verification
+
+Run `git status` to confirm the commit succeeded and show the result.
+
+If the commit fails due to a pre-commit hook:
+- Read the hook output
+- Fix the issue (usually formatting)
+- Re-stage and create a **NEW** commit (do NOT amend — amending after a hook failure modifies the PREVIOUS commit)
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: create-issue
+description: Create a structured GitHub issue with AI-powered domain detection, auto-labeling, and code context — supports bug, feature, refactor, performance, audit types
+argument-hint: "<type>: <title> [--milestone <name>] [--epic <number>]"
+---
+
+# /create-issue — Structured Issue Filing with Code Context
+
+Create a well-structured GitHub issue with automatic domain detection, label assignment, and relevant code context. This skill analyzes the codebase to enrich issue descriptions beyond what a human would typically include.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **type prefix** (required): One of `bug:`, `feat:`, `refactor:`, `perf:`, `audit:`, `test:`
+- **title** (required): The issue title after the type prefix
+- **--milestone \<name\>** (optional): Assign to a milestone
+- **--epic \<number\>** (optional): Link as sub-issue of an epic
+
+If no arguments provided, ask the user for the type and title.
+
+Example invocations:
+```
+/create-issue bug: snap offset exceeds acceptance_radius during waypoint transitions
+/create-issue feat: add multi-class height priors for depth estimation
+/create-issue refactor: extract OccupancyGrid3D from mission planner main
+/create-issue perf: reduce allocation in per-frame detection loop
+/create-issue audit: review thread safety of UKF fusion engine
+/create-issue test: add boundary tests for D* Lite planner edge cases
+```
+
+## Steps
+
+### Step 1: Parse Type and Detect Domain
+
+Map the type prefix to GitHub template and labels:
+
+| Prefix | Template | Labels |
+|--------|----------|--------|
+| `bug:` | Bug Report | `bug`, `triage` |
+| `feat:` | Feature Request | `enhancement`, `triage` |
+| `refactor:` | Refactor | `refactor`, `triage` |
+| `perf:` | Performance | `performance`, `triage` |
+| `audit:` | Safety/Security Audit | `safety-audit` or `security-audit` |
+| `test:` | Test Coverage | `test-coverage`, `triage` |
+
+### Step 2: Detect Domain from Title and Context [PARALLEL]
+
+Analyze the title to detect the affected domain:
+
+**Keyword-based routing** (from the label routing system in `scripts/orchestrator/config.py`):
+
+| Keywords in title | Domain label | Agent |
+|-------------------|-------------|-------|
+| perception, detection, tracking, fusion, camera, detector, YOLOv8, ByteTrack | `domain:perception` | feature-perception |
+| nav, mission, planner, slam, vio, waypoint, obstacle, avoidance, geofence | `domain:nav` | feature-nav |
+| comms, fc_link, gcs, gimbal, payload, monitor, mavlink | `domain:comms` | feature-integration |
+| ipc, zenoh, message_bus, wire_format, pub/sub | `domain:infra-core` | feature-infra-core |
+| config, util, result, error_handling, common | `domain:infra-core` | feature-infra-core |
+| deploy, ci, systemd, cross-compile, board, customer | `domain:infra-platform` | feature-infra-platform |
+
+Also search the codebase for relevant files:
+```bash
+# Search for symbols mentioned in the title
+```
+Use Grep to find files related to the title keywords. This helps:
+1. Identify the exact domain
+2. Find relevant code to reference in the issue body
+3. Detect related existing issues
+
+### Step 3: Search for Related Issues
+
+Check for duplicates or related work:
+```bash
+gh issue list --search "<key terms from title>" --limit 10 --json number,title,state,labels
+```
+
+If potential duplicates found, show them and ask the user to confirm this is a new issue.
+
+### Step 4: Gather Code Context
+
+Based on the detected domain and title, read relevant files to enrich the issue:
+
+**For bugs:**
+- Find the function/class mentioned in the title
+- Read the relevant code to understand current behavior
+- Check for existing tests that should have caught this
+- Look for related comments or TODOs
+
+**For features:**
+- Find the module where the feature would be added
+- Identify affected interfaces (HAL, IPC types)
+- Check if config keys would be needed
+- Identify which tests would need to be added
+
+**For refactors:**
+- Find the code being refactored
+- Measure current complexity (LOC, nesting depth)
+- Identify callers/dependents that would be affected
+
+**For performance:**
+- Find the hot path or code section
+- Check if it's in a per-frame/per-message path
+- Identify allocation or copy patterns
+
+### Step 5: Generate Issue Body
+
+Generate a structured issue body based on the type:
+
+**For bugs:**
+```markdown
+## Bug Report
+
+### Domain
+<detected domain>
+
+### Severity
+<estimate from description: Critical/High/Medium/Low>
+
+### Description
+**What happens:** <from user's title + code analysis>
+**Expected behavior:** <inferred from code intent>
+
+### Steps to Reproduce
+1. <steps if determinable from code>
+
+### Relevant Code
+- `<file>:<line>` — <description of the relevant function/section>
+
+### Root Cause Analysis
+<initial analysis based on code reading — where the bug likely originates>
+
+### Suggested Fix
+<approach based on code understanding>
+
+### Acceptance Criteria
+- [ ] Bug is fixed
+- [ ] Regression test added
+- [ ] No new warnings
+```
+
+**For features:**
+```markdown
+## Feature Request
+
+### Domain
+<detected domain>
+
+### Description
+**Problem:** <what limitation this addresses>
+**Proposed solution:** <from user's title + code analysis>
+
+### Affected Files
+| File | Change needed |
+|------|--------------|
+| <file> | <what changes> |
+
+### Design Considerations
+- **Interfaces affected:** <HAL interfaces, IPC types that would change>
+- **Config keys needed:** <new config parameters>
+- **Thread safety:** <if the feature touches shared state>
+- **IPC impact:** <if new messages or topics needed>
+
+### Implementation Approach
+<multi-step plan based on code understanding>
+
+### Acceptance Criteria
+- [ ] Feature implemented
+- [ ] Unit tests added (target: >80% coverage of new code)
+- [ ] Config keys documented
+- [ ] Design doc updated (if architectural change)
+- [ ] No new warnings
+```
+
+**For refactors:**
+```markdown
+## Refactor
+
+### Domain
+<detected domain>
+
+### Description
+**Current state:** <what the code looks like now, with metrics>
+**Target state:** <what it should look like after>
+
+### Motivation
+<why this refactor matters — complexity, maintainability, modularity>
+
+### Affected Files
+| File | Current | Target |
+|------|---------|--------|
+| <file> | <current state> | <target state> |
+
+### Callers/Dependents
+<list of files that use the code being refactored>
+
+### Acceptance Criteria
+- [ ] Refactor complete
+- [ ] No behavior change (existing tests still pass)
+- [ ] No new warnings
+- [ ] Code complexity reduced (measurable)
+```
+
+### Step 6: Estimate Size
+
+Based on the number of files affected and scope of changes:
+- **Small** (<200 lines, single PR): Single-file changes, minor additions
+- **Medium** (200-600 lines, 1-2 PRs): Multi-file changes, new test suite
+- **Large** (600+ lines, multi-phase): New module, cross-cutting refactor, epic
+
+If Large, suggest splitting into sub-issues with a phased approach.
+
+### Step 7: Preview and Create
+
+Present the full issue preview:
+
+```
+═══ Issue Preview ═══
+
+Title: <type>(#domain): <title>
+Labels: [<labels>]
+Milestone: <milestone if provided>
+
+Body:
+<generated body>
+
+--- Related Issues ---
+#XX — <similar issue title> (open/closed)
+
+--- Suggested Labels ---
+<auto-detected labels from domain + type>
+```
+
+User choices:
+- **create** — create the issue via `gh issue create`
+- **edit** — modify title, body, or labels before creating
+- **cancel** — don't create
+
+If creating:
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<labels>"
+```
+
+If `--milestone` was provided:
+```bash
+gh issue edit <number> --milestone "<milestone>"
+```
+
+If `--epic` was provided, add a comment on the epic issue linking this as a sub-issue.
+
+### Step 8: Post-Creation
+
+After creating the issue:
+1. Show the issue URL
+2. If the issue is a bug, suggest: "Create a branch with `/deploy-issue <number>`?"
+3. If the issue is part of an epic, update the epic's task list
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/deploy-issue/SKILL.md
+++ b/.claude/skills/deploy-issue/SKILL.md
@@ -36,17 +36,21 @@ Display: issue title, labels, state. If the issue is closed, warn the user and a
 
 **Step 1.2 — Triage labels → agent role**
 
-Route the issue to an agent role using this label priority system:
+Route the issue to an agent role using the label routing from `scripts/orchestrator/config.py` (`LABEL_ROUTING` + `LABEL_DIRECT_ROLES`):
 
-| Priority | Labels | Role |
-|----------|--------|------|
-| P3 (highest) | `perception`, `detection`, `tracking`, `fusion` | `feature-perception` |
-| P3 | `nav-planning`, `mission`, `slam`, `vio`, `path-planning` | `feature-nav` |
-| P3 | `comms`, `fc-link`, `gcs`, `gimbal`, `payload`, `monitor` | `feature-integration` |
-| P3 | `ipc`, `config`, `util`, `common`, `modularity` | `feature-infra-core` |
-| P2 | `infrastructure`, `ci`, `deploy`, `systemd`, `cross-compile` | `feature-infra-platform` |
-| Direct | `audit`, `security-audit` | `review-security` |
-| Direct | `test`, `test-coverage` | `test-unit` |
+| Priority | Labels (from `LABEL_ROUTING`) | Role |
+|----------|-------------------------------|------|
+| P3 (highest) | `perception`, `domain:perception` | `feature-perception` |
+| P3 | `nav-planning`, `domain:nav` | `feature-nav` |
+| P3 | `comms`, `domain:comms` | `feature-integration` |
+| P3 | `ipc` | `feature-infra-core` |
+| P2 | `integration`, `domain:integration` | `feature-integration` |
+| P2 | `common`, `infra`, `infrastructure`, `modularity`, `domain:infra-core` | `feature-infra-core` |
+| P1 | `platform`, `deploy`, `ci`, `bsp`, `domain:infra-platform` | `feature-infra-platform` |
+| Direct | `safety-audit` | `review-memory-safety` |
+| Direct | `security-audit` | `review-security` |
+| Direct | `test-coverage` | `test-unit` |
+| Direct | `cross-domain` | `tech-lead` |
 
 Also detect: `bug` label → set `is_bug=true` (affects branch prefix: `fix/` vs `feature/`).
 
@@ -67,17 +71,21 @@ Ask: "Branch to **main** or an **integration branch**?"
 
 If integration: check for existing integration branches with `git branch -r --list 'origin/integration/*'` and let the user pick or create a new one.
 
-**Step 1.4 — Create branch and worktree**
+**Step 1.4 — Create branch**
 
 ```bash
+# Fetch latest remote state to avoid branching from stale local refs
+git fetch origin
+
 # Branch naming
 branch_name="<fix|feature>/issue-<N>-<slug>"  # slug from title, max 40 chars
+base_ref="origin/<base_branch>"               # always use origin/ to avoid stale local ref
 
-# Create branch from base
-git checkout -b "$branch_name" "<base_branch>"
+# Create branch from remote base
+git checkout -b "$branch_name" "$base_ref"
 ```
 
-Note: we work directly on the branch rather than in a separate worktree since we're in the current session.
+Note: The feature agent in Phase 2 runs in an **isolated worktree** (via `isolation: "worktree"`) so it cannot interfere with the current checkout. After the agent completes, its changes are merged back in Step 2.5.
 
 ---
 
@@ -138,10 +146,21 @@ Wait for the agent to complete.
 
 **Step 2.4 — Read results**
 
-After the agent completes, read `AGENT_REPORT.md` from the agent's worktree (the path is returned by the Agent tool). Also run:
+After the agent completes, read `AGENT_REPORT.md` from the agent's worktree (the path is returned by the Agent tool).
+
+**Step 2.5 — Integrate worktree changes**
+
+The Agent tool with `isolation: "worktree"` returns the worktree path and branch. Merge the agent's changes into the working branch:
+
 ```bash
-git diff --stat <base_branch>...HEAD
+# The agent committed to its worktree branch — merge those commits into our branch
+git merge <agent_worktree_branch> --no-edit
+
+# Verify the merge succeeded
+git diff --stat origin/<base_branch>...HEAD
 ```
+
+If the merge has conflicts (unlikely since the worktree branched from our branch), resolve them and commit. Copy `AGENT_REPORT.md` from the worktree to the current directory if not already present after merge.
 
 ---
 

--- a/.claude/skills/deploy-issue/SKILL.md
+++ b/.claude/skills/deploy-issue/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: deploy-issue
+description: Run the full deploy-issue pipeline within the current Claude Code session — routing, agent work, review, PR creation, and cleanup with 5 interactive checkpoints
+argument-hint: "<issue-number> [--base <branch>]"
+---
+
+# /deploy-issue — In-Session Pipeline
+
+Run the full development pipeline for a GitHub issue within the current Claude Code session. You (Claude) act as **tech-lead** throughout — routing, reviewing, synthesizing, and presenting findings at each checkpoint.
+
+**This replaces the `python -m orchestrator deploy-issue` subprocess workflow.** Instead of launching a separate `claude` process, everything happens inline in this conversation.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **issue_number** (required): The GitHub issue number (e.g., `299`)
+- **--base \<branch\>** (optional): Target branch for the PR (default: `main`). Use for integration branches like `--base integration/epic-284`.
+
+If no arguments provided, ask the user for the issue number.
+
+## Pipeline Phases
+
+Execute these phases sequentially. At each checkpoint (marked with **CP**), present your findings and wait for the user's decision before proceeding.
+
+---
+
+### PHASE 1: Routing & Setup [SEQUENTIAL]
+
+**Step 1.1 — Fetch issue**
+
+```bash
+gh issue view <issue_number> --json title,body,labels,state,milestone
+```
+
+Display: issue title, labels, state. If the issue is closed, warn the user and ask whether to proceed.
+
+**Step 1.2 — Triage labels → agent role**
+
+Route the issue to an agent role using this label priority system:
+
+| Priority | Labels | Role |
+|----------|--------|------|
+| P3 (highest) | `perception`, `detection`, `tracking`, `fusion` | `feature-perception` |
+| P3 | `nav-planning`, `mission`, `slam`, `vio`, `path-planning` | `feature-nav` |
+| P3 | `comms`, `fc-link`, `gcs`, `gimbal`, `payload`, `monitor` | `feature-integration` |
+| P3 | `ipc`, `config`, `util`, `common`, `modularity` | `feature-infra-core` |
+| P2 | `infrastructure`, `ci`, `deploy`, `systemd`, `cross-compile` | `feature-infra-platform` |
+| Direct | `audit`, `security-audit` | `review-security` |
+| Direct | `test`, `test-coverage` | `test-unit` |
+
+Also detect: `bug` label → set `is_bug=true` (affects branch prefix: `fix/` vs `feature/`).
+
+Present your routing recommendation:
+```
+Routing Recommendation:
+  Role:     feature-perception
+  Priority: high
+  Bug:      no
+  Reasoning: Issue labels [perception, fusion] map to P3 perception domain
+```
+
+Ask the user: **accept / override with a different role**
+
+**Step 1.3 — Branch strategy**
+
+Ask: "Branch to **main** or an **integration branch**?"
+
+If integration: check for existing integration branches with `git branch -r --list 'origin/integration/*'` and let the user pick or create a new one.
+
+**Step 1.4 — Create branch and worktree**
+
+```bash
+# Branch naming
+branch_name="<fix|feature>/issue-<N>-<slug>"  # slug from title, max 40 chars
+
+# Create branch from base
+git checkout -b "$branch_name" "<base_branch>"
+```
+
+Note: we work directly on the branch rather than in a separate worktree since we're in the current session.
+
+---
+
+### PHASE 2: Agent Work [SEQUENTIAL]
+
+**Step 2.1 — Gather cross-agent context**
+
+Read these files if they exist (skip if missing):
+- `tasks/active-work.md` — current in-flight work
+- `tasks/agent-changelog.md` — recent completed work
+- `.claude/shared-context/domain-knowledge.md` — non-obvious pitfalls
+
+**Step 2.2 — Spawn feature agent**
+
+Use the Agent tool to spawn the routed agent:
+
+```
+Agent(
+  description: "Implement issue #<N>",
+  subagent_type: "<routed-role>",  // e.g., "feature-perception"
+  isolation: "worktree",
+  prompt: <see below>
+)
+```
+
+The prompt must include:
+1. The full issue body
+2. Cross-agent context from Step 2.1
+3. These pipeline instructions:
+   - Implement the issue fully (code, tests, build verification)
+   - Run `bash deploy/build.sh` and verify zero warnings
+   - Run tests with `./tests/run_tests.sh` and verify pass rate
+   - Update documentation as required by DEVELOPMENT_WORKFLOW.md
+   - When done, write `AGENT_REPORT.md` in the worktree root with: Summary, Changes (table of files), Design Decisions, Test Coverage, Build Verification, Remaining Work
+   - Do NOT create a PR or push — leave changes as local commits
+
+Wait for the agent to complete.
+
+**Step 2.3 — Read results**
+
+After the agent completes, read `AGENT_REPORT.md` from the agent's worktree (the path is returned by the Agent tool). Also run:
+```bash
+git diff --stat <base_branch>...HEAD
+```
+
+---
+
+### CP1: Changes Review [INTERACTIVE]
+
+Present to the user:
+
+```
+═══ CHECKPOINT 1/5 — Changes Review ═══
+
+[AGENT_REPORT.md content or summary]
+
+--- Diff Summary ---
+[git diff --stat output]
+
+--- Tech-Lead Recommendation ---
+Based on the agent report and diff, I recommend: [accept/changes]
+Reasoning: [your assessment of completeness, quality, test coverage]
+[Any concerns or suggestions]
+```
+
+User choices:
+- **accept** → proceed to Phase 3
+- **changes** → ask the user what modifications they want, then either make them yourself or spawn the agent again with specific instructions. Return to CP1 after changes.
+- **reject** → go to ABORT
+
+---
+
+### PHASE 3: Validate & Commit
+
+**Step 3.1 — Validation** [PARALLEL where possible]
+
+Run these checks (use parallel Bash calls where possible):
+1. Build: `bash deploy/build.sh` (verify exit code 0, zero warnings)
+2. Format: Find changed C++ files and check with `clang-format-18 --dry-run --Werror`
+3. Test count: `ctest -N --test-dir build | grep "Total Tests:"` — compare against baseline in `tests/TESTS.md`
+
+### CP2: Commit Approval [INTERACTIVE]
+
+```
+═══ CHECKPOINT 2/5 — Commit Approval ═══
+
+--- Validation Results ---
+Build:      PASS (zero warnings)
+Format:     PASS
+Test count: 1259 (expected 1259) ✓
+
+[If any failures, show details and warn]
+```
+
+User choices:
+- **commit** → stage all changes, create commit: `feat(#<N>): <title>\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+- **back** → return to CP1
+- **abort** → go to ABORT
+
+---
+
+### PHASE 4: PR Creation [SEQUENTIAL]
+
+**Step 4.1 — Push**
+
+```bash
+git push -u origin <branch_name>
+```
+
+**Step 4.2 — Generate PR metadata**
+
+Create PR title and body:
+- Title: `feat(#<N>): <issue_title>` (or `fix(#<N>):` for bugs)
+- Body: Summary from AGENT_REPORT.md, diff stat, test plan checklist, `Closes #<N>`
+
+### CP3: PR Preview [INTERACTIVE]
+
+```
+═══ CHECKPOINT 3/5 — PR Preview ═══
+
+Title: feat(#299): add multi-class height priors for depth estimation
+
+Body:
+[generated body]
+```
+
+User choices:
+- **create** → `gh pr create --title "..." --body "..." --base <base_branch>`, then apply labels and milestone from source issue
+- **edit** → let user modify title/body, then loop back
+- **back** → return to CP2
+- **abort** → go to ABORT
+
+After creating: check for existing open PR for same branch first (`gh pr list --head <branch> --state open`). If one exists, offer to update it instead.
+
+---
+
+### PHASE 5: Review [TWO PASSES]
+
+**Pass 1 — Safety & Correctness** [PARALLEL]
+
+Get the PR diff and determine which reviewers to launch:
+
+Always launch:
+- `review-memory-safety`
+- `review-security`
+- `test-unit`
+
+Conditionally launch (check diff content):
+- `review-concurrency` — if diff contains `std::atomic`, `std::mutex`, `std::thread`, `lock_guard`, `memory_order`
+- `review-fault-recovery` — if diff touches `process4_*`, `process5_*`, `process7_*`, `watchdog`, `fault`, `health`
+- `test-scenario` — if diff touches `common/ipc/`, `common/hal/`, `config/scenarios/`, Gazebo configs
+
+Spawn all Pass 1 agents in **parallel** using multiple Agent tool calls in a single message. Each agent receives:
+- The PR diff (or summary of changed files with key snippets)
+- Instructions to report findings with severity (P1/P2/P3) and file:line references
+
+Collect all Pass 1 results.
+
+**Pass 2 — Quality & Contracts** [PARALLEL, after Pass 1]
+
+Spawn these agents in parallel, providing Pass 1 findings as context:
+- `review-test-quality` — validates tests exercise new code paths, assertions are meaningful
+- `review-api-contract` — validates docstrings, data consistency, code completeness
+- `review-code-quality` — catches dead code, DRY violations, complexity, naming issues
+- `review-performance` — catches unnecessary copies, allocation in hot paths, algorithmic complexity
+
+Collect Pass 2 results.
+
+**Merge findings** from both passes into a combined report.
+
+### CP4: Review Findings [INTERACTIVE]
+
+```
+═══ CHECKPOINT 4/5 — Review Findings ═══
+
+--- Review Summary ---
+Pass 1 (Safety & Correctness): 3 agents, 0 P1, 2 P2, 5 P3
+Pass 2 (Quality & Contracts):  4 agents, 0 P1, 1 P2, 3 P3
+
+--- P2 Issues ---
+1. [review-memory-safety] occupancy_grid_3d.h:142 — unguarded signed→unsigned cast on cell_count
+2. [review-test-quality] test_depth.cpp:87 — test doesn't exercise the new multi-class path (detection class is DEFAULT)
+3. [review-api-contract] ukf_fusion_engine.h:45 — estimate_depth() docstring says "returns meters" but returns depth_confidence tier
+
+--- P3 Issues ---
+[...]
+
+--- Tech-Lead Assessment ---
+Recommendation: fix (2 P2 issues are worth addressing before merge)
+```
+
+User choices:
+- **accept** → proceed to CP5 (findings are acceptable as-is)
+- **fix** → spawn feature agent with findings, then re-validate, commit, push, and re-run reviews (FIX LOOP → back to Phase 5)
+- **back** → return to CP3
+- **reject** → go to ABORT
+
+---
+
+### CP5: Final Summary [INTERACTIVE]
+
+```
+═══ CHECKPOINT 5/5 — Final Summary ═══
+
+--- Commit History ---
+[git log --oneline output for this branch]
+
+--- PR ---
+URL: https://github.com/<owner>/<repo>/pull/<N>
+Status: open
+Reviews: [summary]
+
+--- Validation ---
+Last build: PASS
+Last test count: 1259 ✓
+```
+
+User choices:
+- **done** → proceed to CLEANUP
+- **re-review** → re-run Phase 5 review agents
+- **back** → return to CP4
+- **abort** → go to ABORT
+
+---
+
+### CLEANUP [PARALLEL]
+
+1. Verify PR body contains `Closes #<issue_number>` — if not, update it
+2. Append entry to `tasks/agent-changelog.md`:
+   ```
+   ### <date> | <role> | <model> | PR #<N>
+   - **Issue:** #<issue_number> — <title>
+   - **Branch:** <branch_name>
+   - **Mode:** skill (/deploy-issue)
+   - **Status:** completed
+   ```
+3. Post a summary comment on the GitHub issue noting the PR
+4. Report completion to the user:
+   ```
+   Pipeline complete. PR #<N> ready for merge.
+   URL: <pr_url>
+   ```
+
+---
+
+### ABORT (from any checkpoint)
+
+If the user chooses to abort at any checkpoint:
+
+1. Ask: **clean up** (delete branch + any worktree) or **preserve** (keep for manual work)?
+2. If clean: `git checkout <base_branch>` and `git branch -D <branch_name>`
+3. If preserve: show resume instructions
+4. Report abort status
+
+---
+
+## Edge Cases
+
+- **Stale artifacts**: Before spawning the feature agent, check for and remove any existing `AGENT_REPORT.md` in the worktree from prior runs
+- **Duplicate PRs**: Before creating a PR, check `gh pr list --head <branch> --state open` — if one exists, offer to update instead of creating a duplicate
+- **Push failures**: If push fails, go back to CP2 (commit step), not loop within push
+- **Review agent timeout**: If an agent takes too long, report which agents completed and which are pending. Present partial results and ask the user how to proceed.
+- **Base branch verification**: If `--base` specifies an integration branch, verify it exists with `git branch -r --list 'origin/<base>'`
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/deploy-issue/SKILL.md
+++ b/.claude/skills/deploy-issue/SKILL.md
@@ -90,9 +90,29 @@ Read these files if they exist (skip if missing):
 - `tasks/agent-changelog.md` — recent completed work
 - `.claude/shared-context/domain-knowledge.md` — non-obvious pitfalls
 
-**Step 2.2 — Spawn feature agent**
+**Step 2.2 — Confirm feature agent launch**
 
-Use the Agent tool to spawn the routed agent:
+Present the agent that will be launched and ask for approval:
+
+```
+═══ Agent Launch — Feature Implementation ═══
+
+Agent:    <routed-role> (e.g., feature-perception)
+Model:    Opus
+Task:     Implement issue #<N> — <title>
+Isolation: worktree (separate git worktree)
+
+This agent will: implement the issue, write tests, build, and produce AGENT_REPORT.md.
+```
+
+User choices:
+- **launch** → spawn the agent (proceed to Step 2.3)
+- **skip** → skip the feature agent entirely. The user wants to implement manually. Jump straight to CP1 with an empty diff (user will make changes themselves during the "changes" flow at CP1).
+- **override \<role\>** → launch a different agent role instead (e.g., user wants `feature-nav` instead of `feature-integration`)
+
+**Step 2.3 — Spawn feature agent**
+
+Only if the user approved in Step 2.2. Use the Agent tool:
 
 ```
 Agent(
@@ -116,7 +136,7 @@ The prompt must include:
 
 Wait for the agent to complete.
 
-**Step 2.3 — Read results**
+**Step 2.4 — Read results**
 
 After the agent completes, read `AGENT_REPORT.md` from the agent's worktree (the path is returned by the Agent tool). Also run:
 ```bash
@@ -216,37 +236,76 @@ After creating: check for existing open PR for same branch first (`gh pr list --
 
 ### PHASE 5: Review [TWO PASSES]
 
-**Pass 1 — Safety & Correctness** [PARALLEL]
+**Step 5.1 — Build review roster and get approval**
 
-Get the PR diff and determine which reviewers to launch:
+Get the PR diff and determine which reviewers are applicable:
 
-Always launch:
-- `review-memory-safety`
-- `review-security`
-- `test-unit`
+**Pass 1 — Safety & Correctness** (always recommended):
+- `review-memory-safety` — RAII, ownership, lifetimes
+- `review-security` — input validation, auth, TLS
+- `test-unit` — GTest coverage, test count verification
 
-Conditionally launch (check diff content):
+**Pass 1 — Conditional** (recommended based on diff content):
 - `review-concurrency` — if diff contains `std::atomic`, `std::mutex`, `std::thread`, `lock_guard`, `memory_order`
 - `review-fault-recovery` — if diff touches `process4_*`, `process5_*`, `process7_*`, `watchdog`, `fault`, `health`
 - `test-scenario` — if diff touches `common/ipc/`, `common/hal/`, `config/scenarios/`, Gazebo configs
 
-Spawn all Pass 1 agents in **parallel** using multiple Agent tool calls in a single message. Each agent receives:
+**Pass 2 — Quality & Contracts** (always recommended, runs after Pass 1):
+- `review-test-quality` — tests exercise new code paths, assertions meaningful
+- `review-api-contract` — docstrings match impl, data consistency
+- `review-code-quality` — dead code, DRY violations, complexity, naming
+- `review-performance` — unnecessary copies, allocation in hot paths, O(n²)
+
+Present the full roster for approval:
+
+```
+═══ Review Agent Roster ═══
+
+--- Pass 1: Safety & Correctness ---
+  [1] review-memory-safety    RECOMMENDED   RAII, ownership, lifetimes
+  [2] review-security         RECOMMENDED   Input validation, auth, TLS
+  [3] test-unit               RECOMMENDED   GTest coverage, test count
+  [4] review-concurrency      CONDITIONAL   Diff contains std::atomic usage
+  [5] review-fault-recovery   NOT TRIGGERED Diff does not touch P4/P5/P7/watchdog
+
+--- Pass 2: Quality & Contracts (runs after Pass 1) ---
+  [6] review-test-quality     RECOMMENDED   Tests exercise new paths
+  [7] review-api-contract     RECOMMENDED   Docstrings, data consistency
+  [8] review-code-quality     RECOMMENDED   Dead code, DRY, complexity
+  [9] review-performance      RECOMMENDED   Copies, allocation, hot paths
+
+Launch: [1] [2] [3] [4] [6] [7] [8] [9]  (8 agents, ~5 min)
+Skipped: [5] (not triggered)
+```
+
+User choices:
+- **launch all** → launch all recommended/conditional agents as shown
+- **skip \<numbers\>** → skip specific agents (e.g., `skip 4 9` to skip concurrency and performance). The skipped agents will not run and their findings will show as "SKIPPED" in the report.
+- **only \<numbers\>** → launch only the specified agents (e.g., `only 1 2 3` for safety-only review)
+- **skip all** → skip the entire review phase, go directly to CP5
+
+**Step 5.2 — Launch Pass 1 agents** [PARALLEL]
+
+Spawn all **approved** Pass 1 agents in **parallel** using multiple Agent tool calls in a single message. Each agent receives:
 - The PR diff (or summary of changed files with key snippets)
 - Instructions to report findings with severity (P1/P2/P3) and file:line references
 
-Collect all Pass 1 results.
+Collect all Pass 1 results. Report progress as agents complete:
+```
+  ✓ review-memory-safety    complete (0 P1, 1 P2, 2 P3)
+  ✓ review-security         complete (0 P1, 0 P2, 1 P3)
+  ⏳ test-unit              running...
+```
 
-**Pass 2 — Quality & Contracts** [PARALLEL, after Pass 1]
+**Step 5.3 — Launch Pass 2 agents** [PARALLEL, after Pass 1]
 
-Spawn these agents in parallel, providing Pass 1 findings as context:
-- `review-test-quality` — validates tests exercise new code paths, assertions are meaningful
-- `review-api-contract` — validates docstrings, data consistency, code completeness
-- `review-code-quality` — catches dead code, DRY violations, complexity, naming issues
-- `review-performance` — catches unnecessary copies, allocation in hot paths, algorithmic complexity
+Spawn all **approved** Pass 2 agents in parallel, providing Pass 1 findings as context:
+- Each Pass 2 agent receives the merged Pass 1 findings so it can build on them
+- Skipped Pass 2 agents show as "SKIPPED" in the final report
 
 Collect Pass 2 results.
 
-**Merge findings** from both passes into a combined report.
+**Step 5.4 — Merge findings** from both passes into a combined report. Mark skipped agents clearly.
 
 ### CP4: Review Findings [INTERACTIVE]
 
@@ -254,8 +313,18 @@ Collect Pass 2 results.
 ═══ CHECKPOINT 4/5 — Review Findings ═══
 
 --- Review Summary ---
-Pass 1 (Safety & Correctness): 3 agents, 0 P1, 2 P2, 5 P3
-Pass 2 (Quality & Contracts):  4 agents, 0 P1, 1 P2, 3 P3
+Pass 1 (Safety & Correctness): 3 ran, 1 skipped, 0 P1, 2 P2, 5 P3
+Pass 2 (Quality & Contracts):  3 ran, 1 skipped, 0 P1, 1 P2, 3 P3
+
+--- Agent Status ---
+  ✓ review-memory-safety    0 P1, 1 P2, 3 P3
+  ✓ review-security         0 P1, 0 P2, 1 P3
+  ✓ test-unit               0 P1, 1 P2, 1 P3
+  ⊘ review-concurrency      SKIPPED (user)
+  ✓ review-test-quality     0 P1, 1 P2, 2 P3
+  ✓ review-api-contract     0 P1, 0 P2, 1 P3
+  ✓ review-code-quality     0 P1, 0 P2, 0 P3
+  ⊘ review-performance      SKIPPED (user)
 
 --- P2 Issues ---
 1. [review-memory-safety] occupancy_grid_3d.h:142 — unguarded signed→unsigned cast on cell_count
@@ -267,11 +336,13 @@ Pass 2 (Quality & Contracts):  4 agents, 0 P1, 1 P2, 3 P3
 
 --- Tech-Lead Assessment ---
 Recommendation: fix (2 P2 issues are worth addressing before merge)
+Note: 2 agents were skipped by user — those review areas are uncovered.
 ```
 
 User choices:
 - **accept** → proceed to CP5 (findings are acceptable as-is)
 - **fix** → spawn feature agent with findings, then re-validate, commit, push, and re-run reviews (FIX LOOP → back to Phase 5)
+- **fix \<numbers\>** → fix only specific issues by number (e.g., `fix 1 3`), accept the rest as-is
 - **back** → return to CP3
 - **reject** → go to ABORT
 

--- a/.claude/skills/deploy-issue/SKILL.md
+++ b/.claude/skills/deploy-issue/SKILL.md
@@ -191,12 +191,48 @@ User choices:
 
 ### PHASE 3: Validate & Commit
 
-**Step 3.1 — Validation** [PARALLEL where possible]
+**Step 3.1 — Validation (8-check hallucination detector)** [PARALLEL where possible]
 
-Run these checks (use parallel Bash calls where possible):
-1. Build: `bash deploy/build.sh` (verify exit code 0, zero warnings)
-2. Format: Find changed C++ files and check with `clang-format-18 --dry-run --Werror`
-3. Test count: `ctest -N --test-dir build | grep "Total Tests:"` — compare against baseline in `tests/TESTS.md`
+Run these checks. Checks 1-3 are BLOCKING (must pass to commit). Checks 4-8 are WARNING (report but don't block).
+
+**BLOCKING checks:**
+
+1. **Build** — `bash deploy/build.sh` (verify exit code 0, zero warnings)
+2. **Format** — Find changed C++ files and check with `clang-format-18 --dry-run --Werror`
+3. **Test count** — `ctest -N --test-dir build | grep "Total Tests:"` — compare against baseline in `tests/TESTS.md`
+
+**Hallucination detection checks (WARNING):**
+
+4. **Include verification** — Scan the diff for new `#include "..."` directives. For each, verify the header file exists in the repo (skip system/third-party prefixes: `zenoh/`, `Eigen/`, `opencv2/`, `gz/`, `mavsdk/`, `spdlog/`, `nlohmann/`, `gtest/`, `gmock/`).
+```bash
+git diff origin/<base_branch>...HEAD | grep '^\+.*#include "' | sed 's/.*#include "//;s/".*//' | sort -u
+```
+For each include, search the project dirs (`common/`, `process[1-7]_*/`, `tests/`) for the file.
+
+5. **AGENT_REPORT.md vs actual diff** — If AGENT_REPORT.md exists, extract its "Changed files" table and compare against `git diff --name-only origin/<base_branch>...HEAD`. Flag:
+   - Files listed in report but NOT in the diff (phantom changes — agent claimed to change a file it didn't)
+   - Files in the diff but NOT in the report (undocumented changes — agent forgot to report)
+
+6. **Config key consistency** — Search the diff for new `cfg.get<>()` or `cfg_key::` references. For each new config key, verify it exists in `config/default.json`. Agents commonly add code that reads a config key but forget to add the default value.
+```bash
+# Find new config key references in the diff
+git diff origin/<base_branch>...HEAD | grep '^\+' | grep -oE 'cfg\.get<[^>]*>\("[^"]*"' | sed 's/.*"//;s/".*//' | sort -u
+
+# Cross-reference against default.json
+```
+
+7. **Symbol resolution** — For new function calls or class references added in the diff, spot-check that the symbols actually exist. Focus on:
+   - New `#include` files → do the functions used from those headers exist?
+   - New class instantiations → does the constructor signature match?
+   - New method calls on existing classes → does the method exist?
+
+   This is a best-effort heuristic check. Use `grep -r` to verify key symbols. Don't exhaustively check every line — focus on non-trivial additions (new classes, factory calls, HAL interfaces).
+
+8. **Diff sanity** — Check the overall diff for red flags:
+   - Files >1000 lines added in a single commit (may indicate generated/copied code)
+   - Deleted files that are still `#include`d elsewhere
+   - Test files that don't contain any `TEST` or `TEST_F` macros (phantom test files)
+   - `.cpp` files added but not included in any `CMakeLists.txt`
 
 ### CP2: Commit Approval [INTERACTIVE]
 
@@ -204,11 +240,20 @@ Run these checks (use parallel Bash calls where possible):
 ═══ CHECKPOINT 2/5 — Commit Approval ═══
 
 --- Validation Results ---
-Build:      PASS (zero warnings)
-Format:     PASS
-Test count: 1259 (expected 1259) ✓
+[BLOCKING]
+Build:          PASS (zero warnings)
+Format:         PASS
+Test count:     1259 (expected 1259) ✓
 
-[If any failures, show details and warn]
+[HALLUCINATION CHECKS]
+Includes:       PASS (3 new includes, all resolved)
+Report vs diff: WARN (report lists config_validator.h but not in diff)
+Config keys:    PASS (2 new keys, both in default.json)
+Symbol check:   PASS (spot-checked 4 symbols)
+Diff sanity:    PASS
+
+[If any BLOCKING checks fail, recommend going back to CP1]
+[If any hallucination checks WARN, show details and recommend review]
 ```
 
 User choices:

--- a/.claude/skills/production-readiness/SKILL.md
+++ b/.claude/skills/production-readiness/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: production-readiness
+description: Pre-deployment audit for hardware — build verification, safety audit, test coverage, security scan, performance check, config audit, debug code gate, systemd validation
+argument-hint: "[--target <jetson-orin|localhost>] [--quick] [--section <name>]"
+---
+
+# /production-readiness — Pre-Deployment Audit
+
+Comprehensive production readiness assessment before deploying to hardware. Checks 10 categories covering build, safety, security, performance, configuration, documentation, dependencies, debug code, systemd, and scenario tests.
+
+**This is the final gate before code goes on a real drone.** Every finding is either BLOCKING (must fix) or ADVISORY (should fix, document risk if not).
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **--target \<platform\>** (optional): `jetson-orin` (default) or `localhost` (dev machine audit)
+- **--quick** (optional): Run only blocking checks (skip advisory sections)
+- **--section \<name\>** (optional): Run a specific section only (e.g., `safety`, `security`, `performance`)
+
+## Audit Sections
+
+### Section 1: Build Verification [BLOCKING]
+
+Run the build with maximum strictness:
+
+```bash
+bash deploy/build.sh
+```
+
+Verify:
+- [ ] Exit code 0
+- [ ] Zero compiler warnings (`-Werror -Wall -Wextra`)
+- [ ] All `[[nodiscard]]` enforced
+- [ ] Build output size reasonable (check binary sizes in `build/bin/`)
+
+If `--target jetson-orin`, also check:
+- [ ] Cross-compilation config exists (`boards/jetson-orin/`)
+- [ ] ARM64 toolchain available
+
+Report binary sizes:
+```
+Binary sizes:
+  video_capture:    1.2 MB
+  perception:       3.4 MB
+  slam_vio_nav:     2.1 MB
+  mission_planner:  2.8 MB
+  comms:            1.5 MB
+  payload_manager:  0.8 MB
+  system_monitor:   0.9 MB
+  Total:           12.7 MB
+```
+
+### Section 2: Safety Audit [BLOCKING]
+
+Run the existing safety audit script:
+
+```bash
+bash deploy/safety_audit.sh
+```
+
+This checks 29 safety rules from CLAUDE.md:
+- **16 AVOID rules**: memcpy, raw new/delete, shared_ptr, C-style casts, reinterpret_cast without static_assert, volatile, goto, atoi/atof, bare std::thread, using namespace in headers, exit/abort, unscoped enum, global mutable state, memory_order_relaxed, signed→unsigned casts
+- **12 PREFER rules**: [[nodiscard]], RAII locks, = delete, override, noexcept on moves, fixed-width types, default member initializers, strong types
+
+Parse the report and present:
+```
+Safety Audit: 28/29 PASS, 1 WARN, 0 FAIL
+  WARN: Rule 30 (signed→unsigned casts) — 2 instances in process4_mission_planner/
+```
+
+### Section 3: Test Coverage [BLOCKING]
+
+Run tests and verify coverage:
+
+```bash
+# Run all tests
+./tests/run_tests.sh
+
+# Get test count
+ctest -N --test-dir build | grep "Total Tests:"
+
+# Compare to baseline
+```
+
+Read `tests/TESTS.md` for the expected baseline count.
+
+Verify:
+- [ ] All tests pass (100% pass rate)
+- [ ] Test count matches baseline (currently 1259 C++ + 42 shell + 250+ scenario)
+- [ ] No RESOURCE_LOCK warnings (Zenoh session exhaustion)
+
+If coverage build is available (`build-coverage/`):
+```bash
+bash deploy/view_coverage.sh --no-open
+```
+- [ ] Line coverage ≥ 75% (current baseline: 75.1%)
+- [ ] No uncovered safety-critical paths (mission planner, fault recovery, comms)
+
+### Section 4: Sanitizer Verification [BLOCKING]
+
+Run all three sanitizers:
+
+```bash
+bash deploy/build.sh --asan && ./tests/run_tests.sh    # AddressSanitizer
+bash deploy/build.sh --tsan && ./tests/run_tests.sh    # ThreadSanitizer
+bash deploy/build.sh --ubsan && ./tests/run_tests.sh   # UBSanitizer
+```
+
+This is slow (~15 min total). If `--quick`, skip and warn that sanitizers were not run.
+
+Verify:
+- [ ] ASan: zero heap-buffer-overflow, use-after-free, memory leaks
+- [ ] TSan: zero data races (note: Zenoh/MAVSDK tests excluded under TSan)
+- [ ] UBSan: zero undefined behavior (signed overflow, null deref, alignment)
+
+### Section 5: Security Scan [BLOCKING]
+
+Check for security issues:
+
+**Debug/insecure code:**
+```bash
+# ALLOW_INSECURE_ZENOH should NOT be in production builds
+grep -r "ALLOW_INSECURE_ZENOH" CMakeLists.txt build/
+```
+
+**Secrets exposure:**
+```bash
+# Check for hardcoded credentials, tokens, API keys
+grep -rn "password\|secret\|api_key\|token\|credential" common/ process[1-7]_* --include='*.h' --include='*.cpp' -i
+```
+
+**Network exposure:**
+```bash
+# Check Zenoh config for open listeners
+grep -r "listen\|connect" config/default.json config/gazebo_sitl.json
+```
+
+**Input validation:**
+- [ ] All IPC structs have `validate()` methods
+- [ ] MAVLink messages validated before processing
+- [ ] GCS commands bounds-checked
+- [ ] Config values validated (no negative altitudes, no zero timeouts)
+
+Verify:
+- [ ] No `ALLOW_INSECURE_ZENOH` in production config
+- [ ] No hardcoded secrets
+- [ ] Zenoh TLS configured (or documented exception)
+- [ ] All external inputs validated
+
+### Section 6: Performance Check [ADVISORY]
+
+Check for performance issues in hot paths:
+
+**Allocation in frame loop:**
+```bash
+# Search for new/make_unique/make_shared in perception and mission planner hot paths
+grep -n "make_unique\|make_shared\|new " process2_perception/src/*.cpp process4_mission_planner/src/*.cpp
+```
+
+**Lock scope:**
+- Check for mutexes held during I/O or allocation
+- Check for wide lock scopes in per-frame code
+
+**Binary size:**
+- Compare against previous release (if available)
+- Flag binaries > 10 MB (may indicate bloat from template instantiation or debug symbols)
+
+### Section 7: Configuration Audit [BLOCKING]
+
+Verify production config:
+
+1. Read `config/default.json` — check all tunables have sensible defaults
+2. Verify no test/debug overrides:
+   - `ipc_backend` must be `"zenoh"` (not `"shm"`)
+   - `detector.backend` should not be `"simulated"` in production
+   - `video_capture.mission_cam.backend` should not be `"simulated"`
+3. Verify safety parameters:
+   - `geofence.enabled` should be `true`
+   - `battery.rtl_threshold` should be > 0
+   - `watchdog` timeout values reasonable (not too short, not disabled)
+
+If `--target jetson-orin`, check customer configs:
+```bash
+ls config/customers/
+```
+
+### Section 8: Debug Code Gate [BLOCKING]
+
+Check for debug/diagnostic code that should be gated or removed before production.
+
+Search for known debug patterns (from `project_production_debug_cleanup.md` memory):
+
+```bash
+# DIAG logging that should be disabled in Release
+grep -rn "DIAG\|DEBUG_ONLY\|#ifdef DEBUG" common/ process[1-7]_* --include='*.h' --include='*.cpp'
+
+# Test-only code paths
+grep -rn "TEST_ONLY\|TESTING\|#ifdef TESTING" common/ process[1-7]_* --include='*.h' --include='*.cpp'
+
+# Temporary/experimental code
+grep -rn "TODO.*remove\|HACK\|FIXME\|TEMPORARY\|EXPERIMENTAL" common/ process[1-7]_* --include='*.h' --include='*.cpp'
+```
+
+Verify:
+- [ ] No DIAG logging at ERROR/WARN level (should be DEBUG/TRACE only)
+- [ ] No test-only code compiled in Release
+- [ ] All TODOs/HACKs tracked as issues or documented as acceptable
+
+### Section 9: systemd Validation [BLOCKING for hardware]
+
+Verify systemd service units:
+
+```bash
+# Check syntax
+for f in deploy/systemd/*.service; do
+    systemd-analyze verify "$f" 2>&1
+done
+```
+
+Verify:
+- [ ] All 7 service files + target file present
+- [ ] `Type=notify` with `WatchdogSec=10s` on all services
+- [ ] `BindsTo=` dependencies correct (P4 depends on P2, P5, etc.)
+- [ ] `ExecStart=` points to correct binary paths
+- [ ] `Restart=on-failure` with reasonable `RestartSec`
+
+If `--target localhost`, skip and note "systemd validation skipped (not hardware target)".
+
+### Section 10: Scenario Test Results [ADVISORY]
+
+Check recent scenario test results:
+
+```bash
+# Find latest run results
+ls -lt drone_logs/scenarios_gazebo/*/latest/run_metadata.json 2>/dev/null | head -25
+```
+
+If results exist, parse and summarize:
+- [ ] All 20 Tier 1 scenarios pass
+- [ ] All 5 Tier 2 scenarios pass (if Gazebo available)
+- [ ] No regressions from previous run
+
+If no recent results, suggest: "Run `/run-scenario all` before deploying."
+
+### Section 11: Dependency Audit [ADVISORY]
+
+Check dependency versions:
+
+```bash
+# Zenoh version
+dpkg -l | grep zenoh 2>/dev/null || echo "Zenoh not installed via dpkg"
+
+# OpenCV version
+pkg-config --modversion opencv4 2>/dev/null || echo "OpenCV not found"
+
+# MAVSDK version
+grep "MAVSDK" CMakeLists.txt
+```
+
+Compare against known-good versions in `deploy/install_dependencies.sh`.
+
+Verify:
+- [ ] Zenoh version matches CI (1.7.2)
+- [ ] No CVEs in current dependency versions (check recent advisories)
+- [ ] All dependencies available on target platform
+
+---
+
+## Final Report
+
+Present the complete audit report:
+
+```
+═══════════════════════════════════════════════════════
+  PRODUCTION READINESS AUDIT
+  Target: <platform>
+  Date: <today>
+  Branch: <branch>
+  Commit: <commit>
+═══════════════════════════════════════════════════════
+
+--- BLOCKING ---
+[1]  Build Verification     PASS
+[2]  Safety Audit           PASS (28/29 rules, 1 WARN)
+[3]  Test Coverage          PASS (1259 tests, 100% pass)
+[4]  Sanitizers             PASS (ASan + TSan + UBSan clean)
+[5]  Security Scan          PASS
+[7]  Config Audit           WARN (geofence disabled in default.json)
+[8]  Debug Code Gate        PASS (2 TODOs tracked as issues)
+[9]  systemd Validation     PASS (7 services verified)
+
+--- ADVISORY ---
+[6]  Performance Check      WARN (3 allocations in frame loop)
+[10] Scenario Tests         PASS (25/25 green)
+[11] Dependency Audit       PASS (versions match CI)
+
+═══════════════════════════════════════════════════════
+  VERDICT: CONDITIONAL PASS
+  Blocking issues: 0
+  Advisory warnings: 2
+  
+  Action items:
+  1. [ADVISORY] Fix 3 allocations in perception frame loop
+  2. [ADVISORY] Enable geofence in production config
+═══════════════════════════════════════════════════════
+
+Pre-Flight Checklist for Hardware Deployment:
+  □ Flash Jetson Orin with JetPack 6.x
+  □ Install dependencies: bash deploy/install_dependencies.sh --all
+  □ Build: bash deploy/build.sh
+  □ Install systemd units: bash deploy/install_systemd.sh
+  □ Configure customer config: config/customers/<customer>.json
+  □ Enable geofence with mission-specific polygon
+  □ Verify sensor connections (cameras, IMU, radar)
+  □ Test arm/disarm cycle via GCS
+  □ Run nominal_mission scenario on bench
+  □ Verify RTL triggers correctly
+```
+
+User choices:
+- **generate-checklist** — output the pre-flight checklist as a standalone markdown file
+- **file-issues** — create GitHub issues for each blocking/advisory item
+- **re-run \<section\>** — re-run a specific section after fixing issues
+- **done** — acknowledge the audit
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/production-readiness/SKILL.md
+++ b/.claude/skills/production-readiness/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[--target <jetson-orin|localhost>] [--quick] [--section <name>]"
 
 # /production-readiness — Pre-Deployment Audit
 
-Comprehensive production readiness assessment before deploying to hardware. Checks 10 categories covering build, safety, security, performance, configuration, documentation, dependencies, debug code, systemd, and scenario tests.
+Comprehensive production readiness assessment before deploying to hardware. Checks 11 categories covering build, safety, test coverage, sanitizers, security, performance, configuration, debug code, systemd, scenario tests, and dependencies.
 
 **This is the final gate before code goes on a real drone.** Every finding is either BLOCKING (must fix) or ADVISORY (should fix, document risk if not).
 
@@ -188,7 +188,7 @@ ls config/customers/
 
 Check for debug/diagnostic code that should be gated or removed before production.
 
-Search for known debug patterns (from `project_production_debug_cleanup.md` memory):
+Search for known debug patterns:
 
 ```bash
 # DIAG logging that should be disabled in Release

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -42,11 +42,11 @@ Examine the diff to determine which Pass 1 agents to launch:
 **Always launch:**
 - `review-memory-safety`
 - `review-security`
+- `test-unit`
 
 **Conditionally launch (check diff content):**
 - `review-concurrency` — if diff contains `std::atomic`, `std::mutex`, `std::thread`, `lock_guard`, `condition_variable`, `memory_order`
 - `review-fault-recovery` — if diff touches `process4_*`, `process5_*`, `process7_*`, `watchdog`, `fault`, `recovery`
-- `test-unit` — if diff touches files in `tests/` or adds new public APIs that should have tests
 - `test-scenario` — if diff touches `common/ipc/`, `common/hal/`, `config/scenarios/`, Gazebo configs
 
 If `--focus` was specified, prioritize that domain's agent and reduce others to a quick scan.
@@ -57,6 +57,7 @@ Review Routing:
   Pass 1 (safety & correctness):
     - review-memory-safety (always)
     - review-security (always)
+    - test-unit (always)
     - review-concurrency (triggered: diff contains "std::atomic")
   Pass 2 (quality & contracts):
     - review-test-quality (always)

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: review-pr
+description: Run a two-pass domain-aware code review on a pull request — spawns up to 10 review agents with severity-tagged findings
+argument-hint: "<pr-number> [--focus <domain>] [--pass1-only]"
+---
+
+# /review-pr — Domain-Aware Two-Pass Code Review
+
+Run the full two-pass review pipeline on a pull request, with Claude acting as tech-lead to synthesize findings.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **pr_number** (required): The PR number (e.g., `396`)
+- **--focus \<domain\>** (optional): Limit review focus (e.g., `security`, `performance`, `memory-safety`)
+- **--pass1-only** (optional): Skip Pass 2 agents
+
+If no arguments provided, ask the user for the PR number.
+
+---
+
+## Steps
+
+### Step 1: Fetch PR Context [PARALLEL]
+
+Run these in parallel:
+```bash
+gh pr view <pr_number> --json title,body,labels,state,baseRefName,headRefName,files,additions,deletions
+gh pr diff <pr_number>
+gh pr checks <pr_number>
+gh pr view <pr_number> --comments
+```
+
+Display: PR title, state, base branch, files changed count, CI status.
+
+If the PR is merged or closed, warn the user and ask whether to proceed.
+
+### Step 2: Analyze Diff for Review Routing
+
+Examine the diff to determine which Pass 1 agents to launch:
+
+**Always launch:**
+- `review-memory-safety`
+- `review-security`
+
+**Conditionally launch (check diff content):**
+- `review-concurrency` — if diff contains `std::atomic`, `std::mutex`, `std::thread`, `lock_guard`, `condition_variable`, `memory_order`
+- `review-fault-recovery` — if diff touches `process4_*`, `process5_*`, `process7_*`, `watchdog`, `fault`, `recovery`
+- `test-unit` — if diff touches files in `tests/` or adds new public APIs that should have tests
+- `test-scenario` — if diff touches `common/ipc/`, `common/hal/`, `config/scenarios/`, Gazebo configs
+
+If `--focus` was specified, prioritize that domain's agent and reduce others to a quick scan.
+
+Present the routing plan:
+```
+Review Routing:
+  Pass 1 (safety & correctness):
+    - review-memory-safety (always)
+    - review-security (always)
+    - review-concurrency (triggered: diff contains "std::atomic")
+  Pass 2 (quality & contracts):
+    - review-test-quality (always)
+    - review-api-contract (always)
+    - review-code-quality (always)
+    - review-performance (always)
+  Total: 7 agents across 2 passes
+```
+
+### Step 3: Pass 1 — Safety & Correctness [PARALLEL]
+
+Spawn Pass 1 agents in **parallel** using multiple Agent tool calls in a single message. Each agent receives:
+- The PR diff (or summary of changed files with key code snippets for large diffs)
+- The PR description for context
+- Instructions to report findings with severity (P1/P2/P3) and file:line references
+
+Wait for all Pass 1 agents to complete. Collect findings.
+
+### Step 4: Pass 2 — Quality & Contracts [PARALLEL, after Pass 1]
+
+Skip if `--pass1-only` was specified.
+
+Spawn Pass 2 agents in **parallel**, providing Pass 1 findings as context:
+- `review-test-quality` — validates tests exercise new code paths, assertions are meaningful
+- `review-api-contract` — validates docstrings match implementation, data consistency
+- `review-code-quality` — catches dead code, DRY violations, complexity, naming issues
+- `review-performance` — catches unnecessary copies, allocation in hot paths, O(n²)
+
+Wait for all Pass 2 agents to complete. Collect findings.
+
+### Step 5: Synthesize Findings
+
+Merge findings from both passes. As tech-lead, synthesize:
+
+1. **Deduplicate** — multiple agents may flag the same issue
+2. **Prioritize** — rank by severity (P1 > P2 > P3)
+3. **Cross-reference** — connect related findings (e.g., memory-safety flagged a raw pointer AND performance flagged unnecessary copy at the same location)
+4. **Validate** — check if any P1 findings are false positives based on your understanding of the code
+
+Present structured report:
+
+```
+═══ PR Review: #<N> — <title> ═══
+
+--- Review Summary ---
+Pass 1 (Safety & Correctness): N agents, X P1, Y P2, Z P3
+Pass 2 (Quality & Contracts):  N agents, X P1, Y P2, Z P3
+
+--- P1 Issues (blocks merge) ---
+1. [review-memory-safety] file.h:42 — description
+   Fix: specific suggestion
+
+--- P2 Issues (should fix) ---
+1. [review-concurrency] file.cpp:100 — description
+   Fix: specific suggestion
+
+--- P3 Issues (nice to have) ---
+[...]
+
+--- Tech-Lead Assessment ---
+Recommendation: [approve / request-changes / needs-discussion]
+Reasoning: [assessment]
+
+--- PR Template Checklist Verification ---
+✓ No raw new/delete (memory-safety verified)
+✗ Missing [[nodiscard]] on new Result<> returns (api-contract found)
+✓ const correctness (code-quality verified)
+[...]
+```
+
+### Step 6: Interactive Dialog
+
+User choices:
+- **approve** — post summary as PR comment via `gh pr review --approve`
+- **request-changes** — post findings as PR comment via `gh pr review --request-changes`
+- **comment** — post findings as informational comment (no review decision)
+- **discuss** — enter interactive discussion about specific findings
+- **post** — post the review as a PR comment without a review decision
+- **skip** — don't post anything, just show locally
+
+If posting, format the comment with:
+- Severity-tagged findings with file:line references
+- Collapsible sections for P3 issues (use `<details>` tags)
+- Agent attribution for each finding
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/run-scenario/SKILL.md
+++ b/.claude/skills/run-scenario/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: run-scenario
+description: Run Gazebo SITL scenario integration tests with structured analysis — launch, monitor, parse results, diagnose failures, compare runs
+argument-hint: "<scenario-number|all|--list> [--compare <run1> <run2>] [--gui] [--tier <1|2>]"
+---
+
+# /run-scenario — Scenario Integration Test Runner with Analysis
+
+Run Gazebo SITL scenario tests and provide structured analysis of results. This skill wraps `tests/run_scenario_gazebo.sh` with intelligent monitoring, result parsing, failure diagnosis, and cross-run comparison.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **scenario number** (e.g., `02`, `18`) — runs that specific scenario
+- **`all`** — runs all 25 scenarios
+- **`--list`** — list available scenarios without running
+- **`--tier 1`** or **`--tier 2`** — run only Tier 1 (20 simulated) or Tier 2 (5 Gazebo) scenarios
+- **`--compare <path1> <path2>`** — compare two previous run directories side-by-side
+- **`--gui`** — launch Gazebo with 3D visualizer window
+- **`--verbose`** — extra detail in output
+- **`--dry-run`** — parse scenario config, show plan, don't execute
+
+If no arguments, show the scenario list and ask what to run.
+
+## Steps
+
+### Step 1: List / Validate Scenarios
+
+If `--list` or no arguments:
+```bash
+ls config/scenarios/*.json | sort
+```
+
+Parse each scenario's JSON to extract name, tier, description, and timeout. Present as table:
+
+```
+Available Scenarios (25 total: 20 Tier 1, 5 Tier 2):
+
+| # | Name | Tier | Timeout | Description |
+|---|------|------|---------|-------------|
+| 01 | nominal_mission | 2 | 120s | Basic takeoff → navigate → RTL |
+| 02 | obstacle_avoidance | 2 | 150s | D* Lite through 4-obstacle HD-map field |
+| ... | ... | ... | ... | ... |
+```
+
+If a specific scenario number was given, verify the config file exists:
+```bash
+ls config/scenarios/<number>_*.json
+```
+
+### Step 2: Pre-Flight Checks
+
+Before launching:
+
+1. **Build exists:** Check `build/bin/` contains all 7 process binaries
+2. **PX4 available:** Check `$PX4_DIR` exists (default: `~/PX4-Autopilot`)
+3. **Gazebo available:** Check `gz sim --version` works
+4. **No stale processes:** Check for running drone processes (`pgrep -f "video_capture|perception|slam_vio|mission_planner|comms|payload_manager|system_monitor"`)
+
+If any check fails, report and ask whether to proceed or fix first.
+
+### Step 3: Launch Scenario
+
+Run the scenario using the existing script:
+
+```bash
+./tests/run_scenario_gazebo.sh config/scenarios/<number>_<name>.json [--gui] [--verbose]
+```
+
+If running `--all` or `--tier`:
+```bash
+./tests/run_scenario_gazebo.sh --all [--gui]
+```
+
+**Monitoring during execution:**
+- Show periodic status updates (the script logs to `drone_logs/scenarios_gazebo/`)
+- Report when key milestones are reached (TAKEOFF, NAVIGATE, waypoint advances, RTL, LAND)
+- Alert immediately on EMERGENCY_LAND, OBSTACLE COLLISION, or process crash
+
+### Step 4: Parse Results
+
+After the scenario completes, read the structured outputs:
+
+1. **Run metadata:** `<run_dir>/run_metadata.json` — result, duration, pass/fail counts
+2. **Run report:** `<run_dir>/run_report.txt` — human-readable analysis from `lib_scenario_logging.sh`
+3. **Process logs:** Individual process logs in the run directory
+
+Present a structured summary:
+
+```
+═══ Scenario Result: <name> ═══
+
+Status: PASS (12/12 checks passed)
+Duration: 87s (timeout: 150s)
+Git: abc1234 (feature/issue-381-deploy-issue-skill)
+
+--- Mission Timeline ---
+00:05  PREFLIGHT → TAKEOFF
+00:13  TAKEOFF → SURVEY (+8s)
+00:15  SURVEY → NAVIGATE (+2s)
+00:22  Advanced to waypoint 1/5 (+7s)
+00:38  Advanced to waypoint 2/5 (+16s)
+00:55  Advanced to waypoint 3/5 (+17s)
+01:09  Advanced to waypoint 4/5 (+14s)
+01:18  Advanced to waypoint 5/5 (+9s)
+01:18  NAVIGATE → RTL (+0s)
+01:25  Mission complete
+
+--- Perception ---
+Detections: 847 total, 4 unique tracks
+Radar: 312 returns, 289 after ground filter
+Fusion: UKF active, 4 tracks fused
+
+--- Occupancy Grid ---
+Dynamic peak: 12 cells
+Static peak: 24 cells (HD-map: 16, promoted: 8)
+Promotion events: 3
+
+--- Navigation ---
+Planner: D* Lite, 6 replans
+Avoider: ObstacleAvoider3D, 14 corrections (max 0.8 m/s)
+Min obstacle distance: 3.2m (safe — min_distance: 2.0m)
+
+--- Verification Checks (12/12) ---
+✓ "Path planner: DStarLitePlanner" found
+✓ "Obstacle avoider: ObstacleAvoider3D" found
+✓ "backend: bytetrack" found
+✓ All 7 processes alive at end
+✓ No EMERGENCY_LAND
+✓ No OBSTACLE COLLISION
+✓ Mission complete
+[...]
+```
+
+### Step 5: Failure Diagnosis
+
+If the scenario **FAILED**, perform root cause analysis:
+
+1. **Which checks failed?** List each failed verification check with context
+2. **Last process state:** For each process, show the last 10 log lines before failure
+3. **FSM state at failure:** What state was the mission planner in?
+4. **Perception state:** Were detections being generated? Was fusion active?
+5. **Common failure patterns:**
+   - "Mission did NOT complete" + no crash → stuck in a state (check waypoint progress)
+   - "EMERGENCY_LAND" → fault escalation (check fault events in log)
+   - "OBSTACLE COLLISION" → avoidance failure (check min distance, grid state)
+   - Process not alive → crash (check for SIGSEGV/SIGABRT in log)
+   - Timeout → too slow (check replanning frequency, perception latency)
+
+Present diagnosis:
+```
+--- Failure Diagnosis ---
+Root cause: Mission stuck at waypoint 3/5 for >60s
+Evidence:
+  - Last FSM transition: NAVIGATE at 00:55
+  - No waypoint advance after 00:55
+  - D* Lite replanned 47 times (normal: 5-10) — path oscillation
+  - Occupancy grid had 156 static cells (max_static_cells: 800 not hit, but high density)
+Likely issue: False cell promotion near waypoint 3 blocking all paths
+Suggestion: Check perception logs for ground detections being promoted
+```
+
+### Step 6: Compare Runs (if --compare)
+
+If `--compare` was specified, load both run directories and present side-by-side:
+
+```
+═══ Comparison: <run1> vs <run2> ═══
+
+| Metric | Run 1 | Run 2 | Delta |
+|--------|-------|-------|-------|
+| Result | PASS | FAIL | ▼ |
+| Duration | 87s | 142s (timeout) | +55s |
+| Waypoints | 5/5 | 3/5 | -2 |
+| D* replans | 6 | 47 | +41 |
+| Static cells peak | 24 | 156 | +132 |
+| Min obstacle dist | 3.2m | 1.1m | -2.1m |
+| Detections | 847 | 1203 | +356 |
+| Promotions | 3 | 28 | +25 |
+
+Key differences:
+1. Run 2 has 6.5x more cell promotions — likely false promotion bug
+2. Run 2 has 8x more D* replans — path oscillation from dense grid
+3. Run 2 min distance 1.1m < 2.0m threshold — near-collision
+```
+
+### Step 7: Summary and Next Steps
+
+After all scenarios complete (especially for `--all`):
+
+```
+═══ Scenario Summary ═══
+
+| # | Scenario | Result | Duration | Notes |
+|---|----------|--------|----------|-------|
+| 01 | nominal_mission | PASS | 78s | |
+| 02 | obstacle_avoidance | PASS | 87s | |
+| 03 | battery_degradation | PASS | 45s | |
+| ... | ... | ... | ... | ... |
+| 18 | perception_avoidance | FAIL | 142s | Stuck at WP3 |
+
+Total: 24/25 PASS, 1 FAIL
+Failed: #18 perception_avoidance (false cell promotion)
+```
+
+Suggest next steps:
+- If all pass: "All scenarios green. Ready for `/production-readiness` audit."
+- If failures: "Suggest filing issues for failures: `/create-issue bug: <failure description>`"
+- If comparing: "Regression detected in scenario #18 between commits X and Y"
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/.claude/skills/run-scenario/SKILL.md
+++ b/.claude/skills/run-scenario/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "<scenario-number|all|--list> [--compare <run1> <run2>] [--gui] [
 
 # /run-scenario — Scenario Integration Test Runner with Analysis
 
-Run Gazebo SITL scenario tests and provide structured analysis of results. This skill wraps `tests/run_scenario_gazebo.sh` with intelligent monitoring, result parsing, failure diagnosis, and cross-run comparison.
+Run scenario integration tests and provide structured analysis of results. This skill wraps `tests/run_scenario.sh` (Tier 1 simulated + Tier 2 Gazebo) and `tests/run_scenario_gazebo.sh` (Tier 2 Gazebo-only) with intelligent monitoring, result parsing, failure diagnosis, and cross-run comparison.
 
 ## Arguments
 
@@ -61,15 +61,29 @@ If any check fails, report and ask whether to proceed or fix first.
 
 ### Step 3: Launch Scenario
 
-Run the scenario using the existing script:
+Choose the correct script based on tier:
 
+**Single scenario (any tier):**
 ```bash
+# Tier 1 (simulated, no Gazebo needed):
+./tests/run_scenario.sh config/scenarios/<number>_<name>.json [--verbose]
+
+# Tier 2 (Gazebo SITL required):
 ./tests/run_scenario_gazebo.sh config/scenarios/<number>_<name>.json [--gui] [--verbose]
 ```
 
-If running `--all` or `--tier`:
+Check the scenario JSON's `scenario.tier` field to determine which script to use. Tier 1 scenarios have `"requires_gazebo": false`, Tier 2 have `"requires_gazebo": true`.
+
+**Running multiple scenarios (`--all` or `--tier`):**
 ```bash
+# All Tier 1 scenarios (no Gazebo):
+./tests/run_scenario.sh --all --tier 1
+
+# All Tier 2 scenarios (Gazebo):
 ./tests/run_scenario_gazebo.sh --all [--gui]
+
+# All tiers:
+./tests/run_scenario.sh --all --tier 1 && ./tests/run_scenario_gazebo.sh --all [--gui]
 ```
 
 **Monitoring during execution:**

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: update-docs
+description: Auto-generate documentation updates for all tracking files after a PR — PROGRESS.md, ROADMAP.md, BUG_FIXES.md, TESTS.md, API.md, CI_ISSUES.md, design docs, README.md
+argument-hint: "[--pr <number>] [--issue <number>] [--dry-run]"
+---
+
+# /update-docs — Auto-Generate Documentation Updates
+
+The #1 manual burden in the development workflow: every merge requires updating up to 8+ documentation files. This skill auto-generates all entries from the current branch's changes, PR metadata, and test output.
+
+**Pain point context:** PROGRESS.md and ROADMAP.md are the #1 source of merge conflicts because every branch touches them. This skill minimizes the time spent on documentation and reduces conflict risk by generating correct entries quickly.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **--pr \<number\>** (optional): PR number to pull metadata from. If omitted, detect from current branch.
+- **--issue \<number\>** (optional): Issue number. If omitted, extract from branch name (`feature/issue-XX-*`) or PR body (`Closes #XX`).
+- **--dry-run** (optional): Show proposed changes without applying them.
+
+## Steps
+
+### Step 1: Gather Context [PARALLEL]
+
+Run these in parallel:
+```bash
+git branch --show-current
+git diff --stat main...HEAD
+git log --oneline main...HEAD
+```
+
+If `--pr` was provided:
+```bash
+gh pr view <number> --json title,body,labels,baseRefName,additions,deletions,files
+```
+
+If `--issue` was provided:
+```bash
+gh issue view <number> --json title,body,labels
+```
+
+Also gather:
+```bash
+ctest -N --test-dir build 2>/dev/null | grep "Total Tests:"
+```
+
+### Step 2: Determine Which Docs Need Updates
+
+Check each file against the changes:
+
+| File | Condition | Source |
+|------|-----------|--------|
+| `docs/tracking/PROGRESS.md` | Always (every PR adds an improvement) | PR title + body + diff stat |
+| `docs/tracking/ROADMAP.md` | If issue is being closed | Issue number → strikethrough + checkmark |
+| `docs/tracking/BUG_FIXES.md` | If `bug` label or branch starts with `fix/` | Issue body + diff for root cause |
+| `tests/TESTS.md` | If files in `tests/` were added/modified | ctest output + new test file analysis |
+| `docs/design/API.md` | If interfaces in `common/hal/include/` or `common/ipc/` changed | Diff of header files |
+| `docs/tracking/CI_ISSUES.md` | If `.github/workflows/` or `deploy/` CI scripts changed | Diff of CI files |
+| `docs/design/<process>_design.md` | If major architectural changes to a process | Detect from diff scope |
+| `README.md` | If new capabilities, metrics, or architecture changes | Detect from significance |
+
+### Step 3: Generate PROGRESS.md Entry
+
+Read the current `docs/tracking/PROGRESS.md` to determine:
+- Current Phase number and section
+- Next Improvement number (scan for highest `### Improvement #N`)
+- Entry format (follow existing pattern exactly)
+
+Generate entry:
+```markdown
+### Improvement #<N+1> — <PR title>
+
+**Date:** <today's date YYYY-MM-DD>
+**Category:** <detect from labels: Feature/Architecture/Testing/Infrastructure/Bug Fix/Performance>
+**Files Added:**
+<list new files from git diff --stat>
+
+**Files Modified:**
+<list modified files from git diff --stat>
+
+**What:** <2-3 sentence summary from PR body or commit messages>
+
+**Why:** <motivation from issue body if available>
+
+**Test additions:** <list new test files or "No new tests" if none>
+
+---
+```
+
+### Step 4: Generate ROADMAP.md Update
+
+If an issue is being closed, find it in `docs/tracking/ROADMAP.md` and:
+1. Add strikethrough to the issue line: `~~#XX — description~~`
+2. Add checkmark: `✅`
+3. Update the "Current State at a Glance" metrics table if any metrics changed:
+   - Test count (from ctest output)
+   - HAL backends count (if new HAL added)
+   - Line coverage (if coverage build was run)
+   - Any other metrics that changed
+
+Read the current file first to find the exact line to modify.
+
+### Step 5: Generate BUG_FIXES.md Entry
+
+Only if this is a bug fix (branch starts with `fix/` or issue has `bug` label).
+
+Read `docs/tracking/BUG_FIXES.md` to determine:
+- Next Fix number (scan for highest `### Fix #N`)
+- Correct section (IPC, Perception, Mission Planner, etc. — determine from files changed)
+
+Generate entry following the exact format:
+```markdown
+### Fix #<N+1> — <title> (#<issue-number>)
+
+**Date:** <today's date>
+**Severity:** <High/Medium/Low — from issue labels or estimate>
+**File:** <primary files changed>
+
+**Bug:** <description from issue body>
+
+**Root Cause:** <extract from PR body or commit messages — the WHY>
+
+**Fix:** <what was changed — from commit messages>
+
+**Found by:** <from issue: "Code review", "Scenario test", "CI", "User report", "AI review">
+
+**Regression test:** <name of test added, or "N/A">
+
+---
+```
+
+### Step 6: Generate TESTS.md Update
+
+If test files were added or modified:
+
+1. Run `ctest -N --test-dir build 2>/dev/null | grep "Total Tests:"` to get current count
+2. Read `tests/TESTS.md` and find the Summary table
+3. Update the `**Total**` row with new counts
+4. If new test files were added, add entries to the appropriate section following the existing format:
+   - Find the right category section
+   - Add a new subsection with test file name, test count, and description
+   - Grep the test file for `TEST(` and `TEST_F(` to count and list tests
+
+### Step 7: Generate API.md Update
+
+Only if interfaces changed (files in `common/hal/include/hal/` or `common/ipc/include/ipc/`).
+
+Read `docs/design/API.md` and update the relevant tables:
+- New IPC message types → add to message type table
+- New HAL interfaces → add to interface table
+- Modified struct fields → update field lists
+
+### Step 8: Generate CI_ISSUES.md Entry
+
+Only if CI-related files changed (`.github/workflows/`, `deploy/build.sh`, `deploy/run_ci_local.sh`).
+
+Add entry to `docs/tracking/CI_ISSUES.md` following existing format.
+
+### Step 9: Detect Design Doc Updates
+
+Analyze the diff to determine if any **architectural changes** require design document updates. A change is architectural if it:
+- Adds a new class, interface, or module
+- Changes the data flow between processes (IPC topics, message types)
+- Modifies thread structure or synchronization patterns
+- Adds or changes a HAL backend
+- Changes the config schema significantly (new section, new pattern)
+- Modifies the pipeline (detection → tracking → fusion → planning)
+
+Map changed files to design docs:
+
+| Files touched | Design doc |
+|--------------|------------|
+| `process1_video_capture/` | `docs/design/video_capture_design.md` |
+| `process2_perception/` | `docs/design/perception_design.md` |
+| `process3_slam_vio_nav/` | `docs/design/slam_vio_nav_design.md` |
+| `process4_mission_planner/` | `docs/design/mission_planner_design.md` |
+| `process5_comms/` | `docs/design/comms_design.md` |
+| `process6_payload_manager/` | `docs/design/payload_manager_design.md` |
+| `process7_system_monitor/` | `docs/design/system_monitor_design.md` |
+| `common/hal/` | `docs/design/hal_design.md` |
+| `common/ipc/` | `docs/design/ipc_design.md` |
+| `common/util/` (Result, error handling) | `docs/design/error_handling_design.md` |
+| Watchdog, systemd, process management | `docs/design/hardening-design.md` |
+
+For each matched design doc:
+1. Read the current doc
+2. Identify which sections are affected by the changes
+3. Generate a proposed update that adds or modifies the relevant sections
+4. If the change is minor (e.g., bug fix within existing architecture), note it but don't propose changes
+
+Present as: "Design doc `<name>` may need updates — [specific sections affected]"
+
+### Step 10: Detect README.md Updates
+
+Check if the changes warrant a `README.md` update. Update is needed if:
+
+- **New capability** — a major new feature visible to users (new process, new HAL backend, new tool)
+- **Metrics changed** — test count, HAL backend count, scenario count, coverage, etc.
+- **Architecture changed** — new process, new IPC channel, changed dependencies
+- **New documentation** — new guide or design doc that should be in the Documentation Index
+- **Quick start changed** — build commands, dependencies, or setup steps changed
+
+If needed, propose specific edits to `README.md`:
+- Update the metrics in any summary tables
+- Add new entries to the Documentation Index table
+- Update architecture diagrams (process map, IPC channels) if changed
+- Update the Quick Start section if setup steps changed
+
+### Step 11: Present All Proposed Changes
+
+Show a summary of all generated entries:
+
+```
+═══ Documentation Updates ═══
+
+--- Tracking Files ---
+✓ PROGRESS.md: Improvement #<N> entry (always)
+✓ ROADMAP.md: Issue #<X> marked complete + metrics updated
+✗ BUG_FIXES.md: Not applicable (not a bug fix)
+✓ TESTS.md: Total updated 1259 → 1272, 1 new suite added
+
+--- Design Files ---
+✓ API.md: New IPC message type added
+⚠ perception_design.md: May need update (new detector backend added)
+✗ Other design docs: No changes needed
+
+--- Top-Level ---
+✓ README.md: Test count metric, new design doc in index
+
+Files to update: 5 of 8+
+```
+
+If `--dry-run`, stop here and show the proposals.
+
+### Step 12: Apply Changes
+
+Ask the user: **apply all / select which / cancel**
+
+If applying:
+- Use Edit tool to insert each entry at the correct location in each file
+- Verify edits are clean (no formatting issues)
+- Show `git diff --stat` after all edits
+
+**Important formatting rules:**
+- Match the exact indentation and style of existing entries (read surrounding entries first)
+- Use the same date format as existing entries (YYYY-MM-DD)
+- Preserve section ordering in ROADMAP.md (don't move items between sections)
+- In TESTS.md Summary table, ensure column alignment is preserved
+- In README.md, match the existing table formatting and style
+
+If the user provided arguments, use them as context: $ARGUMENTS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,7 +363,7 @@ Scenario integration tests: `tests/run_scenario.sh` (8 JSON configs in `config/s
 
 ## Multi-Agent Pipeline (ADR-010)
 
-This project uses a **13-agent pipeline** orchestrated via Claude Agent SDK. See `docs/adr/ADR-010-multi-agent-pipeline-architecture.md` for the full architecture decision record.
+This project uses a **17-agent pipeline** orchestrated via Claude Agent SDK with a **two-pass review architecture**. See `docs/adr/ADR-010-multi-agent-pipeline-architecture.md` for the full architecture decision record.
 
 ### Agent Roster
 
@@ -375,13 +375,17 @@ This project uses a **13-agent pipeline** orchestrated via Claude Agent SDK. See
 | 4 | `feature-integration` | Opus | P5/P6/P7, IPC, HAL backends |
 | 5 | `feature-infra-core` | Opus | common/, CMake, config |
 | 6 | `feature-infra-platform` | Opus | deploy/, CI, boards/, certification |
-| 7 | `review-memory-safety` | Opus | RAII, ownership, lifetimes (read-only) |
-| 8 | `review-concurrency` | Opus | Races, atomics, deadlocks (read-only) |
-| 9 | `review-fault-recovery` | Opus | Watchdog, degradation (read-only) |
-| 10 | `review-security` | Opus | Input validation, auth, TLS (read-only) |
-| 11 | `test-unit` | Sonnet | GTest, coverage delta (tests/ only) |
-| 12 | `test-scenario` | Sonnet | Gazebo SITL, integration (tests/ only) |
-| 13 | `ops-github` | Haiku | Issue triage, milestones, board (gh CLI) |
+| 7 | `review-memory-safety` | Opus | RAII, ownership, lifetimes (Pass 1, read-only) |
+| 8 | `review-concurrency` | Opus | Races, atomics, deadlocks (Pass 1, read-only) |
+| 9 | `review-fault-recovery` | Opus | Watchdog, degradation (Pass 1, read-only) |
+| 10 | `review-security` | Opus | Input validation, auth, TLS (Pass 1, read-only) |
+| 11 | `test-unit` | Sonnet | GTest, coverage delta (Pass 1, tests/ only) |
+| 12 | `test-scenario` | Sonnet | Gazebo SITL, integration (Pass 1, tests/ only) |
+| 13 | `review-test-quality` | Opus | Tests exercise new paths, assertions meaningful (Pass 2, read-only) |
+| 14 | `review-api-contract` | Sonnet | Docstrings match impl, data consistency (Pass 2, read-only) |
+| 15 | `review-code-quality` | Sonnet | Dead code, DRY, complexity, naming (Pass 2, read-only) |
+| 16 | `review-performance` | Sonnet | Copies, allocation, hot paths, O(n^2) (Pass 2, read-only) |
+| 17 | `ops-github` | Haiku | Issue triage, milestones, board (gh CLI) |
 
 ### Quick Commands
 
@@ -421,9 +425,9 @@ python3 -m orchestrator dashboard                     # team-wide (default)
 python3 -m orchestrator dashboard feature-perception  # per-agent
 ```
 
-### Review Routing
+### Review Routing (Two-Pass)
 
-Not all reviewers run on every PR — routing is by diff content:
+**Pass 1 — Safety & Correctness** (parallel, diff-routed):
 
 | Change touches... | Agents triggered |
 |-------------------|-----------------|
@@ -431,6 +435,11 @@ Not all reviewers run on every PR — routing is by diff content:
 | `std::atomic`, `mutex`, `thread` | + Concurrency |
 | P4/P5/P7, watchdog, fault handling | + Fault Recovery |
 | IPC, HAL, Gazebo configs | + Scenario Test |
+
+**Pass 2 — Quality & Contracts** (parallel after Pass 1, always-on):
+
+All 4 agents run on every PR and receive Pass 1 findings as context:
+Test Quality, API Contract, Code Quality, Performance
 
 ### Shared State
 

--- a/docs/adr/ADR-010-multi-agent-pipeline-architecture.md
+++ b/docs/adr/ADR-010-multi-agent-pipeline-architecture.md
@@ -1,18 +1,18 @@
 # ADR-010: Multi-Agent Pipeline Architecture
 
 **Status:** Accepted
-**Date:** 2026-04-06 (updated 2026-04-07)
-**Issue:** #357, #360
+**Date:** 2026-04-06 (updated 2026-04-09)
+**Issue:** #357, #360, #381, #392
 
 ## Context
 
 The project uses 15+ git worktrees for concurrent AI agent work (ADR-005), but has no formal agent role definitions, coordination layer, boundary enforcement, or session management. As the team scales, **Amdahl's Law** tells us the bottleneck isn't code production — it's verification. In safety-critical drone software, you can't relax quality gates to increase throughput.
 
-**The Amdahl's Law insight:** If S is the serial fraction of the pipeline, maximum speedup with N agents is `1 / (S + (1-S)/N)`. By parallelizing verification (4 review agents + 2 test agents running simultaneously) and keeping the serial fraction to just the human's checkpoint decisions, we minimize S and maximize throughput without sacrificing quality.
+**The Amdahl's Law insight:** If S is the serial fraction of the pipeline, maximum speedup with N agents is `1 / (S + (1-S)/N)`. By parallelizing verification (Pass 1: 4 review + 2 test agents, Pass 2: 4 quality agents — up to 10 agents running in parallel phases) and keeping the serial fraction to just the human's checkpoint decisions, we minimize S and maximize throughput without sacrificing quality.
 
 ## Decision
 
-Implement a **13-agent pipeline** with formal role definitions, orchestration scripts, CI integration, shared state coordination, and a guided pipeline mode with human checkpoints.
+Implement a **17-agent pipeline** with formal role definitions, orchestration scripts, CI integration, shared state coordination, a guided pipeline mode with human checkpoints, and a **two-pass review architecture** where quality/contract agents receive safety agent findings as context.
 
 ### Agent Roster
 
@@ -27,22 +27,48 @@ Implement a **13-agent pipeline** with formal role definitions, orchestration sc
 | 5 | `feature-infra-core` | Opus | common/, CMake, config (Epic #284 + #300 A-B) |
 | 6 | `feature-infra-platform` | Opus | deploy/, CI, boards/ (Epic #300 C-E) |
 
-#### Verification Agents (review + test in parallel)
+#### Pass 1 — Safety & Correctness Agents (parallel, read-only)
 
-| # | Role | Model | Access | Focus |
-|---|------|-------|--------|-------|
-| 7 | `review-memory-safety` | Opus | Read-only | RAII, ownership, lifetimes |
-| 8 | `review-concurrency` | Opus | Read-only | Races, atomics, deadlocks |
-| 9 | `review-fault-recovery` | Opus | Read-only | Watchdog, degradation, restart |
-| 10 | `review-security` | Opus | Read-only | Input validation, auth, TLS |
-| 11 | `test-unit` | Sonnet | tests/ only | Build, run tests, verify count vs baseline |
-| 12 | `test-scenario` | Sonnet | tests/ only | Gazebo SITL scenario integration |
+| # | Role | Model | Trigger | Focus |
+|---|------|-------|---------|-------|
+| 7 | `review-memory-safety` | Opus | Always | RAII, ownership, lifetimes |
+| 8 | `review-concurrency` | Opus | If atomics/mutex/thread in diff | Races, atomics, deadlocks |
+| 9 | `review-fault-recovery` | Opus | If P4/P5/P7/watchdog in diff | Watchdog, degradation, restart |
+| 10 | `review-security` | Opus | Always | Input validation, auth, TLS |
+| 11 | `test-unit` | Sonnet | Always | Build, run tests, verify count vs baseline |
+| 12 | `test-scenario` | Sonnet | If IPC/HAL/Gazebo in diff | Gazebo SITL scenario integration |
+
+#### Pass 2 — Quality & Contracts Agents (parallel after Pass 1, read-only)
+
+These agents run **after** Pass 1 completes and receive Pass 1 findings as context. This allows them to verify that flagged code paths have adequate test coverage, accurate documentation, and acceptable quality.
+
+| # | Role | Model | Focus |
+|---|------|-------|-------|
+| 13 | `review-test-quality` | Opus | Tests exercise new code paths, assertions meaningful, boundary conditions |
+| 14 | `review-api-contract` | Sonnet | Docstrings match implementation, data consistency, naming accuracy |
+| 15 | `review-code-quality` | Sonnet | Dead code, DRY violations, complexity, naming, unnecessary abstractions |
+| 16 | `review-performance` | Sonnet | Unnecessary copies, allocation in hot paths, algorithmic complexity, cache efficiency |
 
 #### Operations Agent
 
 | # | Role | Model | Access | Focus |
 |---|------|-------|--------|-------|
-| 13 | `ops-github` | Haiku | gh CLI only | Auto-triage unlabeled issues, milestones, stale cleanup |
+| 17 | `ops-github` | Haiku | gh CLI only | Auto-triage unlabeled issues, milestones, stale cleanup |
+
+### Claude Code Skills Integration (Issue #381)
+
+In addition to the shell-based orchestrator, the pipeline is also available as **Claude Code skills** that run inline in the current session. This provides a more interactive experience where Claude acts as tech-lead directly in the conversation.
+
+| Skill | Purpose |
+|-------|---------|
+| `/deploy-issue <N>` | Full pipeline inline — routing, agent work, review, PR creation |
+| `/commit` | Smart commit with format check, test count verification |
+
+Skills use the `Agent` tool with `subagent_type` and `isolation: "worktree"` to spawn agents — replacing `claude` subprocess calls. The two-pass review architecture is the same; the difference is that results are presented interactively in the conversation rather than written to log files.
+
+**Skills vs Orchestrator:**
+- Skills: interactive, inline, Claude is tech-lead — for developer use in IDE/CLI
+- Orchestrator: `--auto`, `--headless`, `--pipeline` — for CI/unattended/tmux use
 
 ### Launch Modes
 
@@ -98,7 +124,7 @@ git push + PR created
   ↓
 [CP3] Human previews PR
   ↓
-deploy-review.sh launches in parallel:
+Pass 1 — Safety & Correctness (parallel):
   ├─ review-memory-safety  (always)
   ├─ review-security       (always)
   ├─ review-concurrency    (if atomics/mutexes/threads in diff)
@@ -106,7 +132,13 @@ deploy-review.sh launches in parallel:
   ├─ test-unit             (always — build, run tests, verify count)
   └─ test-scenario         (if IPC/HAL/Gazebo configs in diff)
   ↓
-Consolidated review + test results posted as PR comment
+Pass 2 — Quality & Contracts (parallel, receives Pass 1 findings):
+  ├─ review-test-quality   (always — tests exercise new paths?)
+  ├─ review-api-contract   (always — docstrings match impl?)
+  ├─ review-code-quality   (always — dead code, DRY, complexity?)
+  └─ review-performance    (always — copies, allocation, O(n²)?)
+  ↓
+Consolidated review + test results from both passes posted as PR comment
   ↓
 [CP4] Human reviews findings
   ↓ (if fix needed: feature agent fixes → re-runs all agents → back to CP4)
@@ -144,9 +176,11 @@ Every agent (auto + pipeline) is instructed to update before completing:
 - `docs/tracking/ROADMAP.md` — mark issue done
 - `docs/tracking/BUG_FIXES.md` — bug fix entry
 
-### Review Routing
+### Review Routing (Two-Pass Architecture)
 
-Not all reviewers on every PR — routing is based on diff content:
+Reviews use a two-pass architecture. Pass 1 agents are diff-routed; Pass 2 agents always run and receive Pass 1 findings as context.
+
+**Pass 1 — Safety & Correctness** (parallel, diff-routed):
 
 | Change touches... | Agents triggered |
 |-------------------|-----------------|
@@ -154,6 +188,15 @@ Not all reviewers on every PR — routing is based on diff content:
 | `std::atomic`, `mutex`, `thread`, `lock_guard` | + concurrency |
 | P4/P5/P7, watchdog, fault handling | + fault-recovery |
 | IPC topics, HAL backends, Gazebo configs | + test-scenario |
+
+**Pass 2 — Quality & Contracts** (parallel, always-on, after Pass 1):
+
+| Agent | Focus | Uses Pass 1 findings to... |
+|-------|-------|---------------------------|
+| review-test-quality | Tests exercise new code paths? | Verify flagged code has test coverage |
+| review-api-contract | Docstrings match implementation? | Check safety-flagged APIs have accurate docs |
+| review-code-quality | Dead code, DRY, complexity? | Check if flagged patterns repeat elsewhere |
+| review-performance | Copies, allocation, O(n^2)? | Check if safety fixes introduced perf regressions |
 
 ### Ops-GitHub Integration
 
@@ -194,11 +237,11 @@ Two infra agents are needed because Epic #284 (Modularity, 13 issues) requires c
 
 ### Negative
 
-- **13 agent definitions** to maintain — role files may drift from actual capabilities
+- **17 agent definitions** to maintain — role files may drift from actual capabilities
 - **Orchestration complexity** — 12+ scripts add operational surface area
 - **Boundary enforcement is advisory** — agents can work outside their scope when necessary (by design)
 - **Shared context files can go stale** — `project-status.md` requires human updates each session
-- **Token costs** — full pipeline (1 feature + 2-6 review/test agents) costs ~$3-10 per issue
+- **Token costs** — full pipeline (1 feature + 3-6 Pass 1 + 4 Pass 2 agents) costs ~$5-15 per issue
 
 ### Risks
 
@@ -222,7 +265,7 @@ Two infra agents are needed because Epic #284 (Modularity, 13 issues) requires c
 ## References
 
 - ADR-005: Parallel Agent Git Worktree Strategy
-- `.claude/agents/` — All 13 role definitions
+- `.claude/agents/` — All 17 role definitions
 - `.claude/shared-context/` — Project status and domain knowledge
 - `scripts/` — Orchestration scripts
 - `docs/guides/MULTI_AGENT_GUIDE.md` — Full usage guide with setup, walkthrough, and examples

--- a/docs/guides/MULTI_AGENT_GUIDE.md
+++ b/docs/guides/MULTI_AGENT_GUIDE.md
@@ -1,10 +1,10 @@
 # Multi-Agent Pipeline Guide
 
-This guide explains how the 13-agent pipeline works, how to use it, and how agents coordinate with each other and GitHub.
+This guide explains how the 17-agent pipeline works, how to use it, and how agents coordinate with each other and GitHub.
 
 ## How It Works
 
-The pipeline applies **Amdahl's Law** to software verification: feature agents produce code in parallel, but more importantly, 4 review agents + 2 test agents verify every PR in parallel. The only serial step is the tech lead's merge decision — minimizing the serial fraction that limits speedup.
+The pipeline applies **Amdahl's Law** to software verification: feature agents produce code in parallel, but more importantly, up to 10 verification agents verify every PR in **two parallel passes** — Pass 1 for safety & correctness (3-6 agents), Pass 2 for quality & contracts (4 agents). The only serial step is the tech lead's merge decision — minimizing the serial fraction that limits speedup.
 
 ```
                           ┌──────────────────────────────────────────────────────┐
@@ -32,12 +32,14 @@ The pipeline applies **Amdahl's Law** to software verification: feature agents p
               │  └──────────────────────┬──────────────────────────────┘  │
               │                         │ PR created                      │
               │  ┌──────────────────────▼──────────────────────────────┐  │
-              │  │           REVIEW AGENTS (verify in parallel)        │  │
-              │  │  memory-safety │ concurrency │ fault │ security     │  │
+              │  │     PASS 1: SAFETY & CORRECTNESS (parallel)        │  │
+              │  │  memory-safety │ concurrency │ fault │ security    │  │
+              │  │  unit-test     │ scenario-test                     │  │
               │  └──────────────────────┬──────────────────────────────┘  │
               │  ┌──────────────────────▼──────────────────────────────┐  │
-              │  │            TEST AGENTS (verify in parallel)         │  │
-              │  │            unit-test  │  scenario-test              │  │
+              │  │     PASS 2: QUALITY & CONTRACTS (parallel)         │  │
+              │  │  test-quality │ api-contract │ code-quality │ perf │  │
+              │  │  (receives Pass 1 findings as context)             │  │
               │  └──────────────────────┬──────────────────────────────┘  │
               │                         │                                 │
               └─────────────────────────┼─────────────────────────────────┘
@@ -72,20 +74,30 @@ flowchart TD
     FIC -->|creates PR| PR
     FIP -->|creates PR| PR
 
-    PR -->|orchestrator deploy-review| Review{Route by diff content}
-    Review -->|always| RMS2[review-memory-safety]
-    Review -->|always| RS2[review-security]
-    Review -->|always| TU2[test-unit]
-    Review -->|atomics/mutex| RC[review-concurrency]
-    Review -->|watchdog/P4/P5/P7| RF[review-fault-recovery]
-    Review -->|IPC/HAL/Gazebo| TS[test-scenario]
+    PR -->|orchestrator deploy-review| Pass1{Pass 1: Safety & Correctness}
+    Pass1 -->|always| RMS2[review-memory-safety]
+    Pass1 -->|always| RS2[review-security]
+    Pass1 -->|always| TU2[test-unit]
+    Pass1 -->|atomics/mutex| RC[review-concurrency]
+    Pass1 -->|watchdog/P4/P5/P7| RF[review-fault-recovery]
+    Pass1 -->|IPC/HAL/Gazebo| TS[test-scenario]
 
-    RMS2 -->|comments| PR
-    RS2 -->|comments| PR
-    TU2 -->|comments| PR
-    RC -->|comments| PR
-    RF -->|comments| PR
-    TS -->|comments| PR
+    RMS2 -->|findings| Pass2{Pass 2: Quality & Contracts}
+    RS2 -->|findings| Pass2
+    TU2 -->|findings| Pass2
+    RC -->|findings| Pass2
+    RF -->|findings| Pass2
+    TS -->|findings| Pass2
+
+    Pass2 -->|always| RTQ[review-test-quality]
+    Pass2 -->|always| RAC[review-api-contract]
+    Pass2 -->|always| RCQ[review-code-quality]
+    Pass2 -->|always| RP[review-performance]
+
+    RTQ -->|comments| PR
+    RAC -->|comments| PR
+    RCQ -->|comments| PR
+    RP -->|comments| PR
 
     PR -->|all reviews pass| TL2[tech-lead]
     TL2 -->|orchestrator validate| Merge[Merge to main]
@@ -109,23 +121,46 @@ flowchart TD
     IB -->|"all sub-issues merged + CI green"| Main
 ```
 
-## The 13-Agent Roster
+## The 17-Agent Roster
 
-| # | Role | Model | Type | Scope |
-|---|------|-------|------|-------|
-| 1 | `tech-lead` | Opus | Orchestrator | Routing, merge decisions, coordination |
-| 2 | `feature-perception` | Opus | Feature | P1/P2, camera/detector HAL |
-| 3 | `feature-nav` | Opus | Feature | P3/P4, planner/avoider HAL |
-| 4 | `feature-integration` | Opus | Feature | P5/P6/P7, IPC, HAL backends |
-| 5 | `feature-infra-core` | Opus | Feature | common/, CMake, config |
-| 6 | `feature-infra-platform` | Opus | Feature | deploy/, CI, boards/, certification |
-| 7 | `review-memory-safety` | Opus | Review (read-only) | RAII, ownership, lifetimes |
-| 8 | `review-concurrency` | Opus | Review (read-only) | Races, atomics, deadlocks |
-| 9 | `review-fault-recovery` | Opus | Review (read-only) | Watchdog, degradation |
-| 10 | `review-security` | Opus | Review (read-only) | Input validation, auth, TLS |
-| 11 | `test-unit` | Sonnet | Test | GTest, coverage delta (tests/ only) |
-| 12 | `test-scenario` | Sonnet | Test | Gazebo SITL, integration (tests/ only) |
-| 13 | `ops-github` | Haiku | Operations | Issue triage, milestones, board |
+### Production Agents (write code)
+
+| # | Role | Model | Scope |
+|---|------|-------|-------|
+| 1 | `tech-lead` | Opus | Routing, merge decisions, coordination |
+| 2 | `feature-perception` | Opus | P1/P2, camera/detector HAL |
+| 3 | `feature-nav` | Opus | P3/P4, planner/avoider HAL |
+| 4 | `feature-integration` | Opus | P5/P6/P7, IPC, HAL backends |
+| 5 | `feature-infra-core` | Opus | common/, CMake, config |
+| 6 | `feature-infra-platform` | Opus | deploy/, CI, boards/, certification |
+
+### Pass 1 — Safety & Correctness (read-only, parallel)
+
+| # | Role | Model | Trigger | Focus |
+|---|------|-------|---------|-------|
+| 7 | `review-memory-safety` | Opus | Always | RAII, ownership, lifetimes |
+| 8 | `review-concurrency` | Opus | If atomics/mutex/thread in diff | Races, atomics, deadlocks |
+| 9 | `review-fault-recovery` | Opus | If P4/P5/P7/watchdog in diff | Watchdog, degradation |
+| 10 | `review-security` | Opus | Always | Input validation, auth, TLS |
+| 11 | `test-unit` | Sonnet | Always | GTest, coverage delta (tests/ only) |
+| 12 | `test-scenario` | Sonnet | If IPC/HAL/Gazebo in diff | Gazebo SITL, integration (tests/ only) |
+
+### Pass 2 — Quality & Contracts (read-only, parallel after Pass 1)
+
+These agents always run and receive Pass 1 findings as context, allowing them to verify that flagged code has adequate test coverage, accurate documentation, and acceptable quality.
+
+| # | Role | Model | Focus |
+|---|------|-------|-------|
+| 13 | `review-test-quality` | Opus | Tests exercise new code paths, assertions meaningful, boundary conditions |
+| 14 | `review-api-contract` | Sonnet | Docstrings match implementation, data consistency, naming accuracy |
+| 15 | `review-code-quality` | Sonnet | Dead code, DRY violations, complexity, naming, unnecessary abstractions |
+| 16 | `review-performance` | Sonnet | Unnecessary copies, allocation in hot paths, algorithmic complexity |
+
+### Operations Agent
+
+| # | Role | Model | Focus |
+|---|------|-------|-------|
+| 17 | `ops-github` | Haiku | Issue triage, milestones, board |
 
 ### Agent Boundaries
 
@@ -161,7 +196,7 @@ gh auth login
 export PYTHONPATH=scripts     # Add to .bashrc / .zshrc to make permanent
 
 # 5. Verify agent definitions exist
-ls .claude/agents/    # Should show 13 .md files
+ls .claude/agents/    # Should show 17 .md files
 
 # 6. Verify shared context exists
 ls .claude/shared-context/   # Should show domain-knowledge.md, project-status.md
@@ -171,7 +206,7 @@ bash deploy/build.sh
 
 # 8. Test the setup with a dry run
 python -m orchestrator deploy-issue 123 --dry-run    # Shows routing without launching
-python -m orchestrator list                          # Shows all 13 agent roles
+python -m orchestrator list                          # Shows all 17 agent roles
 ```
 
 ### What's Included in the Repo
@@ -202,7 +237,8 @@ Each agent invocation consumes API tokens charged to **your** Claude account. Ro
 - Feature agent (Opus): ~$1-5 per issue depending on complexity
 - Review agent (Opus): ~$0.50-2 per PR review
 - Test agent (Sonnet): ~$0.25-1 per test run
-- Pipeline mode: runs 1 feature + 2-6 review/test agents = ~$3-10 per issue
+- Pass 2 review agent (Sonnet): ~$0.25-1 per review
+- Pipeline mode: runs 1 feature + 3-6 Pass 1 + 4 Pass 2 agents = ~$5-15 per issue
 
 Use `--dry-run` on any script to preview what would be launched without spending tokens.
 
@@ -265,7 +301,7 @@ python -m orchestrator deploy-review 456 --dry-run
 python -m orchestrator deploy-review 456 --all
 ```
 
-Review agents launch in parallel and post a consolidated comment on the PR when done. Monitor progress in a separate terminal:
+Review agents launch in two passes and post a consolidated comment on the PR when done. Monitor progress in a separate terminal:
 
 ```bash
 # Watch log sizes grow (see which agents are still working)
@@ -321,7 +357,7 @@ gh pr create --base integration/epic-357
 python -m orchestrator deploy-review <pr-number>
 ```
 
-This launches review agents in parallel (memory-safety, security, + conditional concurrency/fault-recovery based on diff content). Monitor them:
+This launches review agents in two passes — Pass 1 (safety: memory-safety, security, + conditional concurrency/fault-recovery) then Pass 2 (quality: test-quality, api-contract, code-quality, performance with Pass 1 findings). Monitor them:
 
 ```bash
 # In a separate terminal — watch progress
@@ -648,15 +684,16 @@ Issue fetch + label routing (automated)
 │   Options: [c]reate / [e]dit / [b]ack / [a]bort     │
 └─────────────────────┬───────────────────────────────┘
                       ▼
-  orchestrator deploy-review runs (automated: 2-4 review agents + 1-2 test agents in parallel)
+  Pass 1 runs (automated: 3-6 safety & correctness agents in parallel)
+  Pass 2 runs (automated: 4 quality & contract agents in parallel, with Pass 1 findings)
                       │
 ┌─────────────────────▼───────────────────────────────┐
 │ CP4: Review & Test Findings                          │
-│   You see: P1-P4 findings from review agents         │
-│            (memory-safety, security, +conditional     │
-│            concurrency, fault-recovery)               │
-│            + test agent results (build, test pass/    │
-│            fail, test count vs baseline, coverage)    │
+│   You see: Merged findings from both passes          │
+│   Pass 1: memory-safety, security, +conditional      │
+│           concurrency, fault-recovery, test agents    │
+│   Pass 2: test-quality, api-contract, code-quality,  │
+│           performance (informed by Pass 1 findings)   │
 │   Options: [a]ccept / [f]ix / [b]ack / [r]eject     │
 └─────────────────────┬───────────────────────────────┘
                       ▼
@@ -725,17 +762,26 @@ $ python -m orchestrator deploy-issue 315 --pipeline --base integration/epic-300
   Your choice: c
   PR created: https://github.com/.../pull/361
 
-  Deploying review agents... (4 agents in parallel)
+  Deploying review agents...
+  Pass 1 (safety & correctness): 4 agents in parallel
   DONE  review-memory-safety
   DONE  review-security
   DONE  review-concurrency
   DONE  review-fault-recovery
+  Pass 2 (quality & contracts): 4 agents in parallel
+  DONE  review-test-quality
+  DONE  review-api-contract
+  DONE  review-code-quality
+  DONE  review-performance
 
 ═══════════════════════════════════════════════════════
-  CHECKPOINT 4/5 — Safety Review Findings
+  CHECKPOINT 4/5 — Review Findings (2 passes)
 ═══════════════════════════════════════════════════════
+  Pass 1: 0 P1, 2 P2, 1 P3
+  Pass 2: 0 P1, 1 P2, 2 P3
   P1: validate() never checks version field (2 findings)
   P2: Missing default member initializers (1 finding)
+  P2: Test doesn't exercise new validation path (1 finding)
   P3: Positional aggregate init fragile (1 finding)
   [a] accept  [f] fix  [b] back  [r] reject
   Your choice: f
@@ -756,6 +802,61 @@ $ python -m orchestrator deploy-issue 315 --pipeline --base integration/epic-300
   Pipeline Complete
   PR: https://github.com/.../pull/361
   Next step: Review and merge the PR in GitHub UI.
+```
+
+---
+
+## Claude Code Skills (Interactive Pipeline)
+
+In addition to the shell-based orchestrator commands, the pipeline is available as **Claude Code skills** that run inline in your current session. This provides a more natural interactive experience where Claude acts as tech-lead directly in the conversation.
+
+### Available Skills
+
+| Skill | Purpose |
+|-------|---------|
+| `/deploy-issue <N>` | Full pipeline inline — routing, agent work, 5 checkpoints, two-pass review, PR creation |
+| `/deploy-issue <N> --base integration/epic-XXX` | Same but targeting an integration branch |
+| `/commit` | Smart commit with format check, sensitive file detection, test count verification |
+
+### Skills vs Orchestrator
+
+| Capability | Orchestrator (`python -m orchestrator`) | Skills (`/deploy-issue`) |
+|-----------|----------------------------------------|--------------------------|
+| Agent launch | `claude` subprocess | Agent tool (inline) |
+| Checkpoints | Console I/O prompts | Conversation (natural) |
+| Tech-lead | Separate Claude process | Current session IS tech-lead |
+| Two-pass reviews | Same routing | Same routing |
+| Auto mode | `--auto` (no human) | N/A (always interactive) |
+| Headless mode | `--headless` | N/A |
+| tmux wrapping | `--tmux` | N/A (IDE native) |
+| Mobile monitoring | `--notify <topic>` | N/A |
+
+**When to use which:**
+- **Skills**: interactive development in IDE/CLI — you're at your desk, want real-time conversation
+- **Orchestrator**: unattended/CI use, remote monitoring via tmux+SSH, auto mode for batch processing
+
+### Example
+
+```
+User: /deploy-issue 299 --base integration/epic-284
+
+Claude: Fetching issue #299...
+  Title: Add multi-class height priors for depth estimation
+  Labels: [perception, enhancement]
+
+  Routing Recommendation:
+    Role: feature-perception
+    Priority: P3 (specific domain match)
+  Accept? [yes]
+
+User: yes
+
+Claude: Spawning feature-perception agent in isolated worktree...
+  [agent works...]
+
+  ═══ CHECKPOINT 1/5 — Changes Review ═══
+  [presents AGENT_REPORT.md + diff stat]
+  Recommendation: accept
 ```
 
 ---

--- a/docs/guides/MULTI_AGENT_GUIDE.md
+++ b/docs/guides/MULTI_AGENT_GUIDE.md
@@ -817,6 +817,11 @@ In addition to the shell-based orchestrator commands, the pipeline is available 
 | `/deploy-issue <N>` | Full pipeline inline — routing, agent work, 5 checkpoints, two-pass review, PR creation |
 | `/deploy-issue <N> --base integration/epic-XXX` | Same but targeting an integration branch |
 | `/commit` | Smart commit with format check, sensitive file detection, test count verification |
+| `/review-pr <N>` | Two-pass domain-aware code review on a PR with severity-tagged findings |
+| `/update-docs` | Auto-generate documentation updates for tracking files, design docs, and README |
+| `/create-issue <type>: <title>` | Structured issue filing with domain detection, auto-labeling, and code context |
+| `/run-scenario <N\|all>` | Gazebo SITL scenario runner with structured analysis and failure diagnosis |
+| `/production-readiness` | 11-section pre-deployment audit (build, safety, security, tests, config, etc.) |
 
 ### Skills vs Orchestrator
 

--- a/scripts/orchestrator/cli.py
+++ b/scripts/orchestrator/cli.py
@@ -213,7 +213,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--dry-run", action="store_true", help="Show routing without launching")
 
     # ── validate ───────────────────────────────────────────────────────
-    p = sub.add_parser("validate", help="Post-session hallucination detector")
+    p = sub.add_parser("validate", help="8-check post-session hallucination detector")
     p.add_argument("--branch", default="", help="Branch to validate")
 
     # ── session ────────────────────────────────────────────────────────

--- a/scripts/orchestrator/commands/deploy_review.py
+++ b/scripts/orchestrator/commands/deploy_review.py
@@ -59,10 +59,17 @@ def run(
         io.print(f"  {t}")
     io.print("")
 
+    io.print("Pass 2 agents to launch:")
+    for p2 in routing.pass2_reviewers:
+        io.print(f"  {p2}")
+    io.print("")
+
     if dry_run:
         io.warn(
             f"DRY RUN — would launch {len(routing.reviewers)} reviewers + "
-            f"{len(routing.testers)} test agents for PR #{pr_number}"
+            f"{len(routing.testers)} test agents (pass 1) + "
+            f"{len(routing.pass2_reviewers)} quality agents (pass 2) "
+            f"for PR #{pr_number}"
         )
         io.print("")
         io.print("Routing reasons:")
@@ -118,16 +125,16 @@ def run(
         f"Report: scenario results, regressions, config issues."
     )
 
-    # 4. Launch all agents
-    all_agents = routing.reviewers + routing.testers
+    # 4. Launch Pass 1 agents (safety & correctness)
+    pass1_agents = routing.reviewers + routing.testers
     session_dir = project_dir / "tasks" / "sessions"
     session_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d-%H%M")
 
-    io.print(f"Launching {len(all_agents)} agents in parallel...")
+    io.print(f"Pass 1: Launching {len(pass1_agents)} agents in parallel...")
 
-    agent_configs = []
-    for agent in all_agents:
+    pass1_configs = []
+    for agent in pass1_agents:
         role_config = ROLES[agent]
         if agent == "test-unit":
             prompt = test_unit_prompt
@@ -137,7 +144,7 @@ def run(
             prompt = review_prompt
 
         log_file = session_dir / f"{timestamp}-review-pr{pr_number}-{agent}.log"
-        agent_configs.append({
+        pass1_configs.append({
             "agent": agent,
             "model": role_config.model,
             "prompt": prompt,
@@ -145,55 +152,127 @@ def run(
         })
         io.print(f"  Launching {agent} (log: {log_file.name})")
 
-    # Run agents with asyncio
-    results = asyncio.run(_launch_agents(agent_configs))
+    pass1_results = asyncio.run(_launch_agents(pass1_configs))
 
     io.print("")
     failed = 0
-    for agent, success in results.items():
+    for agent, success in pass1_results.items():
         if success:
             io.pass_(agent)
         else:
             io.warn(f"{agent} exited with non-zero status")
             failed += 1
 
-    # 5. Consolidate findings
+    # 5. Collect Pass 1 findings for Pass 2 context
+    pass1_findings_parts: list[str] = []
+    for cfg in pass1_configs:
+        log_file = cfg["log_file"]
+        if log_file.exists() and log_file.stat().st_size > 0:
+            content = log_file.read_text()
+            lines = content.splitlines()[-100:]
+            pass1_findings_parts.append(
+                f"--- {cfg['agent']} ---\n" + "\n".join(lines)
+            )
+    pass1_findings = "\n\n".join(pass1_findings_parts)
+
+    # 6. Launch Pass 2 agents (quality & contracts) with Pass 1 context
+    pass2_configs: list[dict] = []
+    if routing.pass2_reviewers:
+        io.print("")
+        io.print(
+            f"Pass 2: Launching {len(routing.pass2_reviewers)} agents "
+            f"in parallel (with Pass 1 findings as context)..."
+        )
+
+        pass2_prompt = (
+            f"Review PR #{pr_number} (Pass 2 — quality & contracts).\n\n"
+            f"Changed files:\n{diff_files}\n\n"
+            f"Diff (first 500 lines):\n{diff_truncated}\n\n"
+            f"## Pass 1 Findings (from safety & correctness reviewers)\n\n"
+            f"{pass1_findings}\n\n"
+            f"Your job: provide a quality/contract review focused on your "
+            f"domain. Build on Pass 1 findings — don't duplicate them. "
+            f"Post findings as a structured list with file:line, severity "
+            f"(P1-P4), and fix suggestion."
+        )
+
+        for agent in routing.pass2_reviewers:
+            role_config = ROLES[agent]
+            log_file = (
+                session_dir / f"{timestamp}-review-pr{pr_number}-{agent}.log"
+            )
+            pass2_configs.append({
+                "agent": agent,
+                "model": role_config.model,
+                "prompt": pass2_prompt,
+                "log_file": log_file,
+            })
+            io.print(f"  Launching {agent} (log: {log_file.name})")
+
+        pass2_results = asyncio.run(_launch_agents(pass2_configs))
+
+        io.print("")
+        for agent, success in pass2_results.items():
+            if success:
+                io.pass_(agent)
+            else:
+                io.warn(f"{agent} exited with non-zero status")
+                failed += 1
+
+    # 7. Consolidate findings from both passes
+    all_configs = pass1_configs + pass2_configs
     io.print("")
     io.print("Consolidating findings...")
 
     date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     sections = [
-        f"## Automated Safety Review — PR #{pr_number}\n",
-        f"**Review agents:** {' '.join(routing.reviewers)}",
-        f"**Test agents:** {' '.join(routing.testers)}",
+        f"## Automated Two-Pass Review — PR #{pr_number}\n",
+        f"**Pass 1 (safety & correctness):** {' '.join(pass1_agents)}",
+        f"**Pass 2 (quality & contracts):** "
+        f"{' '.join(routing.pass2_reviewers)}",
         f"**Date:** {date_str}\n",
         "---\n",
-        "# Safety Review Findings\n",
+        "# Pass 1: Safety & Correctness Findings\n",
     ]
 
-    for cfg in agent_configs:
+    for cfg in pass1_configs:
         agent = cfg["agent"]
         log_file = cfg["log_file"]
         sections.append(f"### {agent}\n")
         if log_file.exists() and log_file.stat().st_size > 0:
             content = log_file.read_text()
-            # Take last 200 lines
             lines = content.splitlines()[-200:]
             sections.append("\n".join(lines))
         else:
             sections.append("_No output captured._")
         sections.append("")
 
+    if pass2_configs:
+        sections.append("---\n")
+        sections.append("# Pass 2: Quality & Contract Findings\n")
+
+        for cfg in pass2_configs:
+            agent = cfg["agent"]
+            log_file = cfg["log_file"]
+            sections.append(f"### {agent}\n")
+            if log_file.exists() and log_file.stat().st_size > 0:
+                content = log_file.read_text()
+                lines = content.splitlines()[-200:]
+                sections.append("\n".join(lines))
+            else:
+                sections.append("_No output captured._")
+            sections.append("")
+
     sections.append("---")
     sections.append(
         f"_Generated by orchestrator deploy-review — "
-        f"{len(routing.reviewers)} reviewers + "
-        f"{len(routing.testers)} test agents_"
+        f"{len(pass1_agents)} pass 1 + "
+        f"{len(routing.pass2_reviewers)} pass 2 agents_"
     )
 
     consolidated = "\n".join(sections)
 
-    # 6. Post as PR comment
+    # 8. Post as PR comment
     io.print(f"Posting consolidated review to PR #{pr_number}...")
     try:
         github.pr_comment(pr_number, consolidated)
@@ -201,16 +280,16 @@ def run(
     except Exception:
         io.fail("Could not post review comment")
         io.print("Logs:")
-        for cfg in agent_configs:
+        for cfg in all_configs:
             io.print(f"  {cfg['log_file']}")
         return 1
 
     io.print("")
     io.print("Review complete")
-    io.print(f"  PR:        #{pr_number}")
-    io.print(f"  Reviewers: {len(routing.reviewers)}")
-    io.print(f"  Testers:   {len(routing.testers)}")
-    io.print(f"  Failed:    {failed}")
+    io.print(f"  PR:          #{pr_number}")
+    io.print(f"  Pass 1:      {len(pass1_agents)} agents")
+    io.print(f"  Pass 2:      {len(routing.pass2_reviewers)} agents")
+    io.print(f"  Failed:      {failed}")
 
     return 0
 

--- a/scripts/orchestrator/commands/validate_session.py
+++ b/scripts/orchestrator/commands/validate_session.py
@@ -1,12 +1,15 @@
-"""Session validation command — 5-check post-session hallucination detector.
+"""Session validation command — 8-check post-session hallucination detector.
 
 Replaces validate-session.sh (304 lines).
-Checks: build, test count, test execution, includes, diff sanity.
+Checks: build, test count, test execution, includes, diff sanity,
+        config key consistency, symbol resolution, diff sanity (extended).
 """
 
 from __future__ import annotations
 
+import json
 import re
+import subprocess
 from pathlib import Path
 
 from orchestrator.build import BuildSystem
@@ -24,7 +27,7 @@ def run(
     *,
     branch: str = "",
 ) -> int:
-    """Run 5-check post-session validation.
+    """Run 8-check post-session validation.
 
     Returns 0 on pass/warn, 1 on failure.
     """
@@ -64,7 +67,7 @@ def run(
         fail_count += 1
 
     # ── 1. Build verification ──────────────────────────────────────────
-    io.print("[1/5] Build verification")
+    io.print("[1/8] Build verification")
     if not build.has_build_dir():
         fail("No build/ directory — run cmake first")
     else:
@@ -82,7 +85,7 @@ def run(
     io.print("")
 
     # ── 2. Test count ───────────────────────────────────────────────────
-    io.print("[2/5] Test count verification")
+    io.print("[2/8] Test count verification")
     actual = build.test_count() if build.has_build_dir() else 0
     expected = build.expected_test_count()
 
@@ -97,7 +100,7 @@ def run(
     io.print("")
 
     # ── 3. Test execution ───────────────────────────────────────────────
-    io.print("[3/5] Test execution")
+    io.print("[3/8] Test execution")
     if not build.has_build_dir():
         fail("Cannot run tests — no build directory")
     else:
@@ -117,7 +120,7 @@ def run(
     io.print("")
 
     # ── 4. Include verification ─────────────────────────────────────────
-    io.print("[4/5] Include verification")
+    io.print("[4/8] Include verification")
     try:
         diff = git.diff_full("main", branch)
         new_includes = re.findall(r'^\+.*#include\s+"([^"]+)"', diff, re.MULTILINE)
@@ -163,7 +166,7 @@ def run(
     io.print("")
 
     # ── 5. Diff sanity ──────────────────────────────────────────────────
-    io.print("[5/5] Diff sanity")
+    io.print("[5/8] Diff sanity")
     try:
         prs = github.pr_list_for_branch(branch)
         if not prs:
@@ -191,6 +194,203 @@ def run(
                 warn("PR body is empty")
     except Exception:
         warn("Could not check PR diff sanity")
+    io.print("")
+
+    # ── 6. Config key consistency ─────────────────────────────────────
+    io.print("[6/8] Config key consistency")
+    try:
+        diff = git.diff_full("main", branch)
+        # Find new cfg.get<> calls in added lines
+        new_keys: list[str] = []
+        for line in diff.splitlines():
+            if not line.startswith("+"):
+                continue
+            # Match cfg.get<Type>("key" or cfg.get<Type>("section.key"
+            for m in re.finditer(r'cfg\.get<[^>]*>\(\s*"([^"]+)"', line):
+                new_keys.append(m.group(1))
+            # Match cfg_key:: constants used as get arguments
+            for m in re.finditer(r'cfg_key::(\w+)::(\w+)', line):
+                new_keys.append(f"{m.group(1)}.{m.group(2)}")
+
+        if not new_keys:
+            pass_("No new config key references in diff")
+        else:
+            new_keys = sorted(set(new_keys))
+            # Load default.json and check keys exist
+            default_json = project_dir / "config" / "default.json"
+            missing_keys: list[str] = []
+            if default_json.exists():
+                try:
+                    config_data = json.loads(default_json.read_text())
+                    for key in new_keys:
+                        parts = key.split(".")
+                        node = config_data
+                        found = True
+                        for part in parts:
+                            if isinstance(node, dict) and part in node:
+                                node = node[part]
+                            else:
+                                found = False
+                                break
+                        if not found:
+                            missing_keys.append(key)
+                except json.JSONDecodeError:
+                    warn("Could not parse config/default.json")
+                    missing_keys = []
+
+            if not missing_keys:
+                pass_(
+                    f"All {len(new_keys)} config key(s) found in default.json"
+                )
+            else:
+                warn(
+                    f"{len(missing_keys)} config key(s) not in default.json:"
+                )
+                for mk in missing_keys:
+                    io.print(f"    - {mk}")
+    except Exception:
+        warn("Could not check config key consistency")
+    io.print("")
+
+    # ── 7. Symbol resolution (spot-check) ─────────────────────────────
+    io.print("[7/8] Symbol resolution (spot-check)")
+    try:
+        diff = git.diff_full("main", branch)
+        # Find new class instantiations and method calls on common types
+        # Focus on make_unique/make_shared — common hallucination points
+        phantom_symbols: list[str] = []
+        new_instantiations: list[str] = []
+        for line in diff.splitlines():
+            if not line.startswith("+"):
+                continue
+            # std::make_unique<ClassName> or std::make_shared<ClassName>
+            for m in re.finditer(
+                r'(?:make_unique|make_shared)<(\w+)>', line
+            ):
+                new_instantiations.append(m.group(1))
+
+        new_instantiations = sorted(set(new_instantiations))
+        if new_instantiations:
+            # Spot-check: grep for class/struct definitions
+            search_dirs = [
+                str(project_dir / d)
+                for d in (
+                    "common", "process1_video_capture",
+                    "process2_perception", "process3_slam_vio_nav",
+                    "process4_mission_planner", "process5_comms",
+                    "process6_payload_manager", "process7_system_monitor",
+                )
+                if (project_dir / d).exists()
+            ]
+            for sym in new_instantiations[:10]:  # cap at 10 checks
+                # Skip standard library / third-party types
+                if sym in (
+                    "string", "vector", "mutex", "thread",
+                    "promise", "future",
+                ):
+                    continue
+                result = subprocess.run(
+                    ["grep", "-rl", f"class {sym}", *search_dirs],
+                    capture_output=True, text=True, timeout=10,
+                )
+                if not result.stdout.strip():
+                    # Also check for struct
+                    result2 = subprocess.run(
+                        ["grep", "-rl", f"struct {sym}", *search_dirs],
+                        capture_output=True, text=True, timeout=10,
+                    )
+                    if not result2.stdout.strip():
+                        phantom_symbols.append(sym)
+
+        if not new_instantiations:
+            pass_("No new class instantiations to verify")
+        elif not phantom_symbols:
+            pass_(
+                f"Spot-checked {len(new_instantiations)} instantiation(s) "
+                f"— all resolve"
+            )
+        else:
+            warn(
+                f"{len(phantom_symbols)} class(es) not found in codebase:"
+            )
+            for ps in phantom_symbols:
+                io.print(f"    - {ps}")
+    except Exception:
+        warn("Could not run symbol resolution check")
+    io.print("")
+
+    # ── 8. Extended diff sanity ───────────────────────────────────────
+    io.print("[8/8] Extended diff sanity")
+    try:
+        changed_files = git.diff_name_only("main", branch)
+        issues: list[str] = []
+
+        # 8a. Test files without TEST macros
+        new_test_files = [
+            f for f in changed_files
+            if f.startswith("tests/") and f.endswith(".cpp")
+        ]
+        for tf in new_test_files:
+            tf_path = project_dir / tf
+            if tf_path.exists():
+                content = tf_path.read_text()
+                if "TEST(" not in content and "TEST_F(" not in content:
+                    issues.append(
+                        f"Test file {tf} has no TEST/TEST_F macros"
+                    )
+
+        # 8b. New .cpp files not in any CMakeLists.txt
+        new_cpp = [
+            f for f in changed_files
+            if f.endswith(".cpp") and not f.startswith("tests/")
+        ]
+        for cpp_file in new_cpp:
+            basename = Path(cpp_file).name
+            # Search CMakeLists.txt in the file's directory and parent
+            cpp_dir = project_dir / Path(cpp_file).parent
+            found_in_cmake = False
+            for cmake_dir in (cpp_dir, cpp_dir.parent):
+                cmake_path = cmake_dir / "CMakeLists.txt"
+                if cmake_path.exists() and basename in cmake_path.read_text():
+                    found_in_cmake = True
+                    break
+            if not found_in_cmake:
+                issues.append(
+                    f"New source {cpp_file} not found in CMakeLists.txt"
+                )
+
+        # 8c. Deleted files still included elsewhere
+        diff = git.diff_full("main", branch)
+        deleted_files = re.findall(
+            r'^--- a/(.+)\n\+\+\+ /dev/null', diff, re.MULTILINE
+        )
+        for df in deleted_files:
+            header_name = Path(df).name
+            if header_name.endswith(".h"):
+                result = subprocess.run(
+                    ["grep", "-rl", f'#include.*{header_name}',
+                     str(project_dir / "common"),
+                     str(project_dir / "tests")],
+                    capture_output=True, text=True, timeout=10,
+                )
+                # Exclude the deleted file itself from matches
+                remaining = [
+                    l for l in result.stdout.strip().splitlines()
+                    if l and df not in l
+                ]
+                if remaining:
+                    issues.append(
+                        f"Deleted {df} still #included in: "
+                        f"{', '.join(Path(r).name for r in remaining[:3])}"
+                    )
+
+        if not issues:
+            pass_("Extended diff sanity checks passed")
+        else:
+            for issue in issues:
+                warn(issue)
+    except Exception:
+        warn("Could not run extended diff sanity checks")
     io.print("")
 
     # ── Verdict ─────────────────────────────────────────────────────────

--- a/scripts/orchestrator/config.py
+++ b/scripts/orchestrator/config.py
@@ -33,7 +33,7 @@ class RoleConfig:
 
 
 # ── Agent Roster ───────────────────────────────────────────────────────────
-# 13 roles across 4 categories: feature (5), review (4), test (2), ops (1), lead (1)
+# 17 roles across 4 categories: feature (5), review (8), test (2), ops (1), lead (1)
 
 ROLES: dict[str, RoleConfig] = {
     # Orchestration
@@ -68,6 +68,19 @@ ROLES: dict[str, RoleConfig] = {
     ),
     "review-security": RoleConfig(
         "review-security", "claude-opus-4-6", ModelTier.OPUS, read_only=True
+    ),
+    # Pass 2 review agents (run after Pass 1, receive Pass 1 findings as context)
+    "review-test-quality": RoleConfig(
+        "review-test-quality", "claude-opus-4-6", ModelTier.OPUS, read_only=True
+    ),
+    "review-api-contract": RoleConfig(
+        "review-api-contract", "claude-sonnet-4-6", ModelTier.SONNET, read_only=True
+    ),
+    "review-code-quality": RoleConfig(
+        "review-code-quality", "claude-sonnet-4-6", ModelTier.SONNET, read_only=True
+    ),
+    "review-performance": RoleConfig(
+        "review-performance", "claude-sonnet-4-6", ModelTier.SONNET, read_only=True
     ),
     # Test agents
     "test-unit": RoleConfig(

--- a/scripts/orchestrator/config.py
+++ b/scripts/orchestrator/config.py
@@ -33,7 +33,7 @@ class RoleConfig:
 
 
 # ── Agent Roster ───────────────────────────────────────────────────────────
-# 17 roles across 4 categories: feature (5), review (8), test (2), ops (1), lead (1)
+# 17 roles across 5 categories: feature (5), review (8), test (2), ops (1), lead (1)
 
 ROLES: dict[str, RoleConfig] = {
     # Orchestration

--- a/scripts/orchestrator/routing.py
+++ b/scripts/orchestrator/routing.py
@@ -114,69 +114,95 @@ def branch_name_for_issue(number: int, title: str, is_bug: bool) -> str:
 
 @dataclass
 class ReviewRouting:
-    """Result of review agent routing decision."""
+    """Result of review agent routing decision.
+
+    Two-pass architecture:
+      Pass 1 (safety & correctness): reviewers + testers — run in parallel
+      Pass 2 (quality & contracts): pass2_reviewers — run after Pass 1,
+        receive Pass 1 findings as context
+    """
 
     reviewers: list[str] = field(default_factory=list)
     testers: list[str] = field(default_factory=list)
+    pass2_reviewers: list[str] = field(default_factory=list)
     reasons: dict[str, str] = field(default_factory=dict)
+
+
+# Pass 2 agents always run (they need Pass 1 findings as input)
+PASS2_REVIEW_AGENTS: list[str] = [
+    "review-test-quality",
+    "review-api-contract",
+    "review-code-quality",
+    "review-performance",
+]
 
 
 def route_review_agents(diff: str, force_all: bool = False) -> ReviewRouting:
     """Determine which review and test agents to launch based on PR diff.
 
-    Always includes: review-memory-safety, review-security, test-unit.
-    Conditionally adds:
-      - review-concurrency: if diff contains atomic/mutex/thread patterns
-      - review-fault-recovery: if diff touches P4/P5/P7 or watchdog/fault code
-      - test-scenario: if diff touches IPC/HAL/Gazebo configs
+    Pass 1 — Safety & Correctness (parallel):
+      Always: review-memory-safety, review-security, test-unit.
+      Conditional:
+        - review-concurrency: if diff contains atomic/mutex/thread patterns
+        - review-fault-recovery: if diff touches P4/P5/P7 or watchdog/fault code
+        - test-scenario: if diff touches IPC/HAL/Gazebo configs
+
+    Pass 2 — Quality & Contracts (parallel, after Pass 1):
+      Always: review-test-quality, review-api-contract, review-code-quality,
+              review-performance.
+      These agents receive Pass 1 findings as context.
     """
     routing = ReviewRouting()
 
-    # Always-on reviewers
+    # ── Pass 1: Always-on reviewers ───────────────────────────────────────
     routing.reviewers = ["review-memory-safety", "review-security"]
-    routing.reasons["review-memory-safety"] = "always"
-    routing.reasons["review-security"] = "always"
+    routing.reasons["review-memory-safety"] = "always (pass 1)"
+    routing.reasons["review-security"] = "always (pass 1)"
 
-    # Always-on testers
+    # Pass 1: Always-on testers
     routing.testers = ["test-unit"]
-    routing.reasons["test-unit"] = "always"
+    routing.reasons["test-unit"] = "always (pass 1)"
 
     if force_all:
         routing.reviewers.extend(["review-concurrency", "review-fault-recovery"])
         routing.testers.append("test-scenario")
-        routing.reasons["review-concurrency"] = "forced (--all)"
-        routing.reasons["review-fault-recovery"] = "forced (--all)"
-        routing.reasons["test-scenario"] = "forced (--all)"
-        return routing
+        routing.reasons["review-concurrency"] = "forced (--all, pass 1)"
+        routing.reasons["review-fault-recovery"] = "forced (--all, pass 1)"
+        routing.reasons["test-scenario"] = "forced (--all, pass 1)"
+    else:
+        # Conditional: concurrency
+        for pattern in REVIEW_CONCURRENCY_PATTERNS:
+            if re.search(pattern, diff):
+                if "review-concurrency" not in routing.reviewers:
+                    routing.reviewers.append("review-concurrency")
+                    routing.reasons["review-concurrency"] = (
+                        f"diff contains '{pattern}' pattern (pass 1)"
+                    )
+                break
 
-    # Conditional: concurrency
-    for pattern in REVIEW_CONCURRENCY_PATTERNS:
-        if re.search(pattern, diff):
-            if "review-concurrency" not in routing.reviewers:
-                routing.reviewers.append("review-concurrency")
-                routing.reasons["review-concurrency"] = (
-                    f"diff contains '{pattern}' pattern"
-                )
-            break
+        # Conditional: fault recovery
+        for pattern in REVIEW_FAULT_RECOVERY_PATTERNS:
+            if re.search(pattern, diff):
+                if "review-fault-recovery" not in routing.reviewers:
+                    routing.reviewers.append("review-fault-recovery")
+                    routing.reasons["review-fault-recovery"] = (
+                        f"diff touches '{pattern}' pattern (pass 1)"
+                    )
+                break
 
-    # Conditional: fault recovery
-    for pattern in REVIEW_FAULT_RECOVERY_PATTERNS:
-        if re.search(pattern, diff):
-            if "review-fault-recovery" not in routing.reviewers:
-                routing.reviewers.append("review-fault-recovery")
-                routing.reasons["review-fault-recovery"] = (
-                    f"diff touches '{pattern}' pattern"
-                )
-            break
+        # Conditional: scenario tests
+        for pattern in REVIEW_SCENARIO_PATTERNS:
+            if re.search(pattern, diff):
+                if "test-scenario" not in routing.testers:
+                    routing.testers.append("test-scenario")
+                    routing.reasons["test-scenario"] = (
+                        f"diff touches '{pattern}' pattern (pass 1)"
+                    )
+                break
 
-    # Conditional: scenario tests
-    for pattern in REVIEW_SCENARIO_PATTERNS:
-        if re.search(pattern, diff):
-            if "test-scenario" not in routing.testers:
-                routing.testers.append("test-scenario")
-                routing.reasons["test-scenario"] = (
-                    f"diff touches '{pattern}' pattern"
-                )
-            break
+    # ── Pass 2: Quality & Contracts (always-on) ──────────────────────────
+    routing.pass2_reviewers = list(PASS2_REVIEW_AGENTS)
+    for agent in PASS2_REVIEW_AGENTS:
+        routing.reasons[agent] = "always (pass 2, receives pass 1 findings)"
 
     return routing

--- a/tests/test_orchestrator/test_config.py
+++ b/tests/test_orchestrator/test_config.py
@@ -24,8 +24,8 @@ from orchestrator.config import (
 class TestRoleConfig:
     """Test the role configuration registry."""
 
-    def test_all_13_roles_defined(self):
-        assert len(ROLES) == 13
+    def test_all_17_roles_defined(self):
+        assert len(ROLES) == 17
 
     def test_all_roles_list_matches_dict(self):
         assert ALL_ROLES == list(ROLES.keys())
@@ -56,11 +56,11 @@ class TestTierCategories:
 
     def test_opus_roles(self):
         opus = [r for r, c in ROLES.items() if c.tier == ModelTier.OPUS]
-        assert len(opus) == 10  # 1 lead + 5 feature + 4 review
+        assert len(opus) == 11  # 1 lead + 5 feature + 5 review (pass 1 + test-quality)
 
     def test_sonnet_roles(self):
         sonnet = [r for r, c in ROLES.items() if c.tier == ModelTier.SONNET]
-        assert len(sonnet) == 2  # test-unit, test-scenario
+        assert len(sonnet) == 5  # test-unit, test-scenario, api-contract, code-quality, performance
 
     def test_haiku_roles(self):
         haiku = [r for r, c in ROLES.items() if c.tier == ModelTier.HAIKU]
@@ -71,7 +71,7 @@ class TestTierCategories:
         assert all(r.startswith("feature-") for r in FEATURE_ROLES)
 
     def test_review_roles(self):
-        assert len(REVIEW_ROLES) == 4
+        assert len(REVIEW_ROLES) == 8  # 4 pass 1 + 4 pass 2
         assert all(r.startswith("review-") for r in REVIEW_ROLES)
 
     def test_test_roles(self):

--- a/tests/test_orchestrator/test_routing.py
+++ b/tests/test_orchestrator/test_routing.py
@@ -207,6 +207,16 @@ class TestRouteReviewAgents:
     def test_reasons_populated(self):
         routing = route_review_agents("+ std::atomic<bool> flag;")
         assert "review-memory-safety" in routing.reasons
-        assert routing.reasons["review-memory-safety"] == "always"
+        assert routing.reasons["review-memory-safety"] == "always (pass 1)"
         assert "review-concurrency" in routing.reasons
         assert "atomic" in routing.reasons["review-concurrency"]
+
+    def test_pass2_reviewers_always_populated(self):
+        routing = route_review_agents("+ int x = 5;")
+        assert len(routing.pass2_reviewers) == 4
+        assert "review-test-quality" in routing.pass2_reviewers
+        assert "review-api-contract" in routing.pass2_reviewers
+        assert "review-code-quality" in routing.pass2_reviewers
+        assert "review-performance" in routing.pass2_reviewers
+        for agent in routing.pass2_reviewers:
+            assert "pass 2" in routing.reasons[agent]


### PR DESCRIPTION
## Summary

Implements the complete 3-wave skills automation plan (Issue #381 + sub-issue #392) — 7 new Claude Code skills and 4 new review agents that automate the full development, review, testing, and production readiness pipeline.

### Wave 1: Core Pipeline + Review Agents
- `/deploy-issue` skill: full 12-state pipeline running inline with 5 interactive checkpoints
- `/commit` skill: smart commit with clang-format check, sensitive file detection, test count verification
- 4 new Pass 2 review agents extending the pipeline to a two-pass review architecture:
  - `review-test-quality` (Opus): verifies tests exercise new code paths, assertions are meaningful
  - `review-api-contract` (Sonnet): verifies docstrings match implementation, data consistency
  - `review-code-quality` (Sonnet): catches dead code, DRY violations, complexity, naming issues
  - `review-performance` (Sonnet): catches unnecessary copies, allocation in hot paths, O(n²)
- Updates two-pass review routing in orchestrator (`pass2_reviewers` field in `ReviewRouting`)
- Updates ADR-010, MULTI_AGENT_GUIDE.md, CLAUDE.md to reflect 13→17 agent roster

### Wave 2: Productivity Skills
- `/review-pr` skill: two-pass domain-aware code review on PRs with auto-routing
- `/update-docs` skill: auto-generates entries for 8+ documentation files per merge (tracking files, design docs, README.md)
- `/create-issue` skill: AI-powered issue filing with domain detection, auto-labeling, code context, and duplicate detection

### Wave 3: Testing & Production Readiness
- `/run-scenario` skill: Gazebo SITL scenario runner with structured analysis, failure diagnosis, cross-run comparison
- `/production-readiness` skill: 11-section pre-deployment audit (build, safety, tests, sanitizers, security, performance, config, debug code, systemd, scenarios, dependencies)

### Two-Pass Review Architecture

\`\`\`
Pass 1 (parallel, 3-6 agents): memory-safety, security, test-unit + conditional
  ↓ findings passed as context
Pass 2 (parallel, 4 agents): test-quality, api-contract, code-quality, performance
\`\`\`

### Files Changed

| File | Wave | Change |
|------|------|--------|
| \`.claude/skills/deploy-issue/SKILL.md\` | 1 | NEW — full pipeline skill |
| \`.claude/skills/commit/SKILL.md\` | 1 | NEW — smart commit skill |
| \`.claude/agents/review-test-quality.md\` | 1 | NEW — Pass 2 agent |
| \`.claude/agents/review-api-contract.md\` | 1 | NEW — Pass 2 agent |
| \`.claude/agents/review-code-quality.md\` | 1 | NEW — Pass 2 agent |
| \`.claude/agents/review-performance.md\` | 1 | NEW — Pass 2 agent |
| \`scripts/orchestrator/config.py\` | 1 | Added 4 new agent role entries |
| \`scripts/orchestrator/routing.py\` | 1 | Added \`pass2_reviewers\` + \`PASS2_REVIEW_AGENTS\` |
| \`CLAUDE.md\` | 1 | Updated agent table (13→17) + two-pass routing |
| \`docs/adr/ADR-010-...\` | 1 | Updated roster, flow, skills integration |
| \`docs/guides/MULTI_AGENT_GUIDE.md\` | 1 | Updated roster, diagrams, costs, skills section |
| \`.claude/skills/review-pr/SKILL.md\` | 2 | NEW — two-pass PR review skill |
| \`.claude/skills/update-docs/SKILL.md\` | 2 | NEW — auto-doc update skill |
| \`.claude/skills/create-issue/SKILL.md\` | 2 | NEW — structured issue filing skill |
| \`.claude/skills/run-scenario/SKILL.md\` | 3 | NEW — Gazebo scenario runner skill |
| \`.claude/skills/production-readiness/SKILL.md\` | 3 | NEW — pre-deployment audit skill |

Closes #381
Closes #392

## Test plan

- [ ] Verify all 7 skills appear in Claude Code autocomplete
- [ ] Verify \`python -m orchestrator list\` shows 17 agents
- [ ] Verify \`route_review_agents()\` returns \`pass2_reviewers\` with 4 agents
- [ ] Run \`/deploy-issue\` on a test issue end-to-end
- [ ] Run \`/review-pr\` on an existing PR
- [ ] Run \`/create-issue bug: test issue\` and verify domain detection
- [ ] Run \`/run-scenario --list\` and verify scenario listing
- [ ] Run \`/production-readiness --quick\` and verify audit output
- [ ] Verify Pass 2 agents receive Pass 1 findings as context

🤖 Generated with [Claude Code](https://claude.com/claude-code)