### PR TITLE
feat(#293): lightweight EventBus for intra-process composition

### DIFF
--- a/common/util/include/util/event_bus.h
+++ b/common/util/include/util/event_bus.h
@@ -1,0 +1,151 @@
+// common/util/include/util/event_bus.h
+// Lightweight per-process EventBus for intra-process declarative composition.
+//
+// Enables patterns like "on obstacle detected within 3m, trigger payload capture"
+// without a full reactive framework.  IPC remains pull-based (correct for real-time).
+//
+// Thread safety:
+//   - subscribe(), unsubscribe (via Subscription destructor), and publish()
+//     are all safe to call concurrently from any thread.
+//   - publish() uses copy-on-write: copies the handler list under lock, then
+//     iterates the copy outside the lock.  This allows publish-from-within-handler
+//     (re-entrancy) and unsubscribe-during-iteration without deadlock.
+//
+// Concurrency tier: std::mutex (non-hot-path shared state).
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace drone::util {
+
+// Forward declaration — Subscription must know EventBus<Event>.
+template<typename Event>
+class EventBus;
+
+/// RAII subscription token.  Automatically unsubscribes on destruction.
+/// Move-only — copying would create double-unsubscribe bugs.
+template<typename Event>
+class Subscription {
+public:
+    Subscription() = default;
+
+    ~Subscription() { unsubscribe(); }
+
+    // Move-only
+    Subscription(Subscription&& other) noexcept : bus_(other.bus_), id_(other.id_) {
+        other.bus_ = nullptr;
+        other.id_  = 0;
+    }
+
+    Subscription& operator=(Subscription&& other) noexcept {
+        if (this != &other) {
+            unsubscribe();
+            bus_       = other.bus_;
+            id_        = other.id_;
+            other.bus_ = nullptr;
+            other.id_  = 0;
+        }
+        return *this;
+    }
+
+    Subscription(const Subscription&)            = delete;
+    Subscription& operator=(const Subscription&) = delete;
+
+    /// Check if this subscription is active.
+    [[nodiscard]] bool is_active() const { return bus_ != nullptr; }
+
+    /// Explicitly unsubscribe (also called by destructor).
+    void unsubscribe() {
+        if (bus_) {
+            bus_->remove_handler(id_);
+            bus_ = nullptr;
+            id_  = 0;
+        }
+    }
+
+private:
+    friend class EventBus<Event>;
+
+    Subscription(EventBus<Event>* bus, uint64_t id) : bus_(bus), id_(id) {}
+
+    EventBus<Event>* bus_ = nullptr;
+    uint64_t         id_  = 0;
+};
+
+/// Lightweight typed event bus for intra-process composition.
+///
+/// Usage:
+///   struct ObstacleDetected { float distance_m; };
+///   EventBus<ObstacleDetected> bus;
+///   auto sub = bus.subscribe([](const ObstacleDetected& e) {
+///       if (e.distance_m < 3.0f) trigger_capture();
+///   });
+///   bus.publish(ObstacleDetected{2.5f});
+template<typename Event>
+class EventBus {
+public:
+    EventBus()  = default;
+    ~EventBus() = default;
+
+    // Non-copyable, non-movable (subscriptions hold raw pointer to bus).
+    EventBus(const EventBus&)            = delete;
+    EventBus& operator=(const EventBus&) = delete;
+    EventBus(EventBus&&)                 = delete;
+    EventBus& operator=(EventBus&&)      = delete;
+
+    /// Subscribe a handler.  Returns an RAII Subscription token that
+    /// automatically unsubscribes when destroyed or moved-from.
+    [[nodiscard]] Subscription<Event> subscribe(std::function<void(const Event&)> handler) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const uint64_t              id = next_id_++;
+        handlers_.push_back({id, std::move(handler)});
+        return Subscription<Event>(this, id);
+    }
+
+    /// Publish an event to all current subscribers.
+    /// Safe to call from within a handler (re-entrant) and from any thread.
+    void publish(const Event& event) {
+        // Copy-on-write: snapshot handler list under lock, iterate outside.
+        std::vector<HandlerEntry> snapshot;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            snapshot = handlers_;
+        }
+        for (const auto& entry : snapshot) {
+            entry.handler(event);
+        }
+    }
+
+    /// Number of active subscriptions (for testing/diagnostics).
+    [[nodiscard]] size_t subscriber_count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return handlers_.size();
+    }
+
+private:
+    friend class Subscription<Event>;
+
+    struct HandlerEntry {
+        uint64_t                          id      = 0;
+        std::function<void(const Event&)> handler = nullptr;
+    };
+
+    /// Remove a handler by subscription ID.  Called by Subscription destructor.
+    void remove_handler(uint64_t id) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handlers_.erase(std::remove_if(handlers_.begin(), handlers_.end(),
+                                       [id](const HandlerEntry& e) { return e.id == id; }),
+                        handlers_.end());
+    }
+
+    mutable std::mutex        mutex_;
+    std::vector<HandlerEntry> handlers_;
+    uint64_t                  next_id_ = 1;
+};
+
+}  // namespace drone::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,3 +299,6 @@ add_drone_test(test_gimbal_auto_tracker test_gimbal_auto_tracker.cpp)
 # ── TopicResolver tests (Issue #289) ─────────────────────
 add_drone_test(test_topic_resolver  test_topic_resolver.cpp
     PROPERTIES RESOURCE_LOCK "zenoh_session")
+
+# ── EventBus tests (Issue #293) ─────────────────────────
+add_drone_test(test_event_bus       test_event_bus.cpp)

--- a/tests/test_event_bus.cpp
+++ b/tests/test_event_bus.cpp
@@ -1,0 +1,295 @@
+// tests/test_event_bus.cpp — EventBus<Event> unit tests (Issue #293)
+#include "util/event_bus.h"
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// ── Test event types ────────────────────────────────────────────────
+
+struct SimpleEvent {
+    int value = 0;
+};
+
+struct StringEvent {
+    std::string message;
+};
+
+// ── Basic functionality ─────────────────────────────────────────────
+
+TEST(EventBus, SubscribeAndPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                received = 0;
+    auto sub = bus.subscribe([&](const SimpleEvent& e) { received = e.value; });
+
+    bus.publish(SimpleEvent{42});
+    EXPECT_EQ(received, 42);
+}
+
+TEST(EventBus, MultipleHandlers) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                sum = 0;
+    auto sub1 = bus.subscribe([&](const SimpleEvent& e) { sum += e.value; });
+    auto sub2 = bus.subscribe([&](const SimpleEvent& e) { sum += e.value * 10; });
+
+    bus.publish(SimpleEvent{3});
+    EXPECT_EQ(sum, 33);  // 3 + 30
+}
+
+TEST(EventBus, EmptyBusPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    // Must not crash
+    bus.publish(SimpleEvent{99});
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+TEST(EventBus, SubscriberCount) {
+    drone::util::EventBus<SimpleEvent> bus;
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+
+    auto sub1 = bus.subscribe([](const SimpleEvent&) {});
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+
+    auto sub2 = bus.subscribe([](const SimpleEvent&) {});
+    EXPECT_EQ(bus.subscriber_count(), 2u);
+}
+
+// ── RAII unsubscribe ────────────────────────────────────────────────
+
+TEST(EventBus, RAIIUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    {
+        auto sub = bus.subscribe([&](const SimpleEvent&) { ++count; });
+        bus.publish(SimpleEvent{});
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(bus.subscriber_count(), 1u);
+    }
+    // sub went out of scope — handler should be removed
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);  // no additional call
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+TEST(EventBus, ExplicitUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    auto                               sub   = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);
+
+    sub.unsubscribe();
+    EXPECT_FALSE(sub.is_active());
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);  // not called after unsubscribe
+}
+
+TEST(EventBus, DoubleUnsubscribeIsSafe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    auto                               sub = bus.subscribe([](const SimpleEvent&) {});
+    sub.unsubscribe();
+    sub.unsubscribe();  // Must not crash or double-free
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+// ── Move semantics on Subscription ──────────────────────────────────
+
+TEST(EventBus, MoveConstructSubscription) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    auto                               sub1  = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    auto sub2(std::move(sub1));
+    EXPECT_FALSE(sub1.is_active());  // NOLINT — testing moved-from state
+    EXPECT_TRUE(sub2.is_active());
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+}
+
+TEST(EventBus, MoveAssignSubscription) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count_a = 0;
+    int                                count_b = 0;
+    auto sub_a = bus.subscribe([&](const SimpleEvent&) { ++count_a; });
+    auto sub_b = bus.subscribe([&](const SimpleEvent&) { ++count_b; });
+    EXPECT_EQ(bus.subscriber_count(), 2u);
+
+    // Move-assign sub_a into sub_b — sub_b's old handler should be unsubscribed
+    sub_b = std::move(sub_a);
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count_a, 1);  // sub_a's handler still active (now owned by sub_b)
+    EXPECT_EQ(count_b, 0);  // sub_b's old handler was unsubscribed
+}
+
+TEST(EventBus, DefaultConstructedSubscriptionInactive) {
+    drone::util::Subscription<SimpleEvent> sub;
+    EXPECT_FALSE(sub.is_active());
+    // Destroying default-constructed subscription must not crash
+}
+
+// ── Re-entrancy (publish from within handler) ───────────────────────
+
+TEST(EventBus, PublishFromWithinHandler) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                outer_count = 0;
+    int                                inner_count = 0;
+
+    auto inner_sub = bus.subscribe([&](const SimpleEvent&) { ++inner_count; });
+
+    auto outer_sub = bus.subscribe([&](const SimpleEvent& e) {
+        ++outer_count;
+        if (e.value == 1) {
+            // Re-entrant publish — must not deadlock
+            bus.publish(SimpleEvent{2});
+        }
+    });
+
+    bus.publish(SimpleEvent{1});
+    // First publish: both handlers called with value=1
+    // Re-entrant publish(2): both handlers called with value=2
+    EXPECT_EQ(outer_count, 2);
+    EXPECT_EQ(inner_count, 2);
+}
+
+// ── Unsubscribe during iteration (safe due to copy-on-write) ────────
+
+TEST(EventBus, UnsubscribeDuringIteration) {
+    drone::util::EventBus<SimpleEvent>     bus;
+    int                                    count = 0;
+    drone::util::Subscription<SimpleEvent> sub2;
+    // Handler that unsubscribes sub2 during publish iteration
+    auto sub1 = bus.subscribe([&](const SimpleEvent&) {
+        ++count;
+        sub2.unsubscribe();  // Modifies handler list while iterating snapshot
+    });
+    sub2      = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    bus.publish(SimpleEvent{});
+    // Both handlers were in the snapshot, so both should have been called
+    EXPECT_EQ(count, 2);
+    // But sub2 is now unsubscribed
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+}
+
+// ── Thread safety ───────────────────────────────────────────────────
+
+TEST(EventBus, ConcurrentPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::atomic<int>                   total{0};
+
+    auto sub = bus.subscribe(
+        [&](const SimpleEvent& e) { total.fetch_add(e.value, std::memory_order_relaxed); });
+
+    constexpr int            kThreads   = 4;
+    constexpr int            kPerThread = 1000;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&bus]() {
+            for (int i = 0; i < kPerThread; ++i) {
+                bus.publish(SimpleEvent{1});
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(total.load(std::memory_order_relaxed), kThreads * kPerThread);
+}
+
+TEST(EventBus, ConcurrentSubscribeUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::atomic<int>                   total{0};
+
+    constexpr int            kThreads = 4;
+    constexpr int            kIters   = 500;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&bus, &total]() {
+            for (int i = 0; i < kIters; ++i) {
+                auto sub = bus.subscribe([&](const SimpleEvent& e) {
+                    total.fetch_add(e.value, std::memory_order_relaxed);
+                });
+                bus.publish(SimpleEvent{1});
+                // sub destroyed here — RAII unsubscribe
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Each iteration: subscribe, publish (at least own handler sees it), unsubscribe.
+    // Total should be >= kThreads * kIters (could be more due to interleaving).
+    EXPECT_GE(total.load(std::memory_order_relaxed), kThreads * kIters);
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+// ── Different event types are independent ───────────────────────────
+
+TEST(EventBus, DifferentEventTypes) {
+    drone::util::EventBus<SimpleEvent> int_bus;
+    drone::util::EventBus<StringEvent> str_bus;
+
+    int         int_count = 0;
+    std::string last_msg;
+
+    auto sub1 = int_bus.subscribe([&](const SimpleEvent& e) { int_count += e.value; });
+    auto sub2 = str_bus.subscribe([&](const StringEvent& e) { last_msg = e.message; });
+
+    int_bus.publish(SimpleEvent{7});
+    str_bus.publish(StringEvent{"hello"});
+
+    EXPECT_EQ(int_count, 7);
+    EXPECT_EQ(last_msg, "hello");
+}
+
+// ── Subscribe after publish ─────────────────────────────────────────
+
+TEST(EventBus, LateSubscriberMissesEarlierEvents) {
+    drone::util::EventBus<SimpleEvent> bus;
+    bus.publish(SimpleEvent{1});
+
+    int  received = 0;
+    auto sub      = bus.subscribe([&](const SimpleEvent& e) { received = e.value; });
+
+    EXPECT_EQ(received, 0);  // Late subscriber did not see earlier event
+
+    bus.publish(SimpleEvent{2});
+    EXPECT_EQ(received, 2);
+}
+
+// ── Multiple publishes ──────────────────────────────────────────────
+
+TEST(EventBus, MultiplePublishes) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::vector<int>                   received;
+
+    auto sub = bus.subscribe([&](const SimpleEvent& e) { received.push_back(e.value); });
+
+    bus.publish(SimpleEvent{1});
+    bus.publish(SimpleEvent{2});
+    bus.publish(SimpleEvent{3});
+
+    ASSERT_EQ(received.size(), 3u);
+    EXPECT_EQ(received[0], 1);
+    EXPECT_EQ(received[1], 2);
+    EXPECT_EQ(received[2], 3);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- Header-only `EventBus<Event>` template in `common/util/` for declarative intra-process composition
- RAII `Subscription` tokens with automatic unsubscribe on destruction
- Copy-on-write publish for re-entrancy safety (publish-from-handler, unsubscribe-during-iteration)
- Thread-safe: mutex-protected handler list, concurrent publish/subscribe safe

## Test plan
- [x] 17 new GTest tests (1389 → 1406)
- [x] Subscribe/publish round-trip
- [x] Multi-handler dispatch
- [x] RAII unsubscribe
- [x] Re-entrant publish (no deadlock)
- [x] Concurrent publish from 4 threads x 1000 events
- [x] Build: zero warnings, format clean

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)