### PR TITLE
feat(#290): ISysInfo platform abstraction with DI

### DIFF
--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -275,6 +275,7 @@ inline constexpr const char* MANUAL_HOLDOFF_S =
 namespace system_monitor {
 inline constexpr const char* SECTION               = "system_monitor";
 inline constexpr const char* BACKEND               = "system_monitor.backend";
+inline constexpr const char* PLATFORM              = "system_monitor.platform";
 inline constexpr const char* UPDATE_RATE_HZ        = "system_monitor.update_rate_hz";
 inline constexpr const char* DISK_CHECK_INTERVAL_S = "system_monitor.disk_check_interval_s";
 

--- a/common/util/include/util/config_validator.h
+++ b/common/util/include/util/config_validator.h
@@ -349,6 +349,7 @@ inline ConfigSchema payload_manager_schema() {
 inline ConfigSchema system_monitor_schema() {
     auto s = common_schema();
     s.required_section("system_monitor");
+    s.optional<std::string>("system_monitor.platform");
     s.required<int>("system_monitor.update_rate_hz").range(1, 100);
     s.optional<double>("system_monitor.thresholds.cpu_warn_percent").range(0.0, 100.0);
     s.optional<double>("system_monitor.thresholds.mem_warn_percent").range(0.0, 100.0);

--- a/common/util/include/util/isys_info.h
+++ b/common/util/include/util/isys_info.h
@@ -1,0 +1,94 @@
+// common/util/include/util/isys_info.h
+// Platform abstraction interface for system information gathering.
+//
+// POD structs (CpuTimes, MemInfo, DiskInfo) live here so they can be
+// shared across implementations without pulling in platform headers.
+// Implementations: LinuxSysInfo (proc/sys), JetsonSysInfo (tegra thermals),
+// MockSysInfo (deterministic testing).
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <sys/types.h>  // pid_t
+
+namespace drone::util {
+
+// ═══════════════════════════════════════════════════════════
+// POD structs — shared by all ISysInfo implementations
+// ═══════════════════════════════════════════════════════════
+
+struct CpuTimes {
+    uint64_t user{0};
+    uint64_t nice{0};
+    uint64_t system{0};
+    uint64_t idle{0};
+    uint64_t iowait{0};
+    uint64_t irq{0};
+    uint64_t softirq{0};
+    uint64_t steal{0};
+
+    uint64_t total() const { return user + nice + system + idle + iowait + irq + softirq + steal; }
+    uint64_t active() const { return total() - idle - iowait; }
+};
+
+struct MemInfo {
+    uint64_t total_kb{0};
+    uint64_t available_kb{0};
+    float    usage_percent{0.0f};
+};
+
+struct DiskInfo {
+    uint64_t total_mb{0};
+    uint64_t free_mb{0};
+    float    usage_percent{0.0f};
+};
+
+// ═══════════════════════════════════════════════════════════
+// ISysInfo — platform abstraction interface
+// ═══════════════════════════════════════════════════════════
+
+class ISysInfo {
+public:
+    virtual ~ISysInfo() = default;
+
+    ISysInfo()                           = default;
+    ISysInfo(const ISysInfo&)            = delete;
+    ISysInfo& operator=(const ISysInfo&) = delete;
+    ISysInfo(ISysInfo&&)                 = default;
+    ISysInfo& operator=(ISysInfo&&)      = default;
+
+    /// Read aggregate CPU times from the platform.
+    virtual CpuTimes read_cpu_times() = 0;
+
+    /// Compute CPU usage percentage from two samples.
+    virtual float compute_cpu_usage(const CpuTimes& prev, const CpuTimes& now) = 0;
+
+    /// Read memory information from the platform.
+    virtual MemInfo read_meminfo() = 0;
+
+    /// Read CPU temperature in degrees Celsius.
+    virtual float read_cpu_temp() = 0;
+
+    /// Read root filesystem disk usage.
+    virtual DiskInfo read_disk_usage() = 0;
+
+    /// Check whether a given PID is alive.
+    virtual bool is_process_alive(pid_t pid) = 0;
+
+    /// Human-readable name for logging.
+    virtual std::string name() const = 0;
+};
+
+// ═══════════════════════════════════════════════════════════
+// Factory — creates the appropriate ISysInfo based on platform string.
+// Declared here, defined in isys_info_factory.h (after all impls).
+// ═══════════════════════════════════════════════════════════
+
+/// Create a platform-specific ISysInfo implementation.
+/// @param platform  One of "linux", "jetson", or "mock".
+/// @return Owning pointer to ISysInfo implementation.
+std::unique_ptr<ISysInfo> create_sys_info(const std::string& platform);
+
+}  // namespace drone::util

--- a/common/util/include/util/jetson_sys_info.h
+++ b/common/util/include/util/jetson_sys_info.h
@@ -1,0 +1,136 @@
+// common/util/include/util/jetson_sys_info.h
+// Jetson-specific ISysInfo implementation.
+//
+// Inherits most behaviour from the standard Linux /proc readers but
+// overrides read_cpu_temp() to prefer the Tegra-specific thermal zone
+// (the CPU zone reported by tegra_tsensor).
+//
+// TODO(hardware): When real Jetson Orin hardware is available, extend
+// with jetson_clocks, power rail (INA3221), and GPU utilization reads.
+#pragma once
+
+#include "util/isys_info.h"
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+namespace drone::util {
+
+class JetsonSysInfo final : public ISysInfo {
+public:
+    CpuTimes read_cpu_times() override {
+        CpuTimes      t{};
+        std::ifstream f("/proc/stat");
+        if (!f.is_open()) return t;
+        std::string line;
+        if (std::getline(f, line)) {
+            std::sscanf(line.c_str(), "cpu %lu %lu %lu %lu %lu %lu %lu %lu", &t.user, &t.nice,
+                        &t.system, &t.idle, &t.iowait, &t.irq, &t.softirq, &t.steal);
+        }
+        return t;
+    }
+
+    float compute_cpu_usage(const CpuTimes& prev, const CpuTimes& now) override {
+        const uint64_t dt = now.total() - prev.total();
+        const uint64_t da = now.active() - prev.active();
+        if (dt == 0) return 0.0f;
+        return 100.0f * static_cast<float>(da) / static_cast<float>(dt);
+    }
+
+    MemInfo read_meminfo() override {
+        MemInfo       m{};
+        std::ifstream f("/proc/meminfo");
+        if (!f.is_open()) return m;
+        std::string line;
+        while (std::getline(f, line)) {
+            if (line.rfind("MemTotal:", 0) == 0)
+                std::sscanf(line.c_str(), "MemTotal: %lu kB", &m.total_kb);
+            else if (line.rfind("MemAvailable:", 0) == 0)
+                std::sscanf(line.c_str(), "MemAvailable: %lu kB", &m.available_kb);
+        }
+        if (m.total_kb > 0) {
+            m.usage_percent = 100.0f * static_cast<float>(m.total_kb - m.available_kb) /
+                              static_cast<float>(m.total_kb);
+        }
+        return m;
+    }
+
+    /// Jetson-specific: scan thermal zones for the CPU sensor (tegra_tsensor).
+    /// Falls back to zone0 if the CPU zone is not found.
+    float read_cpu_temp() override {
+        // Scan up to 16 thermal zones for the CPU-specific sensor
+        for (int i = 0; i < 16; ++i) {
+            char type_path[128];
+            std::snprintf(type_path, sizeof(type_path),
+                          "/sys/devices/virtual/thermal/thermal_zone%d/type", i);
+            std::ifstream type_f(type_path);
+            if (!type_f.is_open()) break;
+
+            std::string zone_type;
+            std::getline(type_f, zone_type);
+
+            // Jetson Orin CPU thermal zone names
+            if (zone_type == "CPU-therm" || zone_type == "cpu-therm" ||
+                zone_type == "Tdiode_tegra") {
+                char temp_path[128];
+                std::snprintf(temp_path, sizeof(temp_path),
+                              "/sys/devices/virtual/thermal/thermal_zone%d/temp", i);
+                std::ifstream temp_f(temp_path);
+                if (temp_f.is_open()) {
+                    int millideg = 0;
+                    temp_f >> millideg;
+                    return static_cast<float>(millideg) / 1000.0f;
+                }
+            }
+        }
+
+        // Fallback: try generic zone0
+        const char* fallback_paths[] = {
+            "/sys/devices/virtual/thermal/thermal_zone0/temp",
+            "/sys/class/thermal/thermal_zone0/temp",
+        };
+        for (auto path : fallback_paths) {
+            std::ifstream f(path);
+            if (f.is_open()) {
+                int millideg = 0;
+                f >> millideg;
+                return static_cast<float>(millideg) / 1000.0f;
+            }
+        }
+        return 42.0f;  // simulated fallback
+    }
+
+    DiskInfo read_disk_usage() override {
+        DiskInfo d{};
+        FILE*    fp = popen("df -m / 2>/dev/null | tail -1", "r");
+        if (fp) {
+            char buf[256];
+            if (fgets(buf, sizeof(buf), fp)) {
+                uint64_t total = 0, used = 0, avail = 0;
+                char     dev[128], mount[128];
+                int      pct = 0;
+                if (std::sscanf(buf, "%s %lu %lu %lu %d%% %s", dev, &total, &used, &avail, &pct,
+                                mount) >= 5) {
+                    d.total_mb      = total;
+                    d.free_mb       = avail;
+                    d.usage_percent = static_cast<float>(pct);
+                }
+            }
+            pclose(fp);
+        }
+        return d;
+    }
+
+    bool is_process_alive(pid_t pid) override {
+        if (pid <= 0) return false;
+        char path[64];
+        std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+        std::ifstream f(path);
+        return f.is_open();
+    }
+
+    std::string name() const override { return "JetsonSysInfo"; }
+};
+
+}  // namespace drone::util

--- a/common/util/include/util/linux_sys_info.h
+++ b/common/util/include/util/linux_sys_info.h
@@ -1,0 +1,103 @@
+// common/util/include/util/linux_sys_info.h
+// Standard Linux ISysInfo implementation — reads from /proc and /sys.
+#pragma once
+
+#include "util/isys_info.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+namespace drone::util {
+
+class LinuxSysInfo final : public ISysInfo {
+public:
+    CpuTimes read_cpu_times() override {
+        CpuTimes      t{};
+        std::ifstream f("/proc/stat");
+        if (!f.is_open()) return t;
+        std::string line;
+        if (std::getline(f, line)) {
+            // "cpu  user nice system idle iowait irq softirq steal ..."
+            std::sscanf(line.c_str(), "cpu %lu %lu %lu %lu %lu %lu %lu %lu", &t.user, &t.nice,
+                        &t.system, &t.idle, &t.iowait, &t.irq, &t.softirq, &t.steal);
+        }
+        return t;
+    }
+
+    float compute_cpu_usage(const CpuTimes& prev, const CpuTimes& now) override {
+        const uint64_t dt = now.total() - prev.total();
+        const uint64_t da = now.active() - prev.active();
+        if (dt == 0) return 0.0f;
+        return 100.0f * static_cast<float>(da) / static_cast<float>(dt);
+    }
+
+    MemInfo read_meminfo() override {
+        MemInfo       m{};
+        std::ifstream f("/proc/meminfo");
+        if (!f.is_open()) return m;
+        std::string line;
+        while (std::getline(f, line)) {
+            if (line.rfind("MemTotal:", 0) == 0)
+                std::sscanf(line.c_str(), "MemTotal: %lu kB", &m.total_kb);
+            else if (line.rfind("MemAvailable:", 0) == 0)
+                std::sscanf(line.c_str(), "MemAvailable: %lu kB", &m.available_kb);
+        }
+        if (m.total_kb > 0) {
+            m.usage_percent = 100.0f * static_cast<float>(m.total_kb - m.available_kb) /
+                              static_cast<float>(m.total_kb);
+        }
+        return m;
+    }
+
+    float read_cpu_temp() override {
+        const char* paths[] = {
+            "/sys/devices/virtual/thermal/thermal_zone0/temp",
+            "/sys/class/thermal/thermal_zone0/temp",
+        };
+        for (auto path : paths) {
+            std::ifstream f(path);
+            if (f.is_open()) {
+                int millideg = 0;
+                f >> millideg;
+                return static_cast<float>(millideg) / 1000.0f;
+            }
+        }
+        return 42.0f;  // simulated fallback
+    }
+
+    DiskInfo read_disk_usage() override {
+        DiskInfo d{};
+        FILE*    fp = popen("df -m / 2>/dev/null | tail -1", "r");
+        if (fp) {
+            char buf[256];
+            if (fgets(buf, sizeof(buf), fp)) {
+                uint64_t total = 0, used = 0, avail = 0;
+                char     dev[128], mount[128];
+                int      pct = 0;
+                if (std::sscanf(buf, "%s %lu %lu %lu %d%% %s", dev, &total, &used, &avail, &pct,
+                                mount) >= 5) {
+                    d.total_mb      = total;
+                    d.free_mb       = avail;
+                    d.usage_percent = static_cast<float>(pct);
+                }
+            }
+            pclose(fp);
+        }
+        return d;
+    }
+
+    bool is_process_alive(pid_t pid) override {
+        if (pid <= 0) return false;
+        char path[64];
+        std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+        std::ifstream f(path);
+        return f.is_open();
+    }
+
+    std::string name() const override { return "LinuxSysInfo"; }
+};
+
+}  // namespace drone::util

--- a/common/util/include/util/mock_sys_info.h
+++ b/common/util/include/util/mock_sys_info.h
@@ -1,0 +1,41 @@
+// common/util/include/util/mock_sys_info.h
+// Mock ISysInfo implementation for deterministic unit testing.
+// All values are settable via public members.
+#pragma once
+
+#include "util/isys_info.h"
+
+namespace drone::util {
+
+class MockSysInfo final : public ISysInfo {
+public:
+    // ── Injectable state ───────────────────────────────────────
+    CpuTimes injected_cpu_times{};
+    MemInfo  injected_meminfo{};
+    DiskInfo injected_disk_info{};
+    float    injected_cpu_temp{42.0f};
+    bool     injected_process_alive{true};
+
+    // ── ISysInfo interface ─────────────────────────────────────
+
+    CpuTimes read_cpu_times() override { return injected_cpu_times; }
+
+    float compute_cpu_usage(const CpuTimes& prev, const CpuTimes& now) override {
+        const uint64_t dt = now.total() - prev.total();
+        const uint64_t da = now.active() - prev.active();
+        if (dt == 0) return 0.0f;
+        return 100.0f * static_cast<float>(da) / static_cast<float>(dt);
+    }
+
+    MemInfo read_meminfo() override { return injected_meminfo; }
+
+    float read_cpu_temp() override { return injected_cpu_temp; }
+
+    DiskInfo read_disk_usage() override { return injected_disk_info; }
+
+    bool is_process_alive(pid_t /*pid*/) override { return injected_process_alive; }
+
+    std::string name() const override { return "MockSysInfo"; }
+};
+
+}  // namespace drone::util

--- a/common/util/include/util/sys_info_factory.h
+++ b/common/util/include/util/sys_info_factory.h
@@ -1,0 +1,30 @@
+// common/util/include/util/sys_info_factory.h
+// Factory for ISysInfo — creates platform-specific implementation.
+// Include this header where you need to create an ISysInfo instance.
+#pragma once
+
+#include "util/isys_info.h"
+#include "util/jetson_sys_info.h"
+#include "util/linux_sys_info.h"
+#include "util/mock_sys_info.h"
+
+#include <memory>
+#include <string>
+
+namespace drone::util {
+
+inline std::unique_ptr<ISysInfo> create_sys_info(const std::string& platform) {
+    if (platform == "linux") {
+        return std::make_unique<LinuxSysInfo>();
+    }
+    if (platform == "jetson") {
+        return std::make_unique<JetsonSysInfo>();
+    }
+    if (platform == "mock") {
+        return std::make_unique<MockSysInfo>();
+    }
+    // Default to Linux for unknown platforms
+    return std::make_unique<LinuxSysInfo>();
+}
+
+}  // namespace drone::util

--- a/config/default.json
+++ b/config/default.json
@@ -246,6 +246,7 @@
     },
 
     "system_monitor": {
+        "platform": "linux",
         "update_rate_hz": 1,
         "disk_check_interval_s": 10,
         "thresholds": {

--- a/process7_system_monitor/include/monitor/iprocess_monitor.h
+++ b/process7_system_monitor/include/monitor/iprocess_monitor.h
@@ -9,6 +9,7 @@
 
 #include "ipc/ipc_types.h"
 #include "monitor/sys_info.h"
+#include "util/isys_info.h"
 
 #include <chrono>
 #include <memory>
@@ -33,12 +34,13 @@ public:
 };
 
 // ─────────────────────────────────────────────────────────────
-// Linux process monitor — reads from /proc and /sys.
+// Linux process monitor — reads from /proc and /sys via ISysInfo.
 // This is the current behaviour extracted into a strategy object.
 // ─────────────────────────────────────────────────────────────
 
 class LinuxProcessMonitor final : public IProcessMonitor {
 public:
+    /// @param sys_info    Platform abstraction for system metrics.
     /// @param cpu_warn    CPU % threshold for WARNING status.
     /// @param mem_warn    Memory % threshold for WARNING status.
     /// @param temp_warn   Temperature (C) threshold for WARNING status.
@@ -47,10 +49,12 @@ public:
     /// @param batt_warn   Battery % threshold for WARNING status.
     /// @param batt_crit   Battery % threshold for CRITICAL status.
     /// @param disk_interval  Check disk every N calls to reduce popen overhead.
-    LinuxProcessMonitor(float cpu_warn = 90.0f, float mem_warn = 90.0f, float temp_warn = 80.0f,
-                        float temp_crit = 95.0f, float disk_crit = 98.0f, float batt_warn = 20.0f,
-                        float batt_crit = 10.0f, int disk_interval = 10)
-        : cpu_warn_(cpu_warn)
+    LinuxProcessMonitor(drone::util::ISysInfo& sys_info, float cpu_warn = 90.0f,
+                        float mem_warn = 90.0f, float temp_warn = 80.0f, float temp_crit = 95.0f,
+                        float disk_crit = 98.0f, float batt_warn = 20.0f, float batt_crit = 10.0f,
+                        int disk_interval = 10)
+        : sys_info_(sys_info)
+        , cpu_warn_(cpu_warn)
         , mem_warn_(mem_warn)
         , temp_warn_(temp_warn)
         , temp_crit_(temp_crit)
@@ -58,26 +62,26 @@ public:
         , batt_warn_(batt_warn)
         , batt_crit_(batt_crit)
         , disk_interval_(disk_interval) {
-        prev_cpu_ = read_cpu_times();
+        prev_cpu_ = sys_info_.read_cpu_times();
     }
 
     drone::ipc::SystemHealth collect() override {
         ++tick_;
 
         // CPU
-        auto  now_cpu   = read_cpu_times();
-        float cpu_usage = compute_cpu_usage(prev_cpu_, now_cpu);
+        auto  now_cpu   = sys_info_.read_cpu_times();
+        float cpu_usage = sys_info_.compute_cpu_usage(prev_cpu_, now_cpu);
         prev_cpu_       = now_cpu;
 
         // Memory
-        auto mem = read_meminfo();
+        auto mem = sys_info_.read_meminfo();
 
         // Temperature
-        float temp = read_cpu_temp();
+        float temp = sys_info_.read_cpu_temp();
 
         // Disk (periodically)
         if (tick_ % disk_interval_ == 1) {
-            disk_ = read_disk_usage();
+            disk_ = sys_info_.read_disk_usage();
         }
 
         // Build health struct
@@ -118,24 +122,27 @@ public:
     void set_battery_percent(float battery) override { battery_ = battery; }
 
 private:
-    float cpu_warn_, mem_warn_, temp_warn_, temp_crit_;
-    float disk_crit_, batt_warn_, batt_crit_;
-    int   disk_interval_;
+    drone::util::ISysInfo& sys_info_;
+    float                  cpu_warn_, mem_warn_, temp_warn_, temp_crit_;
+    float                  disk_crit_, batt_warn_, batt_crit_;
+    int                    disk_interval_;
 
-    CpuTimes prev_cpu_;
-    DiskInfo disk_{};
-    float    battery_ = 100.0f;
-    uint32_t tick_    = 0;
+    drone::util::CpuTimes prev_cpu_;
+    drone::util::DiskInfo disk_{};
+    float                 battery_ = 100.0f;
+    uint32_t              tick_    = 0;
 };
 
 /// Factory — creates the appropriate monitor based on config.
+/// @param sys_info  Platform abstraction (caller owns lifetime).
 inline std::unique_ptr<IProcessMonitor> create_process_monitor(
-    const std::string& backend = "linux", float cpu_warn = 90.0f, float mem_warn = 90.0f,
-    float temp_warn = 80.0f, float temp_crit = 95.0f, float disk_crit = 98.0f,
-    float batt_warn = 20.0f, float batt_crit = 10.0f, int disk_interval = 10) {
-    if (backend == "linux") {
-        return std::make_unique<LinuxProcessMonitor>(cpu_warn, mem_warn, temp_warn, temp_crit,
-                                                     disk_crit, batt_warn, batt_crit,
+    drone::util::ISysInfo& sys_info, const std::string& backend = "linux", float cpu_warn = 90.0f,
+    float mem_warn = 90.0f, float temp_warn = 80.0f, float temp_crit = 95.0f,
+    float disk_crit = 98.0f, float batt_warn = 20.0f, float batt_crit = 10.0f,
+    int disk_interval = 10) {
+    if (backend == "linux" || backend == "jetson") {
+        return std::make_unique<LinuxProcessMonitor>(sys_info, cpu_warn, mem_warn, temp_warn,
+                                                     temp_crit, disk_crit, batt_warn, batt_crit,
                                                      disk_interval);
     }
     throw std::runtime_error("Unknown process monitor: " + backend);

--- a/process7_system_monitor/include/monitor/sys_info.h
+++ b/process7_system_monitor/include/monitor/sys_info.h
@@ -1,127 +1,59 @@
 // process7_system_monitor/include/monitor/sys_info.h
 // Linux system information gathering from /proc and /sys.
+//
+// This header now delegates to the ISysInfo abstraction in common/util.
+// It preserves backward-compatible free functions and re-exports POD types
+// into the drone::monitor namespace so existing callers need no changes.
 
 #pragma once
 
-#include <array>
-#include <chrono>
-#include <cstdint>
-#include <cstdio>
-#include <cstring>
-#include <fstream>
-#include <sstream>
-#include <string>
+#include "util/isys_info.h"
+#include "util/linux_sys_info.h"
 
 namespace drone::monitor {
 
-struct CpuTimes {
-    uint64_t user{0}, nice{0}, system{0}, idle{0};
-    uint64_t iowait{0}, irq{0}, softirq{0}, steal{0};
+// Re-export POD types into drone::monitor for backward compatibility.
+using drone::util::CpuTimes;
+using drone::util::DiskInfo;
+using drone::util::MemInfo;
 
-    uint64_t total() const { return user + nice + system + idle + iowait + irq + softirq + steal; }
-    uint64_t active() const { return total() - idle - iowait; }
-};
+// Re-export LinuxSysInfo so monitor code can refer to it.
+using drone::util::LinuxSysInfo;
 
-// ── CPU usage (two-sample delta) ────────────────────────────
-inline CpuTimes read_cpu_times() {
-    CpuTimes      t{};
-    std::ifstream f("/proc/stat");
-    if (!f.is_open()) return t;
-    std::string line;
-    if (std::getline(f, line)) {
-        // "cpu  user nice system idle iowait irq softirq steal ..."
-        std::sscanf(line.c_str(), "cpu %lu %lu %lu %lu %lu %lu %lu %lu", &t.user, &t.nice,
-                    &t.system, &t.idle, &t.iowait, &t.irq, &t.softirq, &t.steal);
-    }
-    return t;
+// ─────────────────────────────────────────────────────────────
+// Backward-compatible free functions — delegate to LinuxSysInfo.
+// Existing code that calls drone::monitor::read_cpu_times() still works.
+// ─────────────────────────────────────────────────────────────
+
+inline drone::util::CpuTimes read_cpu_times() {
+    LinuxSysInfo sys;
+    return sys.read_cpu_times();
 }
 
-inline float compute_cpu_usage(const CpuTimes& prev, const CpuTimes& now) {
-    uint64_t dt = now.total() - prev.total();
-    uint64_t da = now.active() - prev.active();
-    if (dt == 0) return 0.0f;
-    return 100.0f * static_cast<float>(da) / static_cast<float>(dt);
+inline float compute_cpu_usage(const drone::util::CpuTimes& prev,
+                               const drone::util::CpuTimes& now) {
+    LinuxSysInfo sys;
+    return sys.compute_cpu_usage(prev, now);
 }
 
-// ── Memory ──────────────────────────────────────────────────
-struct MemInfo {
-    uint64_t total_kb{0};
-    uint64_t available_kb{0};
-    float    usage_percent{0.0f};
-};
-
-inline MemInfo read_meminfo() {
-    MemInfo       m{};
-    std::ifstream f("/proc/meminfo");
-    if (!f.is_open()) return m;
-    std::string line;
-    while (std::getline(f, line)) {
-        if (line.rfind("MemTotal:", 0) == 0)
-            std::sscanf(line.c_str(), "MemTotal: %lu kB", &m.total_kb);
-        else if (line.rfind("MemAvailable:", 0) == 0)
-            std::sscanf(line.c_str(), "MemAvailable: %lu kB", &m.available_kb);
-    }
-    if (m.total_kb > 0) {
-        m.usage_percent = 100.0f * static_cast<float>(m.total_kb - m.available_kb) /
-                          static_cast<float>(m.total_kb);
-    }
-    return m;
+inline drone::util::MemInfo read_meminfo() {
+    LinuxSysInfo sys;
+    return sys.read_meminfo();
 }
 
-// ── Temperature ─────────────────────────────────────────────
 inline float read_cpu_temp() {
-    // Try Jetson thermal zone first, then generic
-    const char* paths[] = {
-        "/sys/devices/virtual/thermal/thermal_zone0/temp",
-        "/sys/class/thermal/thermal_zone0/temp",
-    };
-    for (auto path : paths) {
-        std::ifstream f(path);
-        if (f.is_open()) {
-            int millideg = 0;
-            f >> millideg;
-            return static_cast<float>(millideg) / 1000.0f;
-        }
-    }
-    return 42.0f;  // simulated fallback
+    LinuxSysInfo sys;
+    return sys.read_cpu_temp();
 }
 
-// ── Disk usage (simple statfs wrapper) ──────────────────────
-struct DiskInfo {
-    uint64_t total_mb{0};
-    uint64_t free_mb{0};
-    float    usage_percent{0.0f};
-};
-
-inline DiskInfo read_disk_usage() {
-    DiskInfo d{};
-    // Use /proc/mounts approach — simple simulation
-    FILE* fp = popen("df -m / 2>/dev/null | tail -1", "r");
-    if (fp) {
-        char buf[256];
-        if (fgets(buf, sizeof(buf), fp)) {
-            uint64_t total, used, avail;
-            char     dev[128], mount[128];
-            int      pct;
-            if (std::sscanf(buf, "%s %lu %lu %lu %d%% %s", dev, &total, &used, &avail, &pct,
-                            mount) >= 5) {
-                d.total_mb      = total;
-                d.free_mb       = avail;
-                d.usage_percent = static_cast<float>(pct);
-            }
-        }
-        pclose(fp);
-    }
-    return d;
+inline drone::util::DiskInfo read_disk_usage() {
+    LinuxSysInfo sys;
+    return sys.read_disk_usage();
 }
 
-// ── Process watchdog (check if PID is alive) ────────────────
 inline bool is_process_alive(pid_t pid) {
-    if (pid <= 0) return false;
-    char path[64];
-    std::snprintf(path, sizeof(path), "/proc/%d/stat", pid);
-    std::ifstream f(path);
-    return f.is_open();
+    LinuxSysInfo sys;
+    return sys.is_process_alive(pid);
 }
 
 }  // namespace drone::monitor

--- a/process7_system_monitor/src/main.cpp
+++ b/process7_system_monitor/src/main.cpp
@@ -20,6 +20,7 @@
 #include "util/safe_name_copy.h"
 #include "util/sd_notify.h"
 #include "util/signal_handler.h"
+#include "util/sys_info_factory.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -294,12 +295,18 @@ int main(int argc, char* argv[]) {
     // Convert disk check interval from seconds to ticks (calls)
     const int disk_interval_ticks = std::max(1, disk_check_s * (update_rate > 0 ? update_rate : 1));
 
+    // Create platform-specific ISysInfo (linux, jetson, mock)
+    const std::string platform = cfg.get<std::string>(drone::cfg_key::system_monitor::PLATFORM,
+                                                      "linux");
+    auto              sys_info = drone::util::create_sys_info(platform);
+    DRONE_LOG_INFO("Platform sys_info: {} (config='{}')", sys_info->name(), platform);
+
     // Create process monitor via strategy factory (backend from config)
     const std::string monitor_backend =
         cfg.get<std::string>(drone::cfg_key::system_monitor::BACKEND, "linux");
     auto monitor = drone::monitor::create_process_monitor(
-        monitor_backend, cpu_warn, mem_warn, temp_warn, temp_crit, disk_crit, batt_warn, batt_crit,
-        disk_interval_ticks);
+        *sys_info, monitor_backend, cpu_warn, mem_warn, temp_warn, temp_crit, disk_crit, batt_warn,
+        batt_crit, disk_interval_ticks);
     DRONE_LOG_INFO("Process monitor: {}", monitor->name());
 
     // Optional fault-injection override subscriber.

--- a/tests/test_process_interfaces.cpp
+++ b/tests/test_process_interfaces.cpp
@@ -6,6 +6,7 @@
 // Path planner tests moved to test_dstar_lite_planner.cpp (Issue #207).
 // Obstacle avoider tests moved to test_obstacle_avoider_3d.cpp (Issue #207).
 #include "monitor/iprocess_monitor.h"
+#include "util/linux_sys_info.h"
 
 #include <memory>
 #include <vector>
@@ -19,16 +20,19 @@ using namespace drone::monitor;
 // ═══════════════════════════════════════════════════════════
 
 TEST(ProcessMonitorTest, FactoryCreatesLinux) {
-    auto pm = create_process_monitor("linux");
+    drone::util::LinuxSysInfo sys;
+    auto                      pm = create_process_monitor(sys, "linux");
     EXPECT_NE(pm, nullptr);
 }
 
 TEST(ProcessMonitorTest, FactoryThrowsOnUnknown) {
-    EXPECT_THROW(create_process_monitor("windows_nt"), std::runtime_error);
+    drone::util::LinuxSysInfo sys;
+    EXPECT_THROW(create_process_monitor(sys, "windows_nt"), std::runtime_error);
 }
 
 TEST(ProcessMonitorTest, CollectReturnsValidHealth) {
-    auto pm = create_process_monitor("linux");
+    drone::util::LinuxSysInfo sys;
+    auto                      pm = create_process_monitor(sys, "linux");
 
     auto health = pm->collect();
 
@@ -47,16 +51,18 @@ TEST(ProcessMonitorTest, CollectReturnsValidHealth) {
 }
 
 TEST(ProcessMonitorTest, ThermalZonePopulated) {
-    auto pm     = create_process_monitor("linux");
-    auto health = pm->collect();
+    drone::util::LinuxSysInfo sys;
+    auto                      pm     = create_process_monitor(sys, "linux");
+    auto                      health = pm->collect();
 
     // thermal_zone should be one of 0=normal, 1=warm, 2=hot, 3=critical
     EXPECT_LE(health.thermal_zone, 3u);
 }
 
 TEST(ProcessMonitorTest, ImplementsInterface) {
-    auto             pm    = create_process_monitor("linux");
-    IProcessMonitor* iface = pm.get();
+    drone::util::LinuxSysInfo sys;
+    auto                      pm    = create_process_monitor(sys, "linux");
+    IProcessMonitor*          iface = pm.get();
     EXPECT_NE(iface, nullptr);
 
     auto health = iface->collect();
@@ -64,7 +70,8 @@ TEST(ProcessMonitorTest, ImplementsInterface) {
 }
 
 TEST(ProcessMonitorTest, MultipleSamples) {
-    auto pm = create_process_monitor("linux");
+    drone::util::LinuxSysInfo sys;
+    auto                      pm = create_process_monitor(sys, "linux");
     for (int i = 0; i < 3; ++i) {
         auto health = pm->collect();
         EXPECT_GE(health.cpu_usage_percent, 0.0f);

--- a/tests/test_system_monitor.cpp
+++ b/tests/test_system_monitor.cpp
@@ -1,5 +1,10 @@
-// tests/test_system_monitor.cpp — Tests for sys_info.h functions
+// tests/test_system_monitor.cpp — Tests for sys_info.h functions and ISysInfo abstraction
+#include "monitor/iprocess_monitor.h"
 #include "monitor/sys_info.h"
+#include "util/isys_info.h"
+#include "util/linux_sys_info.h"
+#include "util/mock_sys_info.h"
+#include "util/sys_info_factory.h"
 
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -7,17 +12,17 @@
 using namespace drone::monitor;
 
 // ═══════════════════════════════════════════════════════════
-// CpuTimes
+// CpuTimes (backward-compatible free function tests)
 // ═══════════════════════════════════════════════════════════
 
 TEST(SysInfo, CpuTimesDefaultsZero) {
-    CpuTimes t{};
+    drone::util::CpuTimes t{};
     EXPECT_EQ(t.total(), 0u);
     EXPECT_EQ(t.active(), 0u);
 }
 
 TEST(SysInfo, CpuTimesTotalAndActive) {
-    CpuTimes t{};
+    drone::util::CpuTimes t{};
     t.user    = 100;
     t.nice    = 10;
     t.system  = 50;
@@ -38,19 +43,19 @@ TEST(SysInfo, ReadCpuTimesReturnsNonZero) {
 }
 
 TEST(SysInfo, ComputeCpuUsageZeroDelta) {
-    CpuTimes prev{}, now{};
-    float    usage = compute_cpu_usage(prev, now);
+    drone::util::CpuTimes prev{}, now{};
+    float                 usage = compute_cpu_usage(prev, now);
     EXPECT_FLOAT_EQ(usage, 0.0f);
 }
 
 TEST(SysInfo, ComputeCpuUsageKnownValues) {
-    CpuTimes prev{};
+    drone::util::CpuTimes prev{};
     prev.user   = 100;
     prev.system = 50;
     prev.idle   = 200;
     prev.iowait = 50;
 
-    CpuTimes now{};
+    drone::util::CpuTimes now{};
     now.user   = 200;
     now.system = 100;
     now.idle   = 250;
@@ -64,7 +69,7 @@ TEST(SysInfo, ComputeCpuUsageKnownValues) {
 }
 
 // ═══════════════════════════════════════════════════════════
-// MemInfo
+// MemInfo (backward-compatible free function tests)
 // ═══════════════════════════════════════════════════════════
 
 TEST(SysInfo, ReadMeminfoReturnsNonZero) {
@@ -76,7 +81,7 @@ TEST(SysInfo, ReadMeminfoReturnsNonZero) {
 }
 
 // ═══════════════════════════════════════════════════════════
-// Temperature
+// Temperature (backward-compatible free function tests)
 // ═══════════════════════════════════════════════════════════
 
 TEST(SysInfo, ReadCpuTempReasonable) {
@@ -87,7 +92,7 @@ TEST(SysInfo, ReadCpuTempReasonable) {
 }
 
 // ═══════════════════════════════════════════════════════════
-// Disk
+// Disk (backward-compatible free function tests)
 // ═══════════════════════════════════════════════════════════
 
 TEST(SysInfo, ReadDiskUsage) {
@@ -99,7 +104,7 @@ TEST(SysInfo, ReadDiskUsage) {
 }
 
 // ═══════════════════════════════════════════════════════════
-// Process watchdog
+// Process watchdog (backward-compatible free function tests)
 // ═══════════════════════════════════════════════════════════
 
 TEST(SysInfo, CurrentProcessIsAlive) {
@@ -114,4 +119,223 @@ TEST(SysInfo, InvalidPidNotAlive) {
 TEST(SysInfo, NonexistentPidNotAlive) {
     // PID 99999999 almost certainly doesn't exist
     EXPECT_FALSE(is_process_alive(99999999));
+}
+
+// ═══════════════════════════════════════════════════════════
+// ISysInfo interface — LinuxSysInfo
+// ═══════════════════════════════════════════════════════════
+
+TEST(ISysInfo, LinuxSysInfoName) {
+    drone::util::LinuxSysInfo sys;
+    EXPECT_EQ(sys.name(), "LinuxSysInfo");
+}
+
+TEST(ISysInfo, LinuxSysInfoReadCpuTimesNonZero) {
+    drone::util::LinuxSysInfo sys;
+    auto                      t = sys.read_cpu_times();
+    EXPECT_GT(t.total(), 0u);
+}
+
+TEST(ISysInfo, LinuxSysInfoReadMeminfoNonZero) {
+    drone::util::LinuxSysInfo sys;
+    auto                      m = sys.read_meminfo();
+    EXPECT_GT(m.total_kb, 0u);
+}
+
+TEST(ISysInfo, LinuxSysInfoReadCpuTempReasonable) {
+    drone::util::LinuxSysInfo sys;
+    float                     temp = sys.read_cpu_temp();
+    EXPECT_GE(temp, -20.0f);
+    EXPECT_LE(temp, 120.0f);
+}
+
+TEST(ISysInfo, LinuxSysInfoIsProcessAlive) {
+    drone::util::LinuxSysInfo sys;
+    EXPECT_TRUE(sys.is_process_alive(getpid()));
+    EXPECT_FALSE(sys.is_process_alive(0));
+}
+
+// ═══════════════════════════════════════════════════════════
+// ISysInfo interface — MockSysInfo
+// ═══════════════════════════════════════════════════════════
+
+TEST(ISysInfo, MockSysInfoName) {
+    drone::util::MockSysInfo mock;
+    EXPECT_EQ(mock.name(), "MockSysInfo");
+}
+
+TEST(ISysInfo, MockSysInfoReturnsInjectedValues) {
+    drone::util::MockSysInfo mock;
+
+    // Inject CPU times
+    mock.injected_cpu_times.user   = 500;
+    mock.injected_cpu_times.system = 200;
+    mock.injected_cpu_times.idle   = 300;
+    auto cpu                       = mock.read_cpu_times();
+    EXPECT_EQ(cpu.user, 500u);
+    EXPECT_EQ(cpu.system, 200u);
+    EXPECT_EQ(cpu.idle, 300u);
+
+    // Inject memory info
+    mock.injected_meminfo.total_kb      = 16'000'000;
+    mock.injected_meminfo.available_kb  = 8'000'000;
+    mock.injected_meminfo.usage_percent = 50.0f;
+    auto mem                            = mock.read_meminfo();
+    EXPECT_EQ(mem.total_kb, 16'000'000u);
+    EXPECT_FLOAT_EQ(mem.usage_percent, 50.0f);
+
+    // Inject temperature
+    mock.injected_cpu_temp = 65.5f;
+    EXPECT_FLOAT_EQ(mock.read_cpu_temp(), 65.5f);
+
+    // Inject disk info
+    mock.injected_disk_info.total_mb      = 500'000;
+    mock.injected_disk_info.free_mb       = 250'000;
+    mock.injected_disk_info.usage_percent = 50.0f;
+    auto disk                             = mock.read_disk_usage();
+    EXPECT_EQ(disk.total_mb, 500'000u);
+    EXPECT_FLOAT_EQ(disk.usage_percent, 50.0f);
+
+    // Inject process alive
+    mock.injected_process_alive = false;
+    EXPECT_FALSE(mock.is_process_alive(1234));
+}
+
+TEST(ISysInfo, MockSysInfoComputeCpuUsage) {
+    drone::util::MockSysInfo mock;
+
+    drone::util::CpuTimes prev{};
+    prev.user = 100;
+    prev.idle = 100;
+
+    drone::util::CpuTimes now{};
+    now.user = 200;
+    now.idle = 100;
+
+    // delta_total = 300 - 200 = 100, delta_active = 100 - 0 = 100
+    float usage = mock.compute_cpu_usage(prev, now);
+    EXPECT_NEAR(usage, 100.0f, 0.1f);
+}
+
+// ═══════════════════════════════════════════════════════════
+// ISysInfo factory
+// ═══════════════════════════════════════════════════════════
+
+TEST(ISysInfo, FactoryCreatesLinux) {
+    auto sys = drone::util::create_sys_info("linux");
+    ASSERT_NE(sys, nullptr);
+    EXPECT_EQ(sys->name(), "LinuxSysInfo");
+}
+
+TEST(ISysInfo, FactoryCreatesJetson) {
+    auto sys = drone::util::create_sys_info("jetson");
+    ASSERT_NE(sys, nullptr);
+    EXPECT_EQ(sys->name(), "JetsonSysInfo");
+}
+
+TEST(ISysInfo, FactoryCreatesMock) {
+    auto sys = drone::util::create_sys_info("mock");
+    ASSERT_NE(sys, nullptr);
+    EXPECT_EQ(sys->name(), "MockSysInfo");
+}
+
+TEST(ISysInfo, FactoryFallbackToLinux) {
+    auto sys = drone::util::create_sys_info("unknown_platform");
+    ASSERT_NE(sys, nullptr);
+    EXPECT_EQ(sys->name(), "LinuxSysInfo");
+}
+
+// ═══════════════════════════════════════════════════════════
+// LinuxProcessMonitor with MockSysInfo — deterministic health
+// ═══════════════════════════════════════════════════════════
+
+TEST(ProcessMonitor, MockSysInfoDeterministicHealth) {
+    drone::util::MockSysInfo mock;
+
+    // Set up initial CPU times (constructor reads once for prev_cpu_)
+    mock.injected_cpu_times.user   = 100;
+    mock.injected_cpu_times.system = 50;
+    mock.injected_cpu_times.idle   = 200;
+
+    drone::monitor::LinuxProcessMonitor monitor(mock);
+
+    // Now inject "after" CPU times for the first collect()
+    mock.injected_cpu_times.user   = 200;
+    mock.injected_cpu_times.system = 100;
+    mock.injected_cpu_times.idle   = 250;
+
+    // Inject memory: 50% usage
+    mock.injected_meminfo.total_kb      = 16'000'000;
+    mock.injected_meminfo.available_kb  = 8'000'000;
+    mock.injected_meminfo.usage_percent = 50.0f;
+
+    // Inject temperature: normal
+    mock.injected_cpu_temp = 55.0f;
+
+    // Inject disk: 30% usage
+    mock.injected_disk_info.total_mb      = 500'000;
+    mock.injected_disk_info.free_mb       = 350'000;
+    mock.injected_disk_info.usage_percent = 30.0f;
+
+    auto health = monitor.collect();
+
+    // CPU usage: delta_total = (200+100+250) - (100+50+200) = 200
+    //            delta_active = 200 - 50 - 0 = 150 => 75%
+    EXPECT_NEAR(health.cpu_usage_percent, 75.0f, 0.5f);
+    EXPECT_FLOAT_EQ(health.memory_usage_percent, 50.0f);
+    EXPECT_FLOAT_EQ(health.cpu_temp_c, 55.0f);
+    EXPECT_FLOAT_EQ(health.disk_usage_percent, 30.0f);
+    EXPECT_EQ(health.thermal_zone, 0u);  // all normal
+}
+
+TEST(ProcessMonitor, MockSysInfoWarningThreshold) {
+    drone::util::MockSysInfo mock;
+
+    // CPU times: 0 initially
+    mock.injected_cpu_times = {};
+
+    // cpu_warn=90, mem_warn=90, temp_warn=80, temp_crit=95
+    drone::monitor::LinuxProcessMonitor monitor(mock, 90.0f, 90.0f, 80.0f, 95.0f);
+
+    // Now inject high temperature (above warn but below crit)
+    mock.injected_cpu_temp                = 85.0f;
+    mock.injected_meminfo.usage_percent   = 50.0f;
+    mock.injected_disk_info.usage_percent = 10.0f;
+
+    auto health = monitor.collect();
+    EXPECT_EQ(health.thermal_zone, 2u);  // WARNING due to temp > 80
+}
+
+TEST(ProcessMonitor, MockSysInfoCriticalThreshold) {
+    drone::util::MockSysInfo mock;
+    mock.injected_cpu_times = {};
+
+    drone::monitor::LinuxProcessMonitor monitor(mock, 90.0f, 90.0f, 80.0f, 95.0f);
+
+    // Inject critical temperature
+    mock.injected_cpu_temp                = 100.0f;
+    mock.injected_meminfo.usage_percent   = 50.0f;
+    mock.injected_disk_info.usage_percent = 10.0f;
+
+    auto health = monitor.collect();
+    EXPECT_EQ(health.thermal_zone, 3u);  // CRITICAL due to temp > 95
+}
+
+TEST(ProcessMonitor, MockSysInfoBatteryWarning) {
+    drone::util::MockSysInfo mock;
+    mock.injected_cpu_times = {};
+
+    // batt_warn=20, batt_crit=10
+    drone::monitor::LinuxProcessMonitor monitor(mock, 90.0f, 90.0f, 80.0f, 95.0f, 98.0f, 20.0f,
+                                                10.0f);
+
+    mock.injected_cpu_temp                = 40.0f;
+    mock.injected_meminfo.usage_percent   = 30.0f;
+    mock.injected_disk_info.usage_percent = 10.0f;
+
+    // Set low battery
+    monitor.set_battery_percent(15.0f);
+
+    auto health = monitor.collect();
+    EXPECT_GE(health.thermal_zone, 2u);  // WARNING due to battery < 20
 }


### PR DESCRIPTION
## Summary

- Extract `sys_info.h` free functions into `ISysInfo` interface in `common/util/`
- Add `LinuxSysInfo`, `JetsonSysInfo`, `MockSysInfo` implementations
- Inject `ISysInfo&` into `LinuxProcessMonitor` via dependency injection
- Config-driven platform selection via `system_monitor.platform` key
- +16 new unit tests using `MockSysInfo` for deterministic health monitoring

## Files

| File | Change |
|------|--------|
| `common/util/include/util/isys_info.h` | NEW — interface + POD structs |
| `common/util/include/util/linux_sys_info.h` | NEW — Linux /proc implementation |
| `common/util/include/util/jetson_sys_info.h` | NEW — Jetson tegra thermal override |
| `common/util/include/util/mock_sys_info.h` | NEW — injectable test double |
| `common/util/include/util/sys_info_factory.h` | NEW — factory function |
| `process7_system_monitor/include/monitor/sys_info.h` | Backward-compat wrapper |
| `process7_system_monitor/include/monitor/iprocess_monitor.h` | ISysInfo& DI |
| `process7_system_monitor/src/main.cpp` | Create ISysInfo from config |
| `tests/test_system_monitor.cpp` | +16 MockSysInfo tests |

Closes #290

## Test Plan

- [x] Build: zero warnings with `-Werror -Wall -Wextra`
- [x] Test count: 1363 (was 1347, +16 new)
- [x] All 1363 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)