### PR TITLE
feat(#289): TopicResolver + vehicle_id namespace support

### DIFF
--- a/common/ipc/include/ipc/message_bus.h
+++ b/common/ipc/include/ipc/message_bus.h
@@ -24,6 +24,7 @@
 #include "ipc/ipublisher.h"
 #include "ipc/iservice_channel.h"
 #include "ipc/isubscriber.h"
+#include "ipc/topic_resolver.h"
 #include "ipc/zenoh_message_bus.h"
 #include "util/ilogger.h"
 
@@ -83,9 +84,10 @@ public:
     /// @return  Owning publisher — ready to call publish().
     template<typename T>
     [[nodiscard]] std::unique_ptr<IPublisher<T>> advertise(const std::string& topic) {
+        const auto resolved = resolver_.resolve(topic);
         return std::visit(
             [&](auto& b) -> std::unique_ptr<IPublisher<T>> {
-                return b->template advertise<T>(topic);
+                return b->template advertise<T>(resolved);
             },
             impl_);
     }
@@ -99,9 +101,10 @@ public:
     [[nodiscard]] std::unique_ptr<ISubscriber<T>> subscribe(const std::string& topic,
                                                             int                max_retries = 50,
                                                             int                retry_ms    = 200) {
+        const auto resolved = resolver_.resolve(topic);
         return std::visit(
             [&](auto& b) -> std::unique_ptr<ISubscriber<T>> {
-                return b->template subscribe<T>(topic, max_retries, retry_ms);
+                return b->template subscribe<T>(resolved, max_retries, retry_ms);
             },
             impl_);
     }
@@ -119,9 +122,10 @@ public:
     template<typename Req, typename Resp>
     [[nodiscard]] std::unique_ptr<IServiceClient<Req, Resp>> create_client(
         const std::string& service, uint64_t timeout_ms = 5000) {
+        const auto resolved = resolver_.resolve(service);
         return std::visit(
             [&](auto& b) -> std::unique_ptr<IServiceClient<Req, Resp>> {
-                return b->template create_client<Req, Resp>(service, timeout_ms);
+                return b->template create_client<Req, Resp>(resolved, timeout_ms);
             },
             impl_);
     }
@@ -130,9 +134,10 @@ public:
     template<typename Req, typename Resp>
     [[nodiscard]] std::unique_ptr<IServiceServer<Req, Resp>> create_server(
         const std::string& service) {
+        const auto resolved = resolver_.resolve(service);
         return std::visit(
             [&](auto& b) -> std::unique_ptr<IServiceServer<Req, Resp>> {
-                return b->template create_server<Req, Resp>(service);
+                return b->template create_server<Req, Resp>(resolved);
             },
             impl_);
     }
@@ -158,8 +163,17 @@ public:
         return std::holds_alternative<std::unique_ptr<ZenohMessageBus>>(impl_);
     }
 
+    // ─── Topic Resolver ──────────────────────────────────────
+
+    /// Set the topic resolver (for vehicle_id namespacing).
+    void set_topic_resolver(TopicResolver resolver) { resolver_ = std::move(resolver); }
+
+    /// Returns the current topic resolver.
+    [[nodiscard]] const TopicResolver& topic_resolver() const { return resolver_; }
+
 private:
     detail::BusVariant impl_;
+    TopicResolver      resolver_;
 };
 
 }  // namespace drone::ipc

--- a/common/ipc/include/ipc/message_bus_factory.h
+++ b/common/ipc/include/ipc/message_bus_factory.h
@@ -85,7 +85,16 @@ MessageBus create_message_bus(const ConfigT& cfg) {
         zenoh_json = net_cfg.to_json();
     }
 
-    return create_message_bus(backend, shm_pool_mb, zenoh_json);
+    auto bus = create_message_bus(backend, shm_pool_mb, zenoh_json);
+
+    // Apply vehicle_id topic namespacing if configured
+    const auto vehicle_id = cfg.template get<std::string>(drone::cfg_key::VEHICLE_ID, "");
+    if (!vehicle_id.empty()) {
+        bus.set_topic_resolver(TopicResolver(vehicle_id));
+        DRONE_LOG_INFO("[MessageBusFactory] Vehicle ID: '{}' — topics namespaced", vehicle_id);
+    }
+
+    return bus;
 }
 
 }  // namespace drone::ipc

--- a/common/ipc/include/ipc/topic_resolver.h
+++ b/common/ipc/include/ipc/topic_resolver.h
@@ -1,0 +1,52 @@
+// common/ipc/include/ipc/topic_resolver.h
+// Resolves IPC topic names with an optional vehicle_id prefix.
+//
+// Multi-vehicle support: when vehicle_id is set, all topics are
+// namespaced under "/<vehicle_id>/..." so that multiple vehicles
+// on the same Zenoh network don't interfere.
+//
+// Empty vehicle_id (the default) produces IDENTICAL behavior to
+// pre-TopicResolver code — no prefix, no behavioral change.
+#pragma once
+
+#include <string>
+
+namespace drone::ipc {
+
+/// Resolves IPC topic names with optional vehicle_id prefix.
+///
+/// Empty vehicle_id = no prefix = fully backward compatible.
+/// Non-empty vehicle_id prepends "/<vehicle_id>" to every topic.
+///
+/// Example:
+///   TopicResolver r("drone42");
+///   r.resolve("/slam_pose")       -> "/drone42/slam_pose"
+///   r.resolve("/fc_commands")     -> "/drone42/fc_commands"
+///
+///   TopicResolver r_default;      // empty vehicle_id
+///   r_default.resolve("/slam_pose") -> "/slam_pose"  (unchanged)
+class TopicResolver {
+public:
+    explicit TopicResolver(std::string vehicle_id = "") : vehicle_id_(std::move(vehicle_id)) {}
+
+    /// Resolve a base topic name to a namespaced topic.
+    /// @param base_topic  The base topic (e.g. "/slam_pose").
+    /// @return  Namespaced topic, or base_topic unchanged if no vehicle_id.
+    [[nodiscard]] std::string resolve(const std::string& base_topic) const {
+        if (vehicle_id_.empty()) {
+            return base_topic;
+        }
+        return "/" + vehicle_id_ + base_topic;
+    }
+
+    /// Returns the configured vehicle_id (empty string if none).
+    [[nodiscard]] const std::string& vehicle_id() const { return vehicle_id_; }
+
+    /// Returns true if a vehicle_id prefix is configured.
+    [[nodiscard]] bool has_prefix() const { return !vehicle_id_.empty(); }
+
+private:
+    std::string vehicle_id_;
+};
+
+}  // namespace drone::ipc

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -15,6 +15,7 @@ namespace drone::cfg_key {
 // ═══════════════════════════════════════════════════════════
 inline constexpr const char* LOG_LEVEL   = "log_level";
 inline constexpr const char* IPC_BACKEND = "ipc_backend";
+inline constexpr const char* VEHICLE_ID  = "vehicle_id";
 
 // ═══════════════════════════════════════════════════════════
 // Zenoh IPC settings

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
     "_comment": "Default configuration for Drone Companion Stack",
     "log_level": "info",
     "ipc_backend": "zenoh",
+    "vehicle_id": "",
 
     "zenoh": {
         "_comment": "Zenoh IPC settings",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -293,3 +293,7 @@ target_include_directories(test_replay_dispatch PRIVATE
 add_drone_test(test_collision_recovery test_collision_recovery.cpp)
 # ── Gimbal Auto-Tracker tests (Issue #257) ────────────────
 add_drone_test(test_gimbal_auto_tracker test_gimbal_auto_tracker.cpp)
+
+# ── TopicResolver tests (Issue #289) ─────────────────────
+add_drone_test(test_topic_resolver  test_topic_resolver.cpp
+    PROPERTIES RESOURCE_LOCK "zenoh_session")

--- a/tests/test_topic_resolver.cpp
+++ b/tests/test_topic_resolver.cpp
@@ -1,0 +1,172 @@
+// tests/test_topic_resolver.cpp
+// Unit tests for TopicResolver and MessageBus topic namespacing.
+#include "ipc/ipc_types.h"
+#include "ipc/message_bus_factory.h"
+#include "ipc/topic_resolver.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace drone::ipc;
+
+// ═══════════════════════════════════════════════════════════
+// TopicResolver unit tests (no Zenoh session needed)
+// ═══════════════════════════════════════════════════════════
+
+TEST(TopicResolverTest, EmptyVehicleIdNoPrefix) {
+    TopicResolver resolver;
+    EXPECT_EQ(resolver.resolve("/slam_pose"), "/slam_pose");
+    EXPECT_EQ(resolver.resolve("/fc_commands"), "/fc_commands");
+    EXPECT_EQ(resolver.resolve("/detected_objects"), "/detected_objects");
+}
+
+TEST(TopicResolverTest, EmptyStringVehicleIdNoPrefix) {
+    TopicResolver resolver("");
+    EXPECT_EQ(resolver.resolve("/slam_pose"), "/slam_pose");
+    EXPECT_FALSE(resolver.has_prefix());
+    EXPECT_EQ(resolver.vehicle_id(), "");
+}
+
+TEST(TopicResolverTest, VehicleIdPrefixApplied) {
+    TopicResolver resolver("drone42");
+    EXPECT_EQ(resolver.resolve("/slam_pose"), "/drone42/slam_pose");
+    EXPECT_EQ(resolver.resolve("/fc_commands"), "/drone42/fc_commands");
+    EXPECT_EQ(resolver.resolve("/detected_objects"), "/drone42/detected_objects");
+}
+
+TEST(TopicResolverTest, HasPrefixTrue) {
+    TopicResolver resolver("vehicle_a");
+    EXPECT_TRUE(resolver.has_prefix());
+    EXPECT_EQ(resolver.vehicle_id(), "vehicle_a");
+}
+
+TEST(TopicResolverTest, HasPrefixFalse) {
+    TopicResolver resolver;
+    EXPECT_FALSE(resolver.has_prefix());
+}
+
+TEST(TopicResolverTest, PreservesLeadingSlash) {
+    TopicResolver resolver("v1");
+    const auto    resolved = resolver.resolve("/topic");
+    EXPECT_EQ(resolved, "/v1/topic");
+    EXPECT_EQ(resolved[0], '/');
+}
+
+TEST(TopicResolverTest, TopicWithoutLeadingSlash) {
+    // Without a leading slash, the result is /<vehicle_id><base_topic>
+    // (no extra separator inserted). All IPC topics should start with '/'.
+    TopicResolver resolver("drone1");
+    EXPECT_EQ(resolver.resolve("topic"), "/drone1topic");
+}
+
+TEST(TopicResolverTest, EmptyBaseTopic) {
+    TopicResolver resolver("drone1");
+    EXPECT_EQ(resolver.resolve(""), "/drone1");
+
+    TopicResolver resolver_empty;
+    EXPECT_EQ(resolver_empty.resolve(""), "");
+}
+
+TEST(TopicResolverTest, MoveConstruction) {
+    TopicResolver a("drone42");
+    TopicResolver b(std::move(a));
+    EXPECT_EQ(b.resolve("/slam_pose"), "/drone42/slam_pose");
+    EXPECT_TRUE(b.has_prefix());
+}
+
+// ═══════════════════════════════════════════════════════════
+// Test data struct (trivially copyable)
+// ═══════════════════════════════════════════════════════════
+struct ResolverTestPayload {
+    uint64_t id{0};
+    float    value{0.0f};
+};
+
+/// Generate a unique topic name per test to avoid Zenoh cross-test interference.
+static std::string unique_topic(const char* base) {
+    static std::atomic<uint32_t> counter{0};
+    return std::string(base) + "_" + std::to_string(::getpid()) + "_" +
+           std::to_string(counter.fetch_add(1));
+}
+
+// ═══════════════════════════════════════════════════════════
+// MessageBus integration: default resolver (no prefix)
+// ═══════════════════════════════════════════════════════════
+
+TEST(TopicResolverBusTest, DefaultResolverNoPrefix) {
+    auto bus = create_message_bus("zenoh");
+    EXPECT_FALSE(bus.topic_resolver().has_prefix());
+    EXPECT_EQ(bus.topic_resolver().vehicle_id(), "");
+}
+
+TEST(TopicResolverBusTest, SetResolverPersists) {
+    auto bus = create_message_bus("zenoh");
+    bus.set_topic_resolver(TopicResolver("fleet7"));
+    EXPECT_TRUE(bus.topic_resolver().has_prefix());
+    EXPECT_EQ(bus.topic_resolver().vehicle_id(), "fleet7");
+}
+
+// ═══════════════════════════════════════════════════════════
+// End-to-end: pub/sub through namespaced bus
+// ═══════════════════════════════════════════════════════════
+
+TEST(TopicResolverBusTest, NamespacedPubSubRoundTrip) {
+    auto base_topic = unique_topic("/test_resolver_rt");
+
+    auto bus = create_message_bus("zenoh");
+    bus.set_topic_resolver(TopicResolver("drone99"));
+
+    auto pub = bus.advertise<ResolverTestPayload>(base_topic);
+    auto sub = bus.subscribe<ResolverTestPayload>(base_topic);
+    ASSERT_NE(pub, nullptr);
+    ASSERT_NE(sub, nullptr);
+
+    ResolverTestPayload sent{42, 3.14f};
+    pub->publish(sent);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    ResolverTestPayload received{};
+    ASSERT_TRUE(sub->receive(received));
+    EXPECT_EQ(received.id, 42u);
+    EXPECT_FLOAT_EQ(received.value, 3.14f);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Multi-namespace isolation: two buses, different vehicle_ids
+// ═══════════════════════════════════════════════════════════
+
+TEST(TopicResolverBusTest, MultiNamespaceIsolation) {
+    auto base_topic = unique_topic("/test_resolver_iso");
+
+    auto bus_a = create_message_bus("zenoh");
+    bus_a.set_topic_resolver(TopicResolver("alpha"));
+
+    auto bus_b = create_message_bus("zenoh");
+    bus_b.set_topic_resolver(TopicResolver("bravo"));
+
+    // Subscribe on both namespaces
+    auto sub_a = bus_a.subscribe<ResolverTestPayload>(base_topic);
+    auto sub_b = bus_b.subscribe<ResolverTestPayload>(base_topic);
+
+    // Publish only on alpha
+    auto                pub_a = bus_a.advertise<ResolverTestPayload>(base_topic);
+    ResolverTestPayload msg{77, 1.0f};
+    pub_a->publish(msg);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Alpha should receive the message
+    ResolverTestPayload recv_a{};
+    EXPECT_TRUE(sub_a->receive(recv_a));
+    EXPECT_EQ(recv_a.id, 77u);
+
+    // Bravo should NOT receive (different namespace)
+    ResolverTestPayload recv_b{};
+    EXPECT_FALSE(sub_b->receive(recv_b));
+}


### PR DESCRIPTION
## Summary
- Adds `TopicResolver` class that optionally prepends `vehicle_id` to all IPC topic names for multi-vehicle namespace isolation
- Integrates into `MessageBus` (all 5 pub/sub/service methods call `resolver_.resolve()`) and `MessageBusFactory` (reads `vehicle_id` from config)
- Adds `vehicle_id` config key to `config_keys.h` and `default.json` (default: empty = no prefix)
- 13 new tests: prefix behavior, bus integration, Zenoh pub/sub round-trip, multi-namespace isolation

## Test plan
- [x] All 13 TopicResolverTest/TopicResolverBusTest pass
- [x] Full build with zero warnings
- [x] Test count: 1363 → 1376 (+13)
- [x] clang-format-18 clean

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>