### PR TITLE
feat(#291): ProcessBuilder pattern — extract wiring from main()

### DIFF
--- a/common/util/include/util/event_bus.h
+++ b/common/util/include/util/event_bus.h
@@ -1,0 +1,151 @@
+// common/util/include/util/event_bus.h
+// Lightweight per-process EventBus for intra-process declarative composition.
+//
+// Enables patterns like "on obstacle detected within 3m, trigger payload capture"
+// without a full reactive framework.  IPC remains pull-based (correct for real-time).
+//
+// Thread safety:
+//   - subscribe(), unsubscribe (via Subscription destructor), and publish()
+//     are all safe to call concurrently from any thread.
+//   - publish() uses copy-on-write: copies the handler list under lock, then
+//     iterates the copy outside the lock.  This allows publish-from-within-handler
+//     (re-entrancy) and unsubscribe-during-iteration without deadlock.
+//
+// Concurrency tier: std::mutex (non-hot-path shared state).
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace drone::util {
+
+// Forward declaration — Subscription must know EventBus<Event>.
+template<typename Event>
+class EventBus;
+
+/// RAII subscription token.  Automatically unsubscribes on destruction.
+/// Move-only — copying would create double-unsubscribe bugs.
+template<typename Event>
+class Subscription {
+public:
+    Subscription() = default;
+
+    ~Subscription() { unsubscribe(); }
+
+    // Move-only
+    Subscription(Subscription&& other) noexcept : bus_(other.bus_), id_(other.id_) {
+        other.bus_ = nullptr;
+        other.id_  = 0;
+    }
+
+    Subscription& operator=(Subscription&& other) noexcept {
+        if (this != &other) {
+            unsubscribe();
+            bus_       = other.bus_;
+            id_        = other.id_;
+            other.bus_ = nullptr;
+            other.id_  = 0;
+        }
+        return *this;
+    }
+
+    Subscription(const Subscription&)            = delete;
+    Subscription& operator=(const Subscription&) = delete;
+
+    /// Check if this subscription is active.
+    [[nodiscard]] bool is_active() const { return bus_ != nullptr; }
+
+    /// Explicitly unsubscribe (also called by destructor).
+    void unsubscribe() {
+        if (bus_) {
+            bus_->remove_handler(id_);
+            bus_ = nullptr;
+            id_  = 0;
+        }
+    }
+
+private:
+    friend class EventBus<Event>;
+
+    Subscription(EventBus<Event>* bus, uint64_t id) : bus_(bus), id_(id) {}
+
+    EventBus<Event>* bus_ = nullptr;
+    uint64_t         id_  = 0;
+};
+
+/// Lightweight typed event bus for intra-process composition.
+///
+/// Usage:
+///   struct ObstacleDetected { float distance_m; };
+///   EventBus<ObstacleDetected> bus;
+///   auto sub = bus.subscribe([](const ObstacleDetected& e) {
+///       if (e.distance_m < 3.0f) trigger_capture();
+///   });
+///   bus.publish(ObstacleDetected{2.5f});
+template<typename Event>
+class EventBus {
+public:
+    EventBus()  = default;
+    ~EventBus() = default;
+
+    // Non-copyable, non-movable (subscriptions hold raw pointer to bus).
+    EventBus(const EventBus&)            = delete;
+    EventBus& operator=(const EventBus&) = delete;
+    EventBus(EventBus&&)                 = delete;
+    EventBus& operator=(EventBus&&)      = delete;
+
+    /// Subscribe a handler.  Returns an RAII Subscription token that
+    /// automatically unsubscribes when destroyed or moved-from.
+    [[nodiscard]] Subscription<Event> subscribe(std::function<void(const Event&)> handler) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const uint64_t              id = next_id_++;
+        handlers_.push_back({id, std::move(handler)});
+        return Subscription<Event>(this, id);
+    }
+
+    /// Publish an event to all current subscribers.
+    /// Safe to call from within a handler (re-entrant) and from any thread.
+    void publish(const Event& event) {
+        // Copy-on-write: snapshot handler list under lock, iterate outside.
+        std::vector<HandlerEntry> snapshot;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            snapshot = handlers_;
+        }
+        for (const auto& entry : snapshot) {
+            entry.handler(event);
+        }
+    }
+
+    /// Number of active subscriptions (for testing/diagnostics).
+    [[nodiscard]] size_t subscriber_count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return handlers_.size();
+    }
+
+private:
+    friend class Subscription<Event>;
+
+    struct HandlerEntry {
+        uint64_t                          id      = 0;
+        std::function<void(const Event&)> handler = nullptr;
+    };
+
+    /// Remove a handler by subscription ID.  Called by Subscription destructor.
+    void remove_handler(uint64_t id) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        handlers_.erase(std::remove_if(handlers_.begin(), handlers_.end(),
+                                       [id](const HandlerEntry& e) { return e.id == id; }),
+                        handlers_.end());
+    }
+
+    mutable std::mutex        mutex_;
+    std::vector<HandlerEntry> handlers_;
+    uint64_t                  next_id_ = 1;
+};
+
+}  // namespace drone::util

--- a/common/util/include/util/process_context.h
+++ b/common/util/include/util/process_context.h
@@ -1,0 +1,127 @@
+// common/util/include/util/process_context.h
+// ProcessContext — shared boilerplate for all process main() functions.
+//
+// Every process has the same 20-line startup sequence: parse args, install
+// signal handler, init logging, load config, validate, create message bus.
+// init_process() captures that in one call, returning a ready-to-use context.
+//
+// Usage:
+//   static std::atomic<bool> g_running{true};
+//
+//   int main(int argc, char* argv[]) {
+//       auto ctx = drone::util::init_process(
+//           argc, argv, "payload_manager", g_running,
+//           drone::util::payload_manager_schema());
+//       if (!ctx.is_ok()) return ctx.error();
+//       auto& pc = ctx.value();
+//
+//       // ... domain-specific wiring using pc.cfg and pc.bus ...
+//       while (g_running.load(std::memory_order_relaxed)) { ... }
+//       drone::systemd::notify_stopping();
+//       return 0;
+//   }
+//
+// See: Issue #291 (Epic #284 — Platform Modularity)
+#pragma once
+
+#include "ipc/message_bus.h"
+#include "ipc/message_bus_factory.h"
+#include "ipc/zenoh_liveliness.h"
+#include "util/arg_parser.h"
+#include "util/config.h"
+#include "util/config_validator.h"
+#include "util/ilogger.h"
+#include "util/log_config.h"
+#include "util/result.h"
+#include "util/sd_notify.h"
+#include "util/signal_handler.h"
+
+#include <atomic>
+#include <string>
+
+#include <unistd.h>
+
+namespace drone::util {
+
+/// Shared context produced by init_process().
+/// Holds the common infrastructure every process needs after startup.
+/// Move-only (MessageBus is non-copyable).
+struct ProcessContext {
+    std::string          process_name;
+    Config               cfg;
+    ipc::MessageBus      bus;
+    std::atomic<bool>&   running;  // reference to the process's g_running flag
+    ipc::LivelinessToken liveliness;
+
+    // Parsed command-line args
+    ParsedArgs args;
+
+    // Non-copyable, movable
+    ProcessContext(ProcessContext&&) noexcept            = default;
+    ProcessContext& operator=(ProcessContext&&) noexcept = default;
+    ProcessContext(const ProcessContext&)                = delete;
+    ProcessContext& operator=(const ProcessContext&)     = delete;
+
+private:
+    friend Result<ProcessContext, int> init_process(int argc, char* argv[], const std::string& name,
+                                                    std::atomic<bool>&  running,
+                                                    const ConfigSchema& schema);
+
+    /// Private constructor — only init_process() can create a ProcessContext.
+    ProcessContext(std::string name_arg, Config cfg_arg, ipc::MessageBus bus_arg,
+                   std::atomic<bool>& running_ref, ipc::LivelinessToken token,
+                   ParsedArgs parsed_args)
+        : process_name(std::move(name_arg))
+        , cfg(std::move(cfg_arg))
+        , bus(std::move(bus_arg))
+        , running(running_ref)
+        , liveliness(std::move(token))
+        , args(std::move(parsed_args)) {}
+};
+
+/// Initialize the common boilerplate for any process.
+///
+/// Performs (in order):
+///   1. parse_args()
+///   2. SignalHandler::install()
+///   3. LogConfig::init()
+///   4. Config::load() + validate_or_exit()
+///   5. create_message_bus()
+///   6. LivelinessToken declaration
+///
+/// @param argc, argv    Command-line arguments.
+/// @param name          Process name (e.g. "payload_manager").
+/// @param running       Reference to the process's atomic shutdown flag.
+/// @param schema        ConfigSchema for validation.
+/// @return Result<ProcessContext, int> — ok with context, or err with exit code.
+[[nodiscard]] inline Result<ProcessContext, int> init_process(int argc, char* argv[],
+                                                              const std::string&  name,
+                                                              std::atomic<bool>&  running,
+                                                              const ConfigSchema& schema) {
+    auto args = parse_args(argc, argv, name.c_str());
+    if (args.help) {
+        return Result<ProcessContext, int>::err(0);
+    }
+
+    SignalHandler::install(running);
+    LogConfig::init(name, LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
+
+    Config cfg;
+    if (!cfg.load(args.config_path)) {
+        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
+    } else {
+        if (int rc = validate_or_exit(cfg, schema); rc != 0) {
+            return Result<ProcessContext, int>::err(rc);
+        }
+    }
+
+    DRONE_LOG_INFO("=== {} starting (PID {}) ===", name, getpid());
+
+    auto                 bus = ipc::create_message_bus(cfg);
+    ipc::LivelinessToken liveliness(name);
+
+    return Result<ProcessContext, int>::ok(ProcessContext(
+        name, std::move(cfg), std::move(bus), running, std::move(liveliness), std::move(args)));
+}
+
+}  // namespace drone::util

--- a/process1_video_capture/src/main.cpp
+++ b/process1_video_capture/src/main.cpp
@@ -5,18 +5,11 @@
 
 #include "hal/hal_factory.h"
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/scoped_timer.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -216,42 +209,31 @@ static void stereo_cam_thread(drone::hal::ICamera& left_cam, drone::hal::ICamera
 // main()
 // ═══════════════════════════════════════════════════════════
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "video_capture");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("video_capture", LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::video_capture_schema());
-            rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== Video Capture process starting (PID {}) ===", getpid());
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "video_capture", g_running,
+                                                drone::util::video_capture_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Create cameras via HAL factory ──────────────────────
     auto mission_cam =
-        drone::hal::create_camera(cfg, drone::cfg_key::video_capture::mission_cam::SECTION);
-    const auto m_w   = cfg.get<uint32_t>(drone::cfg_key::video_capture::mission_cam::WIDTH, 1920);
-    const auto m_h   = cfg.get<uint32_t>(drone::cfg_key::video_capture::mission_cam::HEIGHT, 1080);
-    const auto m_fps = cfg.get<int>(drone::cfg_key::video_capture::mission_cam::FPS, 30);
+        drone::hal::create_camera(ctx.cfg, drone::cfg_key::video_capture::mission_cam::SECTION);
+    const auto m_w = ctx.cfg.get<uint32_t>(drone::cfg_key::video_capture::mission_cam::WIDTH, 1920);
+    const auto m_h = ctx.cfg.get<uint32_t>(drone::cfg_key::video_capture::mission_cam::HEIGHT,
+                                           1080);
+    const auto m_fps = ctx.cfg.get<int>(drone::cfg_key::video_capture::mission_cam::FPS, 30);
     if (!mission_cam->open(m_w, m_h, m_fps)) {
         DRONE_LOG_ERROR("Failed to open mission camera ({}x{} @ {}fps)", m_w, m_h, m_fps);
         return 1;
     }
 
     auto stereo_left =
-        drone::hal::create_camera(cfg, drone::cfg_key::video_capture::stereo_cam::SECTION);
+        drone::hal::create_camera(ctx.cfg, drone::cfg_key::video_capture::stereo_cam::SECTION);
     auto stereo_right =
-        drone::hal::create_camera(cfg, drone::cfg_key::video_capture::stereo_cam::SECTION);
-    const auto s_w   = cfg.get<uint32_t>(drone::cfg_key::video_capture::stereo_cam::WIDTH, 640);
-    const auto s_h   = cfg.get<uint32_t>(drone::cfg_key::video_capture::stereo_cam::HEIGHT, 480);
-    const auto s_fps = cfg.get<int>(drone::cfg_key::video_capture::stereo_cam::FPS, 30);
+        drone::hal::create_camera(ctx.cfg, drone::cfg_key::video_capture::stereo_cam::SECTION);
+    const auto s_w = ctx.cfg.get<uint32_t>(drone::cfg_key::video_capture::stereo_cam::WIDTH, 640);
+    const auto s_h = ctx.cfg.get<uint32_t>(drone::cfg_key::video_capture::stereo_cam::HEIGHT, 480);
+    const auto s_fps = ctx.cfg.get<int>(drone::cfg_key::video_capture::stereo_cam::FPS, 30);
     if (!stereo_left->open(s_w, s_h, s_fps) || !stereo_right->open(s_w, s_h, s_fps)) {
         DRONE_LOG_ERROR("Failed to open stereo cameras ({}x{} @ {}fps)", s_w, s_h, s_fps);
         return 1;
@@ -260,19 +242,16 @@ int main(int argc, char* argv[]) {
     DRONE_LOG_INFO("Cameras: mission={}, stereo_l={}, stereo_r={}", mission_cam->name(),
                    stereo_left->name(), stereo_right->name());
 
-    // ── Create publishers via message bus factory ───────────
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("video_capture");
-
-    auto mission_pub = bus.advertise<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
+    // ── Create publishers ───────────────────────────────────
+    auto mission_pub =
+        ctx.bus.advertise<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
     if (!mission_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create publisher: {}", drone::ipc::topics::VIDEO_MISSION_CAM);
         return 1;
     }
 
-    auto stereo_pub = bus.advertise<drone::ipc::StereoFrame>(drone::ipc::topics::VIDEO_STEREO_CAM);
+    auto stereo_pub =
+        ctx.bus.advertise<drone::ipc::StereoFrame>(drone::ipc::topics::VIDEO_STEREO_CAM);
     if (!stereo_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create publisher: {}", drone::ipc::topics::VIDEO_STEREO_CAM);
         return 1;
@@ -286,8 +265,8 @@ int main(int argc, char* argv[]) {
 
     // ── Thread watchdog + health publisher ──────────────────
     drone::util::ThreadWatchdog watchdog;
-    auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_VIDEO_CAPTURE);
+    auto                        thread_health_pub = ctx.bus.advertise<drone::ipc::ThreadHealth>(
+        drone::ipc::topics::THREAD_HEALTH_VIDEO_CAPTURE);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "video_capture",
                                                         watchdog);
 

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -6,8 +6,6 @@
 #include "hal/hal_factory.h"
 #include "hal/iradar.h"
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
 #include "perception/detector_interface.h"
 #include "perception/fusion_engine.h"
 #include "perception/ifusion_engine.h"
@@ -15,16 +13,11 @@
 #include "perception/kalman_tracker.h"
 #include "perception/types.h"
 #include "perception/ukf_fusion_engine.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/scoped_timer.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -372,32 +365,15 @@ static void radar_read_thread(drone::hal::IRadar&                               
 // main()
 // ═══════════════════════════════════════════════════════════
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "perception");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("perception", LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::perception_schema());
-            rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== Perception process starting (PID {}) ===", getpid());
-
-    // ── Create message bus (config-driven: shm or zenoh) ───
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("perception");
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "perception", g_running,
+                                                drone::util::perception_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Subscribe to video frames from Process 1 ────────────
-    auto video_sub = bus.subscribe<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
+    auto video_sub =
+        ctx.bus.subscribe<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
     if (!video_sub->is_connected()) {
         DRONE_LOG_ERROR("Cannot connect to video channel — is video_capture running?");
         return 1;
@@ -405,7 +381,7 @@ int main(int argc, char* argv[]) {
 
     // ── Create publisher for detected objects → Process 4 ───
     auto det_pub =
-        bus.advertise<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
+        ctx.bus.advertise<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
     if (!det_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create publisher: {}", drone::ipc::topics::DETECTED_OBJECTS);
         return 1;
@@ -413,14 +389,14 @@ int main(int argc, char* argv[]) {
 
     // ── Create detector from config ────────────────────────────
     std::string detector_backend =
-        cfg.get<std::string>(drone::cfg_key::perception::detector::BACKEND, "simulated");
-    auto detector = create_detector(detector_backend, &cfg);
+        ctx.cfg.get<std::string>(drone::cfg_key::perception::detector::BACKEND, "simulated");
+    auto detector = create_detector(detector_backend, &ctx.cfg);
     DRONE_LOG_INFO("[Perception] Detector backend: {} ({})", detector_backend, detector->name());
 
     // ── Create tracker from config ────────────────────────────
-    std::string tracker_backend = cfg.get<std::string>(drone::cfg_key::perception::tracker::BACKEND,
-                                                       "bytetrack");
-    auto        tracker_result  = create_tracker(tracker_backend, &cfg);
+    std::string tracker_backend =
+        ctx.cfg.get<std::string>(drone::cfg_key::perception::tracker::BACKEND, "bytetrack");
+    auto tracker_result = create_tracker(tracker_backend, &ctx.cfg);
     if (!tracker_result.is_ok()) {
         DRONE_LOG_ERROR("[Perception] Failed to create tracker: {}",
                         tracker_result.error().message());
@@ -432,35 +408,40 @@ int main(int argc, char* argv[]) {
     // ── Create fusion engine from config ────────────────────
     CalibrationData calib;
     calib.camera_intrinsics       = Eigen::Matrix3f::Identity();
-    calib.camera_intrinsics(0, 0) = cfg.get<float>(drone::cfg_key::perception::fusion::FX, 500.0f);
-    calib.camera_intrinsics(1, 1) = cfg.get<float>(drone::cfg_key::perception::fusion::FY, 500.0f);
-    calib.camera_intrinsics(0, 2) = cfg.get<float>(drone::cfg_key::perception::fusion::CX, 960.0f);
-    calib.camera_intrinsics(1, 2) = cfg.get<float>(drone::cfg_key::perception::fusion::CY, 540.0f);
-    calib.camera_height_m = cfg.get<float>(drone::cfg_key::perception::fusion::CAMERA_HEIGHT_M,
-                                           1.5f);
+    calib.camera_intrinsics(0, 0) = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::FX,
+                                                       500.0f);
+    calib.camera_intrinsics(1, 1) = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::FY,
+                                                       500.0f);
+    calib.camera_intrinsics(0, 2) = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::CX,
+                                                       960.0f);
+    calib.camera_intrinsics(1, 2) = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::CY,
+                                                       540.0f);
+    calib.camera_height_m = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::CAMERA_HEIGHT_M,
+                                               1.5f);
     calib.assumed_obstacle_height_m =
-        cfg.get<float>(drone::cfg_key::perception::fusion::ASSUMED_OBSTACLE_HEIGHT_M, 3.0f);
-    calib.depth_scale = cfg.get<float>(drone::cfg_key::perception::fusion::DEPTH_SCALE, 0.7f);
+        ctx.cfg.get<float>(drone::cfg_key::perception::fusion::ASSUMED_OBSTACLE_HEIGHT_M, 3.0f);
+    calib.depth_scale = ctx.cfg.get<float>(drone::cfg_key::perception::fusion::DEPTH_SCALE, 0.7f);
 
-    std::string fusion_backend = cfg.get<std::string>(drone::cfg_key::perception::fusion::BACKEND,
-                                                      "camera_only");
-    auto        fusion_engine  = create_fusion_engine(fusion_backend, calib, &cfg);
+    std::string fusion_backend =
+        ctx.cfg.get<std::string>(drone::cfg_key::perception::fusion::BACKEND, "camera_only");
+    auto fusion_engine = create_fusion_engine(fusion_backend, calib, &ctx.cfg);
     DRONE_LOG_INFO("[Perception] Fusion   backend: {} ({})", fusion_backend, fusion_engine->name());
 
     // ── Create radar HAL + publisher (optional) ────────────
-    bool radar_enabled = cfg.get<bool>(drone::cfg_key::perception::radar::ENABLED, false);
+    bool radar_enabled = ctx.cfg.get<bool>(drone::cfg_key::perception::radar::ENABLED, false);
     std::unique_ptr<drone::hal::IRadar>                                     radar;
     std::unique_ptr<drone::ipc::IPublisher<drone::ipc::RadarDetectionList>> radar_pub;
-    int radar_update_rate_hz = cfg.get<int>(drone::cfg_key::perception::radar::UPDATE_RATE_HZ, 20);
+    int radar_update_rate_hz = ctx.cfg.get<int>(drone::cfg_key::perception::radar::UPDATE_RATE_HZ,
+                                                20);
 
     if (radar_enabled) {
         try {
-            radar = drone::hal::create_radar(cfg, drone::cfg_key::perception::radar::SECTION);
+            radar = drone::hal::create_radar(ctx.cfg, drone::cfg_key::perception::radar::SECTION);
             if (!radar->init()) {
                 DRONE_LOG_ERROR("[Radar] HAL init() failed — radar disabled");
                 radar.reset();
             } else {
-                radar_pub = bus.advertise<drone::ipc::RadarDetectionList>(
+                radar_pub = ctx.bus.advertise<drone::ipc::RadarDetectionList>(
                     drone::ipc::topics::RADAR_DETECTIONS);
                 DRONE_LOG_INFO("[Perception] Radar HAL: {} — publishing to {}", radar->name(),
                                drone::ipc::topics::RADAR_DETECTIONS);
@@ -485,14 +466,14 @@ int main(int argc, char* argv[]) {
                           std::ref(tracker_to_fusion), std::ref(g_running), std::ref(*tracker));
 
     // Subscribe to drone pose for the camera→world transform in the fusion thread
-    auto pose_sub = bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+    auto pose_sub = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
 
     // Subscribe to radar detections for multi-sensor fusion
     auto radar_sub =
-        bus.subscribe<drone::ipc::RadarDetectionList>(drone::ipc::topics::RADAR_DETECTIONS);
+        ctx.bus.subscribe<drone::ipc::RadarDetectionList>(drone::ipc::topics::RADAR_DETECTIONS);
 
     const int fusion_rate_hz =
-        std::clamp(cfg.get<int>(drone::cfg_key::perception::fusion::RATE_HZ, 30), 1, 100);
+        std::clamp(ctx.cfg.get<int>(drone::cfg_key::perception::fusion::RATE_HZ, 30), 1, 100);
     std::thread t_fusion(fusion_thread, std::ref(tracker_to_fusion), std::ref(*det_pub),
                          std::ref(*pose_sub), std::ref(*radar_sub), std::ref(g_running),
                          std::ref(*fusion_engine), fusion_rate_hz);
@@ -509,7 +490,7 @@ int main(int argc, char* argv[]) {
     // ── Thread watchdog + health publisher ──────────────────
     drone::util::ThreadWatchdog watchdog;
     auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_PERCEPTION);
+        ctx.bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_PERCEPTION);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "perception", watchdog);
 
     DRONE_LOG_INFO("All perception threads started — READY");

--- a/process3_slam_vio_nav/src/main.cpp
+++ b/process3_slam_vio_nav/src/main.cpp
@@ -15,22 +15,15 @@
 
 #include "hal/hal_factory.h"
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
 #include "slam/ivio_backend.h"
 #include "slam/types.h"
 #include "slam/vio_types.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/rate_clamp.h"
 #include "util/scoped_timer.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -313,35 +306,19 @@ static void pose_publisher_thread(drone::ipc::IPublisher<drone::ipc::Pose>& pose
 // main()
 // ═══════════════════════════════════════════════════════════
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "slam_vio_nav");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("slam_vio_nav", LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::slam_schema()); rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== SLAM/VIO/Nav process starting (PID {}) ===", getpid());
-
-    // ── Create message bus ──────────────────────────────────
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("slam_vio_nav");
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "slam_vio_nav", g_running,
+                                                drone::util::slam_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // Subscribe to stereo camera from Process 1
-    auto stereo_sub = bus.subscribe<drone::ipc::StereoFrame>(drone::ipc::topics::VIDEO_STEREO_CAM);
+    auto stereo_sub =
+        ctx.bus.subscribe<drone::ipc::StereoFrame>(drone::ipc::topics::VIDEO_STEREO_CAM);
     // With Zenoh, is_connected() only becomes true after the first sample
     // arrives; we cannot use it as a startup gate.  Log a warning and continue —
     // data will arrive once video_capture starts publishing.
-    const auto ipc_backend = cfg.get<std::string>(drone::cfg_key::IPC_BACKEND, "zenoh");
+    const auto ipc_backend = ctx.cfg.get<std::string>(drone::cfg_key::IPC_BACKEND, "zenoh");
     if (!stereo_sub->is_connected()) {
         if (ipc_backend == "shm") {
             // Should never happen — shm backend was removed, factory falls back
@@ -353,7 +330,7 @@ int main(int argc, char* argv[]) {
     }
 
     // Create pose output publisher
-    auto pose_pub = bus.advertise<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+    auto pose_pub = ctx.bus.advertise<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
     if (!pose_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create pose publisher");
         return 1;
@@ -367,12 +344,12 @@ int main(int argc, char* argv[]) {
 
     // ── Rate clamping (safety: prevent runaway loops or undersampling) ──
     const int imu_rate =
-        drone::util::clamp_imu_rate(cfg.get<int>(drone::cfg_key::slam::IMU_RATE_HZ, 400));
+        drone::util::clamp_imu_rate(ctx.cfg.get<int>(drone::cfg_key::slam::IMU_RATE_HZ, 400));
     const int vio_rate =
-        drone::util::clamp_vio_rate(cfg.get<int>(drone::cfg_key::slam::VIO_RATE_HZ, 100));
+        drone::util::clamp_vio_rate(ctx.cfg.get<int>(drone::cfg_key::slam::VIO_RATE_HZ, 100));
 
     // Create IMU via HAL factory
-    auto imu = drone::hal::create_imu_source(cfg, drone::cfg_key::slam::imu::SECTION);
+    auto imu = drone::hal::create_imu_source(ctx.cfg, drone::cfg_key::slam::imu::SECTION);
     if (!imu->init(imu_rate)) {
         DRONE_LOG_ERROR("Failed to initialise IMU source — check config");
         return 1;
@@ -380,30 +357,32 @@ int main(int argc, char* argv[]) {
     DRONE_LOG_INFO("IMU source: {} at {} Hz", imu->name(), imu_rate);
 
     // Create VIO backend via factory
-    auto vio_backend_name = cfg.get<std::string>(drone::cfg_key::slam::vio::BACKEND, "simulated");
-    auto vio_gz_topic     = cfg.get<std::string>(drone::cfg_key::slam::vio::GZ_TOPIC,
-                                                 "/model/x500_companion_0/odometry");
+    auto vio_backend_name = ctx.cfg.get<std::string>(drone::cfg_key::slam::vio::BACKEND,
+                                                     "simulated");
+    auto vio_gz_topic     = ctx.cfg.get<std::string>(drone::cfg_key::slam::vio::GZ_TOPIC,
+                                                     "/model/x500_companion_0/odometry");
     StereoCalibration calib;
-    calib.fx       = cfg.get<double>(drone::cfg_key::slam::stereo::FX, 350.0);
-    calib.fy       = cfg.get<double>(drone::cfg_key::slam::stereo::FY, 350.0);
-    calib.cx       = cfg.get<double>(drone::cfg_key::slam::stereo::CX, 320.0);
-    calib.cy       = cfg.get<double>(drone::cfg_key::slam::stereo::CY, 240.0);
-    calib.baseline = cfg.get<double>(drone::cfg_key::slam::stereo::BASELINE, 0.12);
+    calib.fx       = ctx.cfg.get<double>(drone::cfg_key::slam::stereo::FX, 350.0);
+    calib.fy       = ctx.cfg.get<double>(drone::cfg_key::slam::stereo::FY, 350.0);
+    calib.cx       = ctx.cfg.get<double>(drone::cfg_key::slam::stereo::CX, 320.0);
+    calib.cy       = ctx.cfg.get<double>(drone::cfg_key::slam::stereo::CY, 240.0);
+    calib.baseline = ctx.cfg.get<double>(drone::cfg_key::slam::stereo::BASELINE, 0.12);
 
     ImuNoiseParams imu_params;
-    imu_params.gyro_noise_density  = cfg.get<double>(drone::cfg_key::slam::imu::GYRO_NOISE_DENSITY,
-                                                     0.004);
-    imu_params.gyro_random_walk    = cfg.get<double>(drone::cfg_key::slam::imu::GYRO_RANDOM_WALK,
-                                                     2.2e-5);
-    imu_params.accel_noise_density = cfg.get<double>(drone::cfg_key::slam::imu::ACCEL_NOISE_DENSITY,
-                                                     0.012);
-    imu_params.accel_random_walk   = cfg.get<double>(drone::cfg_key::slam::imu::ACCEL_RANDOM_WALK,
-                                                     8.0e-5);
+    imu_params.gyro_noise_density =
+        ctx.cfg.get<double>(drone::cfg_key::slam::imu::GYRO_NOISE_DENSITY, 0.004);
+    imu_params.gyro_random_walk = ctx.cfg.get<double>(drone::cfg_key::slam::imu::GYRO_RANDOM_WALK,
+                                                      2.2e-5);
+    imu_params.accel_noise_density =
+        ctx.cfg.get<double>(drone::cfg_key::slam::imu::ACCEL_NOISE_DENSITY, 0.012);
+    imu_params.accel_random_walk = ctx.cfg.get<double>(drone::cfg_key::slam::imu::ACCEL_RANDOM_WALK,
+                                                       8.0e-5);
 
-    const float  sim_speed_mps  = cfg.get<float>(drone::cfg_key::slam::vio::SIM_SPEED_MPS, 3.0f);
-    const double good_trace_max = cfg.get<double>(drone::cfg_key::slam::vio::GOOD_TRACE_MAX, 0.1);
-    const double degraded_trace_max = cfg.get<double>(drone::cfg_key::slam::vio::DEGRADED_TRACE_MAX,
-                                                      1.0);
+    const float  sim_speed_mps = ctx.cfg.get<float>(drone::cfg_key::slam::vio::SIM_SPEED_MPS, 3.0f);
+    const double good_trace_max = ctx.cfg.get<double>(drone::cfg_key::slam::vio::GOOD_TRACE_MAX,
+                                                      0.1);
+    const double degraded_trace_max =
+        ctx.cfg.get<double>(drone::cfg_key::slam::vio::DEGRADED_TRACE_MAX, 1.0);
     auto vio = drone::slam::create_vio_backend(vio_backend_name, calib, imu_params, vio_gz_topic,
                                                sim_speed_mps, good_trace_max, degraded_trace_max);
     DRONE_LOG_INFO("VIO backend: {} (sim_speed={:.1f} m/s, quality: good<={:.2f} degraded<={:.2f})",
@@ -416,14 +395,14 @@ int main(int argc, char* argv[]) {
     // get pose from actual sensors and ignore set_trajectory_target().
     std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::TrajectoryCmd>> traj_sub;
     if (vio_backend_name == "simulated") {
-        traj_sub = bus.subscribe<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
+        traj_sub = ctx.bus.subscribe<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
         DRONE_LOG_INFO("Subscribed to {} for simulated VIO target tracking",
                        drone::ipc::topics::TRAJECTORY_CMD);
     }
 
     // Subscribe to fault overrides for VIO quality injection
     auto fault_sub =
-        bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
+        ctx.bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
 
     // Launch threads
     std::thread t_vio(vio_pipeline_thread, std::ref(*stereo_sub), std::ref(*vio),
@@ -436,7 +415,7 @@ int main(int argc, char* argv[]) {
     // ── Thread watchdog + health publisher ──────────────────
     drone::util::ThreadWatchdog watchdog;
     auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_SLAM_VIO_NAV);
+        ctx.bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_SLAM_VIO_NAV);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "slam_vio_nav",
                                                         watchdog);
 

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -4,8 +4,6 @@
 // Sends FC commands (arm, takeoff, mode) to comms via FCCommand.
 
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
 #include "planner/fault_manager.h"
 #include "planner/fault_response_executor.h"
 #include "planner/gcs_command_handler.h"
@@ -18,17 +16,12 @@
 #include "planner/obstacle_avoider_3d.h"
 #include "planner/planner_factory.h"
 #include "planner/static_obstacle_layer.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/correlation.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/scoped_timer.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -66,63 +59,47 @@ static void send_fc_command(drone::ipc::IPublisher<drone::ipc::FCCommand>& pub,
 // main()
 // ═══════════════════════════════════════════════════════════
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "mission_planner");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("mission_planner", LogConfig::resolve_log_dir(), args.log_level,
-                    args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::mission_planner_schema());
-            rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== Mission Planner starting (PID {}) ===", getpid());
-
-    // ── Create message bus (config-driven) ───────────────────
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("mission_planner");
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "mission_planner", g_running,
+                                                drone::util::mission_planner_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Subscribe to inputs ─────────────────────────────────
-    auto pose_sub = bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+    auto pose_sub = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
     if (!pose_sub->is_connected()) {
         DRONE_LOG_ERROR("Cannot connect to SLAM pose");
         return 1;
     }
 
     auto obj_sub =
-        bus.subscribe<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
+        ctx.bus.subscribe<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
     if (!obj_sub->is_connected()) {
         DRONE_LOG_ERROR("Cannot connect to detected objects");
         return 1;
     }
 
-    auto fc_state_sub = bus.subscribe<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
+    auto fc_state_sub = ctx.bus.subscribe<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
     if (!fc_state_sub->is_connected()) {
         DRONE_LOG_ERROR("Cannot connect to FC state — comms may not be running");
         return 1;
     }
 
-    auto gcs_sub = bus.subscribe_optional<drone::ipc::GCSCommand>(drone::ipc::topics::GCS_COMMANDS);
+    auto gcs_sub =
+        ctx.bus.subscribe_optional<drone::ipc::GCSCommand>(drone::ipc::topics::GCS_COMMANDS);
     auto mission_upload_sub =
-        bus.subscribe_optional<drone::ipc::MissionUpload>(drone::ipc::topics::MISSION_UPLOAD);
+        ctx.bus.subscribe_optional<drone::ipc::MissionUpload>(drone::ipc::topics::MISSION_UPLOAD);
     auto health_sub =
-        bus.subscribe_optional<drone::ipc::SystemHealth>(drone::ipc::topics::SYSTEM_HEALTH);
+        ctx.bus.subscribe_optional<drone::ipc::SystemHealth>(drone::ipc::topics::SYSTEM_HEALTH);
 
     // ── Create publishers ───────────────────────────────────
-    auto status_pub = bus.advertise<drone::ipc::MissionStatus>(drone::ipc::topics::MISSION_STATUS);
-    auto traj_pub   = bus.advertise<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
+    auto status_pub =
+        ctx.bus.advertise<drone::ipc::MissionStatus>(drone::ipc::topics::MISSION_STATUS);
+    auto traj_pub =
+        ctx.bus.advertise<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
     auto payload_pub =
-        bus.advertise<drone::ipc::PayloadCommand>(drone::ipc::topics::PAYLOAD_COMMANDS);
-    auto fc_cmd_pub = bus.advertise<drone::ipc::FCCommand>(drone::ipc::topics::FC_COMMANDS);
+        ctx.bus.advertise<drone::ipc::PayloadCommand>(drone::ipc::topics::PAYLOAD_COMMANDS);
+    auto fc_cmd_pub = ctx.bus.advertise<drone::ipc::FCCommand>(drone::ipc::topics::FC_COMMANDS);
 
     if (!status_pub->is_ready() || !traj_pub->is_ready() || !payload_pub->is_ready() ||
         !fc_cmd_pub->is_ready()) {
@@ -132,15 +109,15 @@ int main(int argc, char* argv[]) {
 
     // ── Load mission from config or use defaults ────────────
     const float overshoot_proximity =
-        cfg.get<float>(drone::cfg_key::mission_planner::OVERSHOOT_PROXIMITY_FACTOR, 3.0f);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::OVERSHOOT_PROXIMITY_FACTOR, 3.0f);
     MissionFSM fsm(overshoot_proximity);
-    auto       wp_json = cfg.section(drone::cfg_key::mission_planner::WAYPOINTS);
+    auto       wp_json = ctx.cfg.section(drone::cfg_key::mission_planner::WAYPOINTS);
     if (wp_json.is_array() && !wp_json.empty()) {
         std::vector<Waypoint> waypoints;
         const float           default_radius =
-            cfg.get<float>(drone::cfg_key::mission_planner::ACCEPTANCE_RADIUS_M, 2.0f);
+            ctx.cfg.get<float>(drone::cfg_key::mission_planner::ACCEPTANCE_RADIUS_M, 2.0f);
         const float default_speed =
-            cfg.get<float>(drone::cfg_key::mission_planner::CRUISE_SPEED_MPS, 2.0f);
+            ctx.cfg.get<float>(drone::cfg_key::mission_planner::CRUISE_SPEED_MPS, 2.0f);
         for (const auto& w : wp_json) {
             waypoints.push_back({w.value("x", 0.0f), w.value("y", 0.0f), w.value("z", 5.0f),
                                  w.value("yaw", 0.0f), default_radius,
@@ -159,91 +136,92 @@ int main(int argc, char* argv[]) {
     fsm.on_arm();  // IDLE → PREFLIGHT
 
     // ── Create path planner and obstacle avoider strategies ──
-    const float takeoff_alt = cfg.get<float>(drone::cfg_key::mission_planner::TAKEOFF_ALTITUDE_M,
-                                             10.0f);
-    const float influence_radius = cfg.get<float>(
+    const float takeoff_alt =
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::TAKEOFF_ALTITUDE_M, 10.0f);
+    const float influence_radius = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::obstacle_avoidance::INFLUENCE_RADIUS_M, 5.0f);
-    const float repulsive_gain =
-        cfg.get<float>(drone::cfg_key::mission_planner::obstacle_avoidance::REPULSIVE_GAIN, 2.0f);
-    const int update_rate_hz = cfg.get<int>(drone::cfg_key::mission_planner::UPDATE_RATE_HZ, 10);
+    const float repulsive_gain = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::obstacle_avoidance::REPULSIVE_GAIN, 2.0f);
+    const int update_rate_hz = ctx.cfg.get<int>(drone::cfg_key::mission_planner::UPDATE_RATE_HZ,
+                                                10);
     const int loop_sleep_ms  = std::max(1, update_rate_hz > 0 ? 1000 / update_rate_hz : 100);
 
-    auto planner_backend = cfg.get<std::string>(
+    auto planner_backend = ctx.cfg.get<std::string>(
         drone::cfg_key::mission_planner::path_planner::BACKEND, "potential_field");
     drone::planner::GridPlannerConfig planner_cfg;
-    planner_cfg.resolution_m = cfg.get<float>(
+    planner_cfg.resolution_m = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::RESOLUTION_M, planner_cfg.resolution_m);
-    planner_cfg.grid_extent_m = cfg.get<float>(
+    planner_cfg.grid_extent_m = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::GRID_EXTENT_M, planner_cfg.grid_extent_m);
     planner_cfg.inflation_radius_m =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::INFLATION_RADIUS_M,
-                       planner_cfg.inflation_radius_m);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::INFLATION_RADIUS_M,
+                           planner_cfg.inflation_radius_m);
     planner_cfg.replan_interval_s =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::REPLAN_INTERVAL_S,
-                       planner_cfg.replan_interval_s);
-    planner_cfg.path_speed_mps = cfg.get<float>(
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::REPLAN_INTERVAL_S,
+                           planner_cfg.replan_interval_s);
+    planner_cfg.path_speed_mps = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::PATH_SPEED_MPS, planner_cfg.path_speed_mps);
     planner_cfg.smoothing_alpha =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SMOOTHING_ALPHA,
-                       planner_cfg.smoothing_alpha);
-    planner_cfg.max_iterations = cfg.get<int>(
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SMOOTHING_ALPHA,
+                           planner_cfg.smoothing_alpha);
+    planner_cfg.max_iterations = ctx.cfg.get<int>(
         drone::cfg_key::mission_planner::path_planner::MAX_ITERATIONS, planner_cfg.max_iterations);
     planner_cfg.max_search_time_ms =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::MAX_SEARCH_TIME_MS,
-                       planner_cfg.max_search_time_ms);
-    planner_cfg.ramp_dist_m = cfg.get<float>(
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::MAX_SEARCH_TIME_MS,
+                           planner_cfg.max_search_time_ms);
+    planner_cfg.ramp_dist_m = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::RAMP_DIST_M, planner_cfg.ramp_dist_m);
-    planner_cfg.min_speed_mps = cfg.get<float>(
+    planner_cfg.min_speed_mps = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::MIN_SPEED_MPS, planner_cfg.min_speed_mps);
     planner_cfg.snap_search_radius =
-        cfg.get<int>(drone::cfg_key::mission_planner::path_planner::SNAP_SEARCH_RADIUS,
-                     planner_cfg.snap_search_radius);
+        ctx.cfg.get<int>(drone::cfg_key::mission_planner::path_planner::SNAP_SEARCH_RADIUS,
+                         planner_cfg.snap_search_radius);
 
     // Occupancy-grid-specific settings: scenario configs use occupancy_grid.* keys
     // to configure these fields instead of the path_planner.* defaults.
-    planner_cfg.resolution_m = cfg.get<float>(
+    planner_cfg.resolution_m = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::occupancy_grid::RESOLUTION_M, planner_cfg.resolution_m);
     planner_cfg.inflation_radius_m =
-        cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::INFLATION_RADIUS_M,
-                       planner_cfg.inflation_radius_m);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::INFLATION_RADIUS_M,
+                           planner_cfg.inflation_radius_m);
     planner_cfg.cell_ttl_s =
-        cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::DYNAMIC_OBSTACLE_TTL_S,
-                       planner_cfg.cell_ttl_s);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::DYNAMIC_OBSTACLE_TTL_S,
+                           planner_cfg.cell_ttl_s);
     planner_cfg.min_confidence =
-        cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::MIN_CONFIDENCE,
-                       planner_cfg.min_confidence);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::MIN_CONFIDENCE,
+                           planner_cfg.min_confidence);
     planner_cfg.promotion_hits =
-        cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::PROMOTION_HITS,
-                     planner_cfg.promotion_hits);
+        ctx.cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::PROMOTION_HITS,
+                         planner_cfg.promotion_hits);
     planner_cfg.radar_promotion_hits = static_cast<uint32_t>(
-        cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::RADAR_PROMOTION_HITS,
-                     static_cast<int>(planner_cfg.radar_promotion_hits)));
-    planner_cfg.min_promotion_depth_confidence = cfg.get<float>(
+        ctx.cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::RADAR_PROMOTION_HITS,
+                         static_cast<int>(planner_cfg.radar_promotion_hits)));
+    planner_cfg.min_promotion_depth_confidence = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::occupancy_grid::MIN_PROMOTION_DEPTH_CONFIDENCE,
         planner_cfg.min_promotion_depth_confidence);
     planner_cfg.max_static_cells =
-        cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::MAX_STATIC_CELLS,
-                     planner_cfg.max_static_cells);
+        ctx.cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::MAX_STATIC_CELLS,
+                         planner_cfg.max_static_cells);
     // Prediction config — under occupancy_grid.* for consistency with other grid params
     planner_cfg.prediction_enabled =
-        cfg.get<bool>(drone::cfg_key::mission_planner::occupancy_grid::PREDICTION_ENABLED,
-                      planner_cfg.prediction_enabled);
+        ctx.cfg.get<bool>(drone::cfg_key::mission_planner::occupancy_grid::PREDICTION_ENABLED,
+                          planner_cfg.prediction_enabled);
     planner_cfg.prediction_dt_s =
-        cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::PREDICTION_DT_S,
-                       planner_cfg.prediction_dt_s);
-    planner_cfg.z_band_cells = cfg.get<int>(
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::occupancy_grid::PREDICTION_DT_S,
+                           planner_cfg.prediction_dt_s);
+    planner_cfg.z_band_cells = ctx.cfg.get<int>(
         drone::cfg_key::mission_planner::path_planner::Z_BAND_CELLS, planner_cfg.z_band_cells);
-    planner_cfg.look_ahead_m = cfg.get<float>(
+    planner_cfg.look_ahead_m = ctx.cfg.get<float>(
         drone::cfg_key::mission_planner::path_planner::LOOK_AHEAD_M, planner_cfg.look_ahead_m);
     planner_cfg.yaw_towards_travel =
-        cfg.get<bool>(drone::cfg_key::mission_planner::path_planner::YAW_TOWARDS_TRAVEL,
-                      planner_cfg.yaw_towards_travel);
+        ctx.cfg.get<bool>(drone::cfg_key::mission_planner::path_planner::YAW_TOWARDS_TRAVEL,
+                          planner_cfg.yaw_towards_travel);
     planner_cfg.yaw_smoothing_rate =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::YAW_SMOOTHING_RATE,
-                       planner_cfg.yaw_smoothing_rate);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::YAW_SMOOTHING_RATE,
+                           planner_cfg.yaw_smoothing_rate);
     planner_cfg.snap_approach_bias =
-        cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SNAP_APPROACH_BIAS,
-                       planner_cfg.snap_approach_bias);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SNAP_APPROACH_BIAS,
+                           planner_cfg.snap_approach_bias);
 
     auto path_planner = drone::planner::create_path_planner(planner_backend, planner_cfg);
     DRONE_LOG_INFO("Path planner: {}", path_planner->name());
@@ -251,19 +229,19 @@ int main(int argc, char* argv[]) {
 
     // ── HD-map static obstacles ─────────────────────────────
     StaticObstacleLayer obstacle_layer;
-    obstacle_layer.load(cfg, grid_planner);
+    obstacle_layer.load(ctx.cfg, grid_planner);
 
-    auto avoider_backend = cfg.get<std::string>(
+    auto avoider_backend = ctx.cfg.get<std::string>(
         drone::cfg_key::mission_planner::obstacle_avoider::BACKEND, "potential_field");
     auto avoider = drone::planner::create_obstacle_avoider(avoider_backend, influence_radius,
-                                                           repulsive_gain, &cfg);
+                                                           repulsive_gain, &ctx.cfg);
     DRONE_LOG_INFO("Obstacle avoider: {}", avoider->name());
 
     // ── Geofence setup ─────────────────────────────────────
     Geofence   geofence;
     const bool geofence_cfg_enabled =
-        cfg.get<bool>(drone::cfg_key::mission_planner::geofence::ENABLED, true);
-    auto fence_json = cfg.section(drone::cfg_key::mission_planner::geofence::POLYGON);
+        ctx.cfg.get<bool>(drone::cfg_key::mission_planner::geofence::ENABLED, true);
+    auto fence_json = ctx.cfg.section(drone::cfg_key::mission_planner::geofence::POLYGON);
     if (geofence_cfg_enabled && fence_json.is_array() && fence_json.size() >= 3) {
         std::vector<GeoVertex> vertices;
         for (const auto& v : fence_json) {
@@ -271,19 +249,19 @@ int main(int argc, char* argv[]) {
         }
         geofence.set_polygon(vertices);
         float alt_floor =
-            cfg.get<float>(drone::cfg_key::mission_planner::geofence::ALTITUDE_FLOOR_M, 0.0f);
-        float alt_ceiling =
-            cfg.get<float>(drone::cfg_key::mission_planner::geofence::ALTITUDE_CEILING_M, 120.0f);
+            ctx.cfg.get<float>(drone::cfg_key::mission_planner::geofence::ALTITUDE_FLOOR_M, 0.0f);
+        float alt_ceiling = ctx.cfg.get<float>(
+            drone::cfg_key::mission_planner::geofence::ALTITUDE_CEILING_M, 120.0f);
         geofence.set_altitude_limits(alt_floor, alt_ceiling);
         geofence.set_warning_margin(
-            cfg.get<float>(drone::cfg_key::mission_planner::geofence::WARNING_MARGIN_M, 5.0f));
-        geofence.set_altitude_tolerance(
-            cfg.get<float>(drone::cfg_key::mission_planner::geofence::ALTITUDE_TOLERANCE_M, 0.5f));
+            ctx.cfg.get<float>(drone::cfg_key::mission_planner::geofence::WARNING_MARGIN_M, 5.0f));
+        geofence.set_altitude_tolerance(ctx.cfg.get<float>(
+            drone::cfg_key::mission_planner::geofence::ALTITUDE_TOLERANCE_M, 0.5f));
         geofence.enable(true);
         DRONE_LOG_INFO(
             "Geofence: {} vertices, alt [{:.0f}, {:.0f}]m, margin {:.0f}m", vertices.size(),
             alt_floor, alt_ceiling,
-            cfg.get<float>(drone::cfg_key::mission_planner::geofence::WARNING_MARGIN_M, 5.0f));
+            ctx.cfg.get<float>(drone::cfg_key::mission_planner::geofence::WARNING_MARGIN_M, 5.0f));
     } else {
         DRONE_LOG_INFO("Geofence: disabled ({})",
                        geofence_cfg_enabled ? "no polygon configured" : "disabled by config");
@@ -291,23 +269,23 @@ int main(int argc, char* argv[]) {
 
     // ── Create extracted subsystems ─────────────────────────
     const float rtl_acceptance_m =
-        cfg.get<float>(drone::cfg_key::mission_planner::RTL_ACCEPTANCE_RADIUS_M, 1.5f);
-    const float landed_alt_m  = cfg.get<float>(drone::cfg_key::mission_planner::LANDED_ALTITUDE_M,
-                                               0.5f);
-    const int rtl_min_dwell_s = cfg.get<int>(drone::cfg_key::mission_planner::RTL_MIN_DWELL_SECONDS,
-                                             5);
-    const float survey_duration = cfg.get<float>(drone::cfg_key::mission_planner::SURVEY_DURATION_S,
-                                                 0.0f);
-    const float survey_yaw_rate = cfg.get<float>(drone::cfg_key::mission_planner::SURVEY_YAW_RATE,
-                                                 0.3f);
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::RTL_ACCEPTANCE_RADIUS_M, 1.5f);
+    const float landed_alt_m =
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::LANDED_ALTITUDE_M, 0.5f);
+    const int rtl_min_dwell_s =
+        ctx.cfg.get<int>(drone::cfg_key::mission_planner::RTL_MIN_DWELL_SECONDS, 5);
+    const float survey_duration =
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::SURVEY_DURATION_S, 0.0f);
+    const float survey_yaw_rate =
+        ctx.cfg.get<float>(drone::cfg_key::mission_planner::SURVEY_YAW_RATE, 0.3f);
 
     // Collision recovery config (Issue #226)
     const bool collision_recovery_enabled =
-        cfg.get<bool>(drone::cfg_key::mission_planner::collision_recovery::ENABLED, true);
-    const float collision_climb_delta =
-        cfg.get<float>(drone::cfg_key::mission_planner::collision_recovery::CLIMB_DELTA_M, 3.0f);
-    const float collision_hover_duration =
-        cfg.get<float>(drone::cfg_key::mission_planner::collision_recovery::HOVER_DURATION_S, 2.0f);
+        ctx.cfg.get<bool>(drone::cfg_key::mission_planner::collision_recovery::ENABLED, true);
+    const float collision_climb_delta = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::collision_recovery::CLIMB_DELTA_M, 3.0f);
+    const float collision_hover_duration = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::collision_recovery::HOVER_DURATION_S, 2.0f);
 
     MissionStateTick      state_tick({takeoff_alt, rtl_acceptance_m, landed_alt_m, rtl_min_dwell_s,
                                       survey_duration, survey_yaw_rate, collision_recovery_enabled,
@@ -319,7 +297,7 @@ int main(int argc, char* argv[]) {
     };
 
     // ── Create fault manager (config-driven thresholds) ────
-    FaultManager fault_mgr(cfg);
+    FaultManager fault_mgr(ctx.cfg);
 
     DRONE_LOG_INFO("Mission Planner READY — {} waypoints loaded", fsm.total_waypoints());
     drone::systemd::notify_ready();
@@ -327,8 +305,8 @@ int main(int argc, char* argv[]) {
     // ── Thread heartbeat + watchdog + health publisher ──────
     auto                        planning_hb = drone::util::ScopedHeartbeat("planning_loop", true);
     drone::util::ThreadWatchdog watchdog;
-    auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_MISSION_PLANNER);
+    auto                        thread_health_pub = ctx.bus.advertise<drone::ipc::ThreadHealth>(
+        drone::ipc::topics::THREAD_HEALTH_MISSION_PLANNER);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "mission_planner",
                                                         watchdog);
     uint32_t                           health_tick = 0;

--- a/process5_comms/src/main.cpp
+++ b/process5_comms/src/main.cpp
@@ -10,19 +10,12 @@
 
 #include "hal/hal_factory.h"
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/correlation.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/realtime.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -254,76 +247,62 @@ static void gcs_tx_thread(drone::hal::IGCSLink&                               gc
 
 // ═══════════════════════════════════════════════════════════
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "comms");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("comms", LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::comms_schema()); rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== Comms process starting (PID {}) ===", getpid());
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "comms", g_running,
+                                                drone::util::comms_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Create links via HAL factory ────────────────────────
-    auto fc_link    = drone::hal::create_fc_link(cfg, drone::cfg_key::comms::mavlink::SECTION);
-    auto fc_backend = cfg.get<std::string>(drone::cfg_key::comms::mavlink::BACKEND, "simulated");
+    auto fc_link    = drone::hal::create_fc_link(ctx.cfg, drone::cfg_key::comms::mavlink::SECTION);
+    auto fc_backend = ctx.cfg.get<std::string>(drone::cfg_key::comms::mavlink::BACKEND,
+                                               "simulated");
     bool fc_open_ok = false;
     if (fc_backend == "mavlink") {
         // MavlinkFCLink: "port" = connection URI, "baud" = timeout_ms
-        fc_open_ok =
-            fc_link->open(cfg.get<std::string>(drone::cfg_key::comms::mavlink::URI, "udp://:14540"),
-                          cfg.get<int>(drone::cfg_key::comms::mavlink::TIMEOUT_MS, 8000));
+        fc_open_ok = fc_link->open(
+            ctx.cfg.get<std::string>(drone::cfg_key::comms::mavlink::URI, "udp://:14540"),
+            ctx.cfg.get<int>(drone::cfg_key::comms::mavlink::TIMEOUT_MS, 8000));
     } else {
         fc_open_ok = fc_link->open(
-            cfg.get<std::string>(drone::cfg_key::comms::mavlink::SERIAL_PORT, "/dev/ttyTHS1"),
-            cfg.get<int>(drone::cfg_key::comms::mavlink::BAUD_RATE, 921600));
+            ctx.cfg.get<std::string>(drone::cfg_key::comms::mavlink::SERIAL_PORT, "/dev/ttyTHS1"),
+            ctx.cfg.get<int>(drone::cfg_key::comms::mavlink::BAUD_RATE, 921600));
     }
     if (!fc_open_ok) {
         DRONE_LOG_ERROR("Failed to open FC link (backend: {})", fc_backend);
         return 1;
     }
 
-    auto gcs_link = drone::hal::create_gcs_link(cfg, drone::cfg_key::comms::gcs::SECTION);
-    if (!gcs_link->open("0.0.0.0", cfg.get<int>(drone::cfg_key::comms::gcs::UDP_PORT, 14550))) {
+    auto gcs_link = drone::hal::create_gcs_link(ctx.cfg, drone::cfg_key::comms::gcs::SECTION);
+    if (!gcs_link->open("0.0.0.0", ctx.cfg.get<int>(drone::cfg_key::comms::gcs::UDP_PORT, 14550))) {
         DRONE_LOG_ERROR("Failed to open GCS link");
         return 1;
     }
 
     DRONE_LOG_INFO("FC link: {}, GCS link: {}", fc_link->name(), gcs_link->name());
 
-    // ── Create message bus (config-driven: shm or zenoh) ───
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("comms");
-
     // ── Publishers ──────────────────────────────────────────
-    auto fc_pub      = bus.advertise<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
-    auto gcs_cmd_pub = bus.advertise<drone::ipc::GCSCommand>(drone::ipc::topics::GCS_COMMANDS);
+    auto fc_pub      = ctx.bus.advertise<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
+    auto gcs_cmd_pub = ctx.bus.advertise<drone::ipc::GCSCommand>(drone::ipc::topics::GCS_COMMANDS);
     auto mission_upload_pub =
-        bus.advertise<drone::ipc::MissionUpload>(drone::ipc::topics::MISSION_UPLOAD);
+        ctx.bus.advertise<drone::ipc::MissionUpload>(drone::ipc::topics::MISSION_UPLOAD);
     if (!fc_pub->is_ready() || !gcs_cmd_pub->is_ready() || !mission_upload_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create Comms publishers");
         return 1;
     }
 
     // ── Subscribers ─────────────────────────────────────────
-    auto traj_sub    = bus.subscribe<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
-    auto fc_cmd_sub  = bus.subscribe<drone::ipc::FCCommand>(drone::ipc::topics::FC_COMMANDS);
-    auto pose_sub    = bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
-    auto mission_sub = bus.subscribe<drone::ipc::MissionStatus>(drone::ipc::topics::MISSION_STATUS);
-    auto fc_sub      = bus.subscribe<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
+    auto traj_sub =
+        ctx.bus.subscribe<drone::ipc::TrajectoryCmd>(drone::ipc::topics::TRAJECTORY_CMD);
+    auto fc_cmd_sub = ctx.bus.subscribe<drone::ipc::FCCommand>(drone::ipc::topics::FC_COMMANDS);
+    auto pose_sub   = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+    auto mission_sub =
+        ctx.bus.subscribe<drone::ipc::MissionStatus>(drone::ipc::topics::MISSION_STATUS);
+    auto fc_sub = ctx.bus.subscribe<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
 
     // ── Subscribe to fault overrides (optional — may not be publishing yet) ──
     auto fault_sub =
-        bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
+        ctx.bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
 
     DRONE_LOG_INFO("Comms READY");
     drone::systemd::notify_ready();
@@ -338,7 +317,7 @@ int main(int argc, char* argv[]) {
     // ── Thread watchdog + health publisher ──────────────────
     drone::util::ThreadWatchdog watchdog;
     auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_COMMS);
+        ctx.bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_COMMS);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "comms", watchdog);
 
     // ── Main loop: health publishing (replaces bare join) ─

--- a/process6_payload_manager/src/main.cpp
+++ b/process6_payload_manager/src/main.cpp
@@ -6,19 +6,12 @@
 
 #include "hal/hal_factory.h"
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
-#include "ipc/zenoh_liveliness.h"
 #include "payload/auto_tracker.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/realtime.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
 #include "util/thread_watchdog.h"
@@ -30,46 +23,30 @@
 static std::atomic<bool> g_running{true};
 
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "payload_manager");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("payload_manager", LogConfig::resolve_log_dir(), args.log_level,
-                    args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::payload_manager_schema());
-            rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== Payload Manager starting (PID {}) ===", getpid());
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "payload_manager", g_running,
+                                                drone::util::payload_manager_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Init gimbal via HAL factory ─────────────────────────
-    auto gimbal = drone::hal::create_gimbal(cfg, "payload_manager.gimbal");
+    auto gimbal = drone::hal::create_gimbal(ctx.cfg, "payload_manager.gimbal");
     if (!gimbal->init()) {
         DRONE_LOG_ERROR("Failed to initialise gimbal ({})", gimbal->name());
         return 1;
     }
     DRONE_LOG_INFO("Gimbal: {}", gimbal->name());
 
-    // ── Create message bus (config-driven: shm or zenoh) ───
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("payload_manager");
-
-    auto cmd_sub = bus.subscribe<drone::ipc::PayloadCommand>(drone::ipc::topics::PAYLOAD_COMMANDS);
+    // ── IPC channels ────────────────────────────────────────
+    auto cmd_sub =
+        ctx.bus.subscribe<drone::ipc::PayloadCommand>(drone::ipc::topics::PAYLOAD_COMMANDS);
     if (!cmd_sub->is_connected()) {
         DRONE_LOG_ERROR("Cannot open payload commands channel");
         return 1;
     }
 
-    auto status_pub = bus.advertise<drone::ipc::PayloadStatus>(drone::ipc::topics::PAYLOAD_STATUS);
+    auto status_pub =
+        ctx.bus.advertise<drone::ipc::PayloadStatus>(drone::ipc::topics::PAYLOAD_STATUS);
     if (!status_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create payload status publisher");
         return 1;
@@ -78,13 +55,13 @@ int main(int argc, char* argv[]) {
     // ── Auto-tracking: subscribe to detections + pose ──────
     drone::payload::AutoTrackConfig auto_track_cfg{};
     auto_track_cfg.enabled =
-        cfg.get<bool>(drone::cfg_key::payload_manager::gimbal::auto_track::ENABLED, false);
-    auto_track_cfg.min_confidence =
-        cfg.get<float>(drone::cfg_key::payload_manager::gimbal::auto_track::MIN_CONFIDENCE, 0.5f);
+        ctx.cfg.get<bool>(drone::cfg_key::payload_manager::gimbal::auto_track::ENABLED, false);
+    auto_track_cfg.min_confidence = ctx.cfg.get<float>(
+        drone::cfg_key::payload_manager::gimbal::auto_track::MIN_CONFIDENCE, 0.5f);
 
     auto detections_sub =
-        bus.subscribe<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
-    auto pose_sub = bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+        ctx.bus.subscribe<drone::ipc::DetectedObjectList>(drone::ipc::topics::DETECTED_OBJECTS);
+    auto pose_sub = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
 
     if (auto_track_cfg.enabled) {
         if (!detections_sub->is_connected()) {
@@ -104,8 +81,8 @@ int main(int argc, char* argv[]) {
 
     // Manual command holdoff — suppress auto-tracking for a configurable duration
     // after the last manual command to avoid fighting the operator.
-    const float manual_holdoff_s =
-        cfg.get<float>(drone::cfg_key::payload_manager::gimbal::auto_track::MANUAL_HOLDOFF_S, 2.0f);
+    const float manual_holdoff_s = ctx.cfg.get<float>(
+        drone::cfg_key::payload_manager::gimbal::auto_track::MANUAL_HOLDOFF_S, 2.0f);
     auto last_manual_cmd_time = std::chrono::steady_clock::time_point{};
 
     DRONE_LOG_INFO("Payload Manager READY");
@@ -115,15 +92,15 @@ int main(int argc, char* argv[]) {
     uint64_t capture_count = 0;
     uint64_t cmd_count     = 0;
 
-    const int   update_hz     = cfg.get<int>(drone::cfg_key::payload_manager::UPDATE_RATE_HZ, 50);
+    const int   update_hz = ctx.cfg.get<int>(drone::cfg_key::payload_manager::UPDATE_RATE_HZ, 50);
     const int   loop_sleep_ms = std::max(1, update_hz > 0 ? 1000 / update_hz : 20);
     const float dt            = loop_sleep_ms / 1000.0f;
 
     // ── Thread heartbeat + watchdog + health publisher ──────
     auto                        payload_hb = drone::util::ScopedHeartbeat("payload_loop", false);
     drone::util::ThreadWatchdog watchdog;
-    auto                        thread_health_pub =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_PAYLOAD_MANAGER);
+    auto                        thread_health_pub = ctx.bus.advertise<drone::ipc::ThreadHealth>(
+        drone::ipc::topics::THREAD_HEALTH_PAYLOAD_MANAGER);
     drone::util::ThreadHealthPublisher health_publisher(*thread_health_pub, "payload_manager",
                                                         watchdog);
     uint32_t                           health_tick = 0;

--- a/process7_system_monitor/src/main.cpp
+++ b/process7_system_monitor/src/main.cpp
@@ -3,23 +3,17 @@
 // watchdog.  Publishes SystemHealth.
 
 #include "ipc/ipc_types.h"
-#include "ipc/message_bus_factory.h"
 #include "ipc/zenoh_liveliness.h"
 #include "monitor/iprocess_monitor.h"
 #include "monitor/process_manager.h"
 #include "monitor/sys_info.h"
-#include "util/arg_parser.h"
-#include "util/config.h"
 #include "util/config_keys.h"
-#include "util/config_validator.h"
 #include "util/diagnostic.h"
-#include "util/ilogger.h"
-#include "util/log_config.h"
+#include "util/process_context.h"
 #include "util/process_graph.h"
 #include "util/restart_policy.h"
 #include "util/safe_name_copy.h"
 #include "util/sd_notify.h"
-#include "util/signal_handler.h"
 #include "util/sys_info_factory.h"
 #include "util/thread_health_publisher.h"
 #include "util/thread_heartbeat.h"
@@ -39,28 +33,16 @@
 static std::atomic<bool> g_running{true};
 
 int main(int argc, char* argv[]) {
-    auto args = parse_args(argc, argv, "system_monitor");
-    if (args.help) return 0;
-
-    SignalHandler::install(g_running);
-    LogConfig::init("system_monitor", LogConfig::resolve_log_dir(), args.log_level, args.json_logs);
-
-    drone::Config cfg;
-    if (!cfg.load(args.config_path)) {
-        DRONE_LOG_WARN("Running with default configuration; failed to load '{}'", args.config_path);
-    } else {
-        if (int rc = drone::util::validate_or_exit(cfg, drone::util::system_monitor_schema());
-            rc != 0) {
-            return rc;
-        }
-    }
-
-    DRONE_LOG_INFO("=== System Monitor starting (PID {}) ===", getpid());
+    // ── Common boilerplate (args, signals, logging, config, bus) ──
+    auto ctx_result = drone::util::init_process(argc, argv, "system_monitor", g_running,
+                                                drone::util::system_monitor_schema());
+    if (!ctx_result.is_ok()) return ctx_result.error();
+    auto& ctx = ctx_result.value();
 
     // ── Supervised mode: fork+exec child processes ──────────
     std::unique_ptr<drone::monitor::ProcessManager> supervisor;
     drone::util::ProcessGraph                       process_graph;
-    if (args.supervised) {
+    if (ctx.args.supervised) {
         DRONE_LOG_INFO("[Supervisor] Mode ENABLED — will fork+exec child processes");
 
         // Resolve binary directory from our own /proc/self/exe
@@ -78,17 +60,17 @@ int main(int argc, char* argv[]) {
 
         // Build extra args string (pass through config, log-level, etc.)
         std::string extra_args;
-        if (args.config_path != "config/default.json") {
-            extra_args += "--config " + args.config_path + " ";
+        if (ctx.args.config_path != "config/default.json") {
+            extra_args += "--config " + ctx.args.config_path + " ";
         }
-        if (args.log_level != "info") {
-            extra_args += "--log-level " + args.log_level + " ";
+        if (ctx.args.log_level != "info") {
+            extra_args += "--log-level " + ctx.args.log_level + " ";
         }
-        if (args.simulation) extra_args += "--sim ";
-        if (args.json_logs) extra_args += "--json-logs ";
+        if (ctx.args.simulation) extra_args += "--sim ";
+        if (ctx.args.json_logs) extra_args += "--json-logs ";
 
         // Load per-process configs from "watchdog.processes" section
-        auto proc_section = cfg.section(drone::cfg_key::watchdog::PROCESSES);
+        auto proc_section = ctx.cfg.section(drone::cfg_key::watchdog::PROCESSES);
 
         // Default process list (if config section is absent or empty)
         static const std::vector<std::string> default_process_names = {
@@ -163,7 +145,7 @@ int main(int argc, char* argv[]) {
             }
         }
 
-        // Build name → config lookup
+        // Build name -> config lookup
         std::unordered_map<std::string, const drone::util::ProcessConfig*> config_map;
         for (const auto& pc : process_configs) {
             config_map[pc.name] = &pc;
@@ -193,23 +175,19 @@ int main(int argc, char* argv[]) {
         // Launch all children in topological order
         supervisor->launch_all();
         DRONE_LOG_INFO("[Supervisor] All child processes launched (order: {})",
-                       fmt::join(launch_order, " → "));
+                       fmt::join(launch_order, " -> "));
     }
 
-    // ── Create message bus (config-driven: shm or zenoh) ───
-    auto bus = drone::ipc::create_message_bus(cfg);
-
-    // ── Declare liveliness token (auto-dropped on exit/crash) ──
-    drone::ipc::LivelinessToken liveliness_token("system_monitor");
-
-    auto health_pub = bus.advertise<drone::ipc::SystemHealth>(drone::ipc::topics::SYSTEM_HEALTH);
+    // ── IPC channels ────────────────────────────────────────
+    auto health_pub =
+        ctx.bus.advertise<drone::ipc::SystemHealth>(drone::ipc::topics::SYSTEM_HEALTH);
     if (!health_pub->is_ready()) {
         DRONE_LOG_ERROR("Failed to create system health publisher");
         return 1;
     }
 
     // ── Optional: subscribe to FC state for battery info ────
-    auto fc_sub = bus.subscribe_optional<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
+    auto fc_sub = ctx.bus.subscribe_optional<drone::ipc::FCState>(drone::ipc::topics::FC_STATE);
 
     // ── Process health monitoring via liveliness tokens ─────
     // Critical processes: if these die, flag critical_failure.
@@ -247,7 +225,7 @@ int main(int argc, char* argv[]) {
             liveness->events.push_back({proc, false, now_ns});
         });
 
-    // Local map: process name → (alive, last_seen_ns)
+    // Local map: process name -> (alive, last_seen_ns)
     struct ProcessState {
         bool     alive        = false;
         uint64_t last_seen_ns = 0;
@@ -267,38 +245,38 @@ int main(int argc, char* argv[]) {
     // ── Thread heartbeat + watchdog + health publisher ──────
     auto                        health_hb = drone::util::ScopedHeartbeat("health_loop", false);
     drone::util::ThreadWatchdog watchdog;
-    auto                        thread_health_pub_ch =
-        bus.advertise<drone::ipc::ThreadHealth>(drone::ipc::topics::THREAD_HEALTH_SYSTEM_MONITOR);
+    auto                        thread_health_pub_ch = ctx.bus.advertise<drone::ipc::ThreadHealth>(
+        drone::ipc::topics::THREAD_HEALTH_SYSTEM_MONITOR);
     drone::util::ThreadHealthPublisher thread_health_publisher(*thread_health_pub_ch,
                                                                "system_monitor", watchdog);
 
     // Config-driven thresholds (collected into MonitorThresholds struct)
-    const int update_rate   = cfg.get<int>(drone::cfg_key::system_monitor::UPDATE_RATE_HZ, 1);
+    const int update_rate   = ctx.cfg.get<int>(drone::cfg_key::system_monitor::UPDATE_RATE_HZ, 1);
     const int loop_sleep_ms = std::max(1, update_rate > 0 ? 1000 / update_rate : 1000);
-    const int disk_check_s  = cfg.get<int>(drone::cfg_key::system_monitor::DISK_CHECK_INTERVAL_S,
-                                           10);
+    const int disk_check_s = ctx.cfg.get<int>(drone::cfg_key::system_monitor::DISK_CHECK_INTERVAL_S,
+                                              10);
 
     drone::monitor::MonitorThresholds thresholds;
     thresholds.cpu_warn =
-        cfg.get<float>(drone::cfg_key::system_monitor::thresholds::CPU_WARN_PERCENT, 90.0f);
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::CPU_WARN_PERCENT, 90.0f);
     thresholds.mem_warn =
-        cfg.get<float>(drone::cfg_key::system_monitor::thresholds::MEM_WARN_PERCENT, 90.0f);
-    thresholds.temp_warn = cfg.get<float>(drone::cfg_key::system_monitor::thresholds::TEMP_WARN_C,
-                                          80.0f);
-    thresholds.temp_crit = cfg.get<float>(drone::cfg_key::system_monitor::thresholds::TEMP_CRIT_C,
-                                          95.0f);
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::MEM_WARN_PERCENT, 90.0f);
+    thresholds.temp_warn =
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::TEMP_WARN_C, 80.0f);
+    thresholds.temp_crit =
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::TEMP_CRIT_C, 95.0f);
     thresholds.disk_crit =
-        cfg.get<float>(drone::cfg_key::system_monitor::thresholds::DISK_CRIT_PERCENT, 98.0f);
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::DISK_CRIT_PERCENT, 98.0f);
     thresholds.batt_warn =
-        cfg.get<float>(drone::cfg_key::system_monitor::thresholds::BATTERY_WARN_PERCENT, 20.0f);
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::BATTERY_WARN_PERCENT, 20.0f);
     thresholds.batt_crit =
-        cfg.get<float>(drone::cfg_key::system_monitor::thresholds::BATTERY_CRIT_PERCENT, 10.0f);
+        ctx.cfg.get<float>(drone::cfg_key::system_monitor::thresholds::BATTERY_CRIT_PERCENT, 10.0f);
     // Convert disk check interval from seconds to ticks (calls)
     thresholds.disk_interval = std::max(1, disk_check_s * (update_rate > 0 ? update_rate : 1));
 
     // Create platform-specific ISysInfo (linux, jetson, mock)
-    const std::string platform = cfg.get<std::string>(drone::cfg_key::system_monitor::PLATFORM,
-                                                      "linux");
+    const std::string platform = ctx.cfg.get<std::string>(drone::cfg_key::system_monitor::PLATFORM,
+                                                          "linux");
     auto              sys_info = drone::util::create_sys_info(platform);
     DRONE_LOG_INFO("Platform sys_info: {} (config='{}')", sys_info->name(), platform);
 
@@ -308,7 +286,7 @@ int main(int argc, char* argv[]) {
 
     // Optional fault-injection override subscriber.
     auto fault_sub =
-        bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
+        ctx.bus.subscribe_optional<drone::ipc::FaultOverrides>(drone::ipc::topics::FAULT_OVERRIDES);
 
     uint32_t tick = 0;
 
@@ -401,7 +379,7 @@ int main(int argc, char* argv[]) {
                 status_str = "CRITICAL";
 
             DRONE_LOG_INFO(
-                "[SysMon] CPU={:.1f}% MEM={:.1f}% TEMP={:.1f}°C "
+                "[SysMon] CPU={:.1f}% MEM={:.1f}% TEMP={:.1f}C "
                 "DISK={:.0f}% BATT={:.0f}% thermal_zone={} stack={} => {}",
                 health.cpu_usage_percent, health.memory_usage_percent, health.cpu_temp_c,
                 health.disk_usage_percent, battery, health.thermal_zone,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,5 +300,9 @@ add_drone_test(test_gimbal_auto_tracker test_gimbal_auto_tracker.cpp)
 add_drone_test(test_topic_resolver  test_topic_resolver.cpp
     PROPERTIES RESOURCE_LOCK "zenoh_session")
 
-# ── EventBus tests (Issue #293) ─────────────────────────
-add_drone_test(test_event_bus       test_event_bus.cpp)
+# ── ProcessContext tests (Issue #291) ────────────────────
+add_drone_test(test_process_context test_process_context.cpp
+    PROPERTIES RESOURCE_LOCK "zenoh_session")
+target_compile_definitions(test_process_context PRIVATE
+    PROJECT_CONFIG_DIR="${PROJECT_SOURCE_DIR}/config"
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -299,3 +299,6 @@ add_drone_test(test_gimbal_auto_tracker test_gimbal_auto_tracker.cpp)
 # ── TopicResolver tests (Issue #289) ─────────────────────
 add_drone_test(test_topic_resolver  test_topic_resolver.cpp
     PROPERTIES RESOURCE_LOCK "zenoh_session")
+
+# ── EventBus tests (Issue #293) ─────────────────────────
+add_drone_test(test_event_bus       test_event_bus.cpp)

--- a/tests/test_event_bus.cpp
+++ b/tests/test_event_bus.cpp
@@ -1,0 +1,295 @@
+// tests/test_event_bus.cpp — EventBus<Event> unit tests (Issue #293)
+#include "util/event_bus.h"
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// ── Test event types ────────────────────────────────────────────────
+
+struct SimpleEvent {
+    int value = 0;
+};
+
+struct StringEvent {
+    std::string message;
+};
+
+// ── Basic functionality ─────────────────────────────────────────────
+
+TEST(EventBus, SubscribeAndPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                received = 0;
+    auto sub = bus.subscribe([&](const SimpleEvent& e) { received = e.value; });
+
+    bus.publish(SimpleEvent{42});
+    EXPECT_EQ(received, 42);
+}
+
+TEST(EventBus, MultipleHandlers) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                sum = 0;
+    auto sub1 = bus.subscribe([&](const SimpleEvent& e) { sum += e.value; });
+    auto sub2 = bus.subscribe([&](const SimpleEvent& e) { sum += e.value * 10; });
+
+    bus.publish(SimpleEvent{3});
+    EXPECT_EQ(sum, 33);  // 3 + 30
+}
+
+TEST(EventBus, EmptyBusPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    // Must not crash
+    bus.publish(SimpleEvent{99});
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+TEST(EventBus, SubscriberCount) {
+    drone::util::EventBus<SimpleEvent> bus;
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+
+    auto sub1 = bus.subscribe([](const SimpleEvent&) {});
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+
+    auto sub2 = bus.subscribe([](const SimpleEvent&) {});
+    EXPECT_EQ(bus.subscriber_count(), 2u);
+}
+
+// ── RAII unsubscribe ────────────────────────────────────────────────
+
+TEST(EventBus, RAIIUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    {
+        auto sub = bus.subscribe([&](const SimpleEvent&) { ++count; });
+        bus.publish(SimpleEvent{});
+        EXPECT_EQ(count, 1);
+        EXPECT_EQ(bus.subscriber_count(), 1u);
+    }
+    // sub went out of scope — handler should be removed
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);  // no additional call
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+TEST(EventBus, ExplicitUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    auto                               sub   = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);
+
+    sub.unsubscribe();
+    EXPECT_FALSE(sub.is_active());
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);  // not called after unsubscribe
+}
+
+TEST(EventBus, DoubleUnsubscribeIsSafe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    auto                               sub = bus.subscribe([](const SimpleEvent&) {});
+    sub.unsubscribe();
+    sub.unsubscribe();  // Must not crash or double-free
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+// ── Move semantics on Subscription ──────────────────────────────────
+
+TEST(EventBus, MoveConstructSubscription) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count = 0;
+    auto                               sub1  = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    auto sub2(std::move(sub1));
+    EXPECT_FALSE(sub1.is_active());  // NOLINT — testing moved-from state
+    EXPECT_TRUE(sub2.is_active());
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count, 1);
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+}
+
+TEST(EventBus, MoveAssignSubscription) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                count_a = 0;
+    int                                count_b = 0;
+    auto sub_a = bus.subscribe([&](const SimpleEvent&) { ++count_a; });
+    auto sub_b = bus.subscribe([&](const SimpleEvent&) { ++count_b; });
+    EXPECT_EQ(bus.subscriber_count(), 2u);
+
+    // Move-assign sub_a into sub_b — sub_b's old handler should be unsubscribed
+    sub_b = std::move(sub_a);
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+
+    bus.publish(SimpleEvent{});
+    EXPECT_EQ(count_a, 1);  // sub_a's handler still active (now owned by sub_b)
+    EXPECT_EQ(count_b, 0);  // sub_b's old handler was unsubscribed
+}
+
+TEST(EventBus, DefaultConstructedSubscriptionInactive) {
+    drone::util::Subscription<SimpleEvent> sub;
+    EXPECT_FALSE(sub.is_active());
+    // Destroying default-constructed subscription must not crash
+}
+
+// ── Re-entrancy (publish from within handler) ───────────────────────
+
+TEST(EventBus, PublishFromWithinHandler) {
+    drone::util::EventBus<SimpleEvent> bus;
+    int                                outer_count = 0;
+    int                                inner_count = 0;
+
+    auto inner_sub = bus.subscribe([&](const SimpleEvent&) { ++inner_count; });
+
+    auto outer_sub = bus.subscribe([&](const SimpleEvent& e) {
+        ++outer_count;
+        if (e.value == 1) {
+            // Re-entrant publish — must not deadlock
+            bus.publish(SimpleEvent{2});
+        }
+    });
+
+    bus.publish(SimpleEvent{1});
+    // First publish: both handlers called with value=1
+    // Re-entrant publish(2): both handlers called with value=2
+    EXPECT_EQ(outer_count, 2);
+    EXPECT_EQ(inner_count, 2);
+}
+
+// ── Unsubscribe during iteration (safe due to copy-on-write) ────────
+
+TEST(EventBus, UnsubscribeDuringIteration) {
+    drone::util::EventBus<SimpleEvent>     bus;
+    int                                    count = 0;
+    drone::util::Subscription<SimpleEvent> sub2;
+    // Handler that unsubscribes sub2 during publish iteration
+    auto sub1 = bus.subscribe([&](const SimpleEvent&) {
+        ++count;
+        sub2.unsubscribe();  // Modifies handler list while iterating snapshot
+    });
+    sub2      = bus.subscribe([&](const SimpleEvent&) { ++count; });
+
+    bus.publish(SimpleEvent{});
+    // Both handlers were in the snapshot, so both should have been called
+    EXPECT_EQ(count, 2);
+    // But sub2 is now unsubscribed
+    EXPECT_EQ(bus.subscriber_count(), 1u);
+}
+
+// ── Thread safety ───────────────────────────────────────────────────
+
+TEST(EventBus, ConcurrentPublish) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::atomic<int>                   total{0};
+
+    auto sub = bus.subscribe(
+        [&](const SimpleEvent& e) { total.fetch_add(e.value, std::memory_order_relaxed); });
+
+    constexpr int            kThreads   = 4;
+    constexpr int            kPerThread = 1000;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&bus]() {
+            for (int i = 0; i < kPerThread; ++i) {
+                bus.publish(SimpleEvent{1});
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(total.load(std::memory_order_relaxed), kThreads * kPerThread);
+}
+
+TEST(EventBus, ConcurrentSubscribeUnsubscribe) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::atomic<int>                   total{0};
+
+    constexpr int            kThreads = 4;
+    constexpr int            kIters   = 500;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&bus, &total]() {
+            for (int i = 0; i < kIters; ++i) {
+                auto sub = bus.subscribe([&](const SimpleEvent& e) {
+                    total.fetch_add(e.value, std::memory_order_relaxed);
+                });
+                bus.publish(SimpleEvent{1});
+                // sub destroyed here — RAII unsubscribe
+            }
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // Each iteration: subscribe, publish (at least own handler sees it), unsubscribe.
+    // Total should be >= kThreads * kIters (could be more due to interleaving).
+    EXPECT_GE(total.load(std::memory_order_relaxed), kThreads * kIters);
+    EXPECT_EQ(bus.subscriber_count(), 0u);
+}
+
+// ── Different event types are independent ───────────────────────────
+
+TEST(EventBus, DifferentEventTypes) {
+    drone::util::EventBus<SimpleEvent> int_bus;
+    drone::util::EventBus<StringEvent> str_bus;
+
+    int         int_count = 0;
+    std::string last_msg;
+
+    auto sub1 = int_bus.subscribe([&](const SimpleEvent& e) { int_count += e.value; });
+    auto sub2 = str_bus.subscribe([&](const StringEvent& e) { last_msg = e.message; });
+
+    int_bus.publish(SimpleEvent{7});
+    str_bus.publish(StringEvent{"hello"});
+
+    EXPECT_EQ(int_count, 7);
+    EXPECT_EQ(last_msg, "hello");
+}
+
+// ── Subscribe after publish ─────────────────────────────────────────
+
+TEST(EventBus, LateSubscriberMissesEarlierEvents) {
+    drone::util::EventBus<SimpleEvent> bus;
+    bus.publish(SimpleEvent{1});
+
+    int  received = 0;
+    auto sub      = bus.subscribe([&](const SimpleEvent& e) { received = e.value; });
+
+    EXPECT_EQ(received, 0);  // Late subscriber did not see earlier event
+
+    bus.publish(SimpleEvent{2});
+    EXPECT_EQ(received, 2);
+}
+
+// ── Multiple publishes ──────────────────────────────────────────────
+
+TEST(EventBus, MultiplePublishes) {
+    drone::util::EventBus<SimpleEvent> bus;
+    std::vector<int>                   received;
+
+    auto sub = bus.subscribe([&](const SimpleEvent& e) { received.push_back(e.value); });
+
+    bus.publish(SimpleEvent{1});
+    bus.publish(SimpleEvent{2});
+    bus.publish(SimpleEvent{3});
+
+    ASSERT_EQ(received.size(), 3u);
+    EXPECT_EQ(received[0], 1);
+    EXPECT_EQ(received[1], 2);
+    EXPECT_EQ(received[2], 3);
+}
+
+}  // namespace

--- a/tests/test_process_context.cpp
+++ b/tests/test_process_context.cpp
@@ -1,0 +1,124 @@
+// tests/test_process_context.cpp
+// Tests for drone::util::init_process() and ProcessContext.
+// Issue #291 (Epic #284 — Platform Modularity)
+
+#include "util/config_validator.h"
+#include "util/process_context.h"
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// ── Helper: build argc/argv from a vector of strings ────────
+class ArgvBuilder {
+public:
+    explicit ArgvBuilder(std::vector<std::string> args) : args_(std::move(args)) {
+        for (auto& s : args_) {
+            ptrs_.push_back(s.data());
+        }
+    }
+    int    argc() const { return static_cast<int>(ptrs_.size()); }
+    char** argv() { return ptrs_.data(); }
+
+private:
+    std::vector<std::string> args_;
+    std::vector<char*>       ptrs_;
+};
+
+// ── Test: --help returns exit code 0 (not an error) ─────────
+TEST(ProcessContext, HelpReturnsExitCodeZero) {
+    std::atomic<bool> running{true};
+    ArgvBuilder       argv_builder({"test_process", "--help"});
+
+    auto result = drone::util::init_process(argv_builder.argc(), argv_builder.argv(), "test_proc",
+                                            running, drone::util::common_schema());
+
+    EXPECT_FALSE(result.is_ok());
+    EXPECT_EQ(result.error(), 0);
+}
+
+// ── Test: valid config produces a usable ProcessContext ──────
+TEST(ProcessContext, ValidConfigProducesContext) {
+    std::atomic<bool> running{true};
+
+    // Use the real project config if available via compile-time define
+#ifdef PROJECT_CONFIG_DIR
+    std::string config_path = std::string(PROJECT_CONFIG_DIR) + "/default.json";
+#else
+    std::string config_path = "config/default.json";
+#endif
+
+    ArgvBuilder argv_builder({"test_process", "--config", config_path});
+
+    auto result = drone::util::init_process(argv_builder.argc(), argv_builder.argv(), "test_proc",
+                                            running, drone::util::common_schema());
+
+    // May fail if config file not found in CI — skip gracefully
+    if (!result.is_ok()) {
+        GTEST_SKIP() << "Config file not found (expected in CI without config)";
+    }
+
+    auto& ctx = result.value();
+    EXPECT_EQ(ctx.process_name, "test_proc");
+    EXPECT_EQ(&ctx.running, &running);
+    EXPECT_FALSE(ctx.args.help);
+}
+
+// ── Test: no args uses defaults, context still created ──────
+TEST(ProcessContext, NoArgsUsesDefaults) {
+    std::atomic<bool> running{true};
+    ArgvBuilder       argv_builder({"test_process"});
+
+    // With no --config, it tries config/default.json. If it doesn't exist,
+    // it still proceeds with default config (load warning).
+    auto result = drone::util::init_process(argv_builder.argc(), argv_builder.argv(), "test_proc",
+                                            running, drone::util::common_schema());
+
+    // Should succeed even if config file is missing (uses defaults)
+    ASSERT_TRUE(result.is_ok());
+    auto& ctx = result.value();
+    EXPECT_EQ(ctx.process_name, "test_proc");
+}
+
+// ── Test: ProcessContext is move-constructible ───────────────
+TEST(ProcessContext, IsMoveConstructible) {
+    EXPECT_TRUE(std::is_move_constructible_v<drone::util::ProcessContext>);
+}
+
+// ── Test: ProcessContext is not copy-constructible ───────────
+TEST(ProcessContext, IsNotCopyConstructible) {
+    EXPECT_FALSE(std::is_copy_constructible_v<drone::util::ProcessContext>);
+}
+
+// ── Test: running flag reference is correct ─────────────────
+TEST(ProcessContext, RunningFlagReference) {
+    std::atomic<bool> running{true};
+    ArgvBuilder       argv_builder({"test_process"});
+
+    auto result = drone::util::init_process(argv_builder.argc(), argv_builder.argv(), "test_proc",
+                                            running, drone::util::common_schema());
+
+    ASSERT_TRUE(result.is_ok());
+    auto& ctx = result.value();
+
+    // Verify the reference points to our flag
+    EXPECT_TRUE(ctx.running.load(std::memory_order_relaxed));
+    running.store(false, std::memory_order_relaxed);
+    EXPECT_FALSE(ctx.running.load(std::memory_order_relaxed));
+}
+
+// ── Test: parsed args are preserved ─────────────────────────
+TEST(ProcessContext, ParsedArgsPreserved) {
+    std::atomic<bool> running{true};
+    ArgvBuilder       argv_builder({"test_process", "--log-level", "debug", "--json-logs"});
+
+    auto result = drone::util::init_process(argv_builder.argc(), argv_builder.argv(), "test_proc",
+                                            running, drone::util::common_schema());
+
+    ASSERT_TRUE(result.is_ok());
+    auto& ctx = result.value();
+    EXPECT_EQ(ctx.args.log_level, "debug");
+    EXPECT_TRUE(ctx.args.json_logs);
+}


### PR DESCRIPTION
## Summary
- Created `ProcessContext` struct + `init_process()` function in `common/util/`
- Refactored all 7 process main() files to use it, eliminating ~150 lines of duplicated boilerplate
- `init_process()` returns `Result<ProcessContext, int>` handling args, signals, logging, config, message bus
- Domain-specific wiring stays in each main() — only the common prefix is extracted

## Changes
| Process | Before | After | Saved |
|---------|--------|-------|-------|
| P1 video_capture | 316 | ~296 | ~20 |
| P2 perception | 536 | ~516 | ~20 |
| P3 slam_vio_nav | 491 | ~470 | ~21 |
| P4 mission_planner | 477 | ~455 | ~22 |
| P5 comms | 363 | ~341 | ~22 |
| P6 payload_manager | 237 | ~217 | ~20 |
| P7 system_monitor | 438 | ~418 | ~20 |

## Test plan
- [x] 7 new ProcessContext tests (1389 → 1396)
- [x] All existing tests pass (no behavior change)
- [x] Build: zero warnings, format clean
- [x] Each refactored main() verified to compile and link

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)