### PR TITLE
refactor(#385): move SpdlogLogger to separate header — decouple ilogger.h from spdlog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 
 # ── Find system dependencies ────────────────────────────────
 find_package(Threads       REQUIRED)
+find_package(fmt           REQUIRED)
 find_package(spdlog        REQUIRED)
 find_package(Eigen3        REQUIRED NO_MODULE)
 find_package(nlohmann_json REQUIRED)

--- a/common/util/CMakeLists.txt
+++ b/common/util/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(drone_util INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(drone_util INTERFACE
+    fmt::fmt
     spdlog::spdlog
     nlohmann_json::nlohmann_json
     pthread

--- a/common/util/include/util/ilogger.h
+++ b/common/util/include/util/ilogger.h
@@ -6,7 +6,9 @@
 //   - Global accessor: drone::log::logger() / set_logger()
 //   - DRONE_LOG_DEBUG/INFO/WARN/ERROR/CRITICAL macros (fmt-style)
 //
-// Default implementation: SpdlogLogger (delegates to spdlog default logger).
+// Default fallback: StderrFallbackLogger (writes to stderr, no spdlog needed).
+// Production logger: SpdlogLogger (in spdlog_logger.h) — installed via
+//   init_process() / LogConfig::init() during startup.
 // Test implementations: NullLogger, CapturingLogger (separate headers).
 //
 // Usage:
@@ -26,13 +28,13 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/spdlog.h>
+#include <fmt/format.h>
 
 namespace drone::log {
 
@@ -67,29 +69,21 @@ public:
     ILogger& operator=(ILogger&&)      = delete;
 };
 
-// ── SpdlogLogger (default) ─────────────────────────────────
-/// Production logger that delegates to spdlog's default logger.
-/// This is the default when no custom logger is installed.
-class SpdlogLogger final : public ILogger {
+// ── StderrFallbackLogger ───────────────────────────────────
+/// Minimal fallback logger that writes to stderr.  Used as the
+/// default before SpdlogLogger is installed via init_process().
+/// Has no dependency on spdlog — keeps ilogger.h decoupled.
+class StderrFallbackLogger final : public ILogger {
 public:
     void log(Level level, std::string_view msg) override {
-        spdlog::log(to_spdlog_level(level), "{}", msg);
+        static constexpr const char* kLevelNames[] = {"DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"};
+        const auto                   idx           = static_cast<uint8_t>(level);
+        const char*                  name          = (idx < 5) ? kLevelNames[idx] : "UNKNOWN";
+        std::fprintf(stderr, "[%s] %.*s\n", name, static_cast<int>(msg.size()), msg.data());
     }
 
-    [[nodiscard]] bool should_log(Level level) const override {
-        return spdlog::should_log(to_spdlog_level(level));
-    }
-
-private:
-    static spdlog::level::level_enum to_spdlog_level(Level level) {
-        switch (level) {
-            case Level::Debug: return spdlog::level::debug;
-            case Level::Info: return spdlog::level::info;
-            case Level::Warn: return spdlog::level::warn;
-            case Level::Error: return spdlog::level::err;
-            case Level::Critical: return spdlog::level::critical;
-        }
-        return spdlog::level::info;  // unreachable, but silences -Wreturn-type
+    [[nodiscard]] bool should_log(Level /*level*/) const override {
+        return true;  // Fallback logger emits everything.
     }
 };
 
@@ -126,9 +120,10 @@ inline std::atomic<ILogger*>& logger_ptr() {
     return ptr;
 }
 
-/// Process-wide default SpdlogLogger instance.
+/// Process-wide fallback logger (stderr).  Used when no SpdlogLogger
+/// has been installed yet (before init_process) or after reset_logger().
 inline ILogger& default_logger() {
-    static SpdlogLogger instance;
+    static StderrFallbackLogger instance;
     return instance;
 }
 
@@ -142,8 +137,8 @@ inline ILogger& logger() {
     return detail::default_logger();
 }
 
-/// Install a custom logger (e.g. CapturingLogger for tests).
-/// Pass nullptr or call reset_logger() to revert to default.
+/// Install a custom logger (e.g. SpdlogLogger, CapturingLogger).
+/// Pass nullptr or call reset_logger() to revert to fallback.
 /// Thread-safe: serialized by mutex, atomic store visible to all readers.
 inline void set_logger(std::unique_ptr<ILogger> l) {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
@@ -151,7 +146,7 @@ inline void set_logger(std::unique_ptr<ILogger> l) {
     detail::logger_ptr().store(detail::logger_owner().get(), std::memory_order_release);
 }
 
-/// Revert to the default SpdlogLogger.
+/// Revert to the StderrFallbackLogger.
 inline void reset_logger() {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
     detail::logger_owner().reset();

--- a/common/util/include/util/log_config.h
+++ b/common/util/include/util/log_config.h
@@ -1,10 +1,15 @@
 // common/util/include/util/log_config.h
 // Logging initialisation using spdlog.
+//
+// After configuring spdlog sinks and levels, installs a SpdlogLogger as the
+// global ILogger so that all DRONE_LOG_* macros route through spdlog.
 #pragma once
 #include "util/ilogger.h"
 #include "util/json_log_sink.h"
+#include "util/spdlog_logger.h"
 
 #include <cstdlib>
+#include <memory>
 #include <string>
 
 #include <spdlog/sinks/rotating_file_sink.h>
@@ -58,6 +63,11 @@ inline void init(const std::string& process_name, const std::string& log_dir,
             logger->set_level(spdlog::level::info);
 
         spdlog::set_default_logger(logger);
+
+        // Install SpdlogLogger as the global ILogger so DRONE_LOG_* macros
+        // route through the spdlog logger we just configured.
+        drone::log::set_logger(std::make_unique<drone::log::SpdlogLogger>());
+
         DRONE_LOG_INFO("Logger '{}' initialised — level={}, json={}", process_name, level_str,
                        json_mode ? "on" : "off");
     } catch (const spdlog::spdlog_ex& ex) {

--- a/common/util/include/util/spdlog_logger.h
+++ b/common/util/include/util/spdlog_logger.h
@@ -1,10 +1,48 @@
 // common/util/include/util/spdlog_logger.h
-// Convenience header — re-exports SpdlogLogger from ilogger.h.
+// Production ILogger implementation that delegates to spdlog.
 //
-// SpdlogLogger is the default ILogger implementation, defined in
-// ilogger.h to make the DRONE_LOG macros self-contained.
-// Include this header if you need to explicitly reference SpdlogLogger
-// (e.g. to construct one for a non-default spdlog logger instance).
+// Separated from ilogger.h (Issue #385) so that the 60+ files including
+// ilogger.h do not transitively depend on spdlog headers.
+//
+// Include this header only where SpdlogLogger is explicitly constructed:
+//   - log_config.h (LogConfig::init installs SpdlogLogger via set_logger)
+//   - process_context.h (includes log_config.h)
+//   - Tests that directly exercise SpdlogLogger behaviour
+//
+// All other code should include only ilogger.h and use the DRONE_LOG_* macros.
 #pragma once
 
 #include "util/ilogger.h"
+
+#include <spdlog/spdlog.h>
+
+namespace drone::log {
+
+// ── Level conversion ───────────────────────────────────────
+/// Map drone::log::Level to spdlog::level::level_enum.
+inline spdlog::level::level_enum to_spdlog_level(Level level) {
+    switch (level) {
+        case Level::Debug: return spdlog::level::debug;
+        case Level::Info: return spdlog::level::info;
+        case Level::Warn: return spdlog::level::warn;
+        case Level::Error: return spdlog::level::err;
+        case Level::Critical: return spdlog::level::critical;
+    }
+    return spdlog::level::info;  // unreachable, but silences -Wreturn-type
+}
+
+// ── SpdlogLogger ───────────────────────────────────────────
+/// Production logger that delegates to spdlog's default logger.
+/// Installed during init_process() via LogConfig::init().
+class SpdlogLogger final : public ILogger {
+public:
+    void log(Level level, std::string_view msg) override {
+        spdlog::log(to_spdlog_level(level), "{}", msg);
+    }
+
+    [[nodiscard]] bool should_log(Level level) const override {
+        return spdlog::should_log(to_spdlog_level(level));
+    }
+};
+
+}  // namespace drone::log

--- a/process4_mission_planner/include/planner/mission_fsm.h
+++ b/process4_mission_planner/include/planner/mission_fsm.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <string>
+#include <vector>
 
 namespace drone::planner {
 

--- a/process6_payload_manager/include/payload/gimbal_controller.h
+++ b/process6_payload_manager/include/payload/gimbal_controller.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "util/ilogger.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdint>

--- a/tests/test_ilogger.cpp
+++ b/tests/test_ilogger.cpp
@@ -7,6 +7,7 @@
 #include "util/capturing_logger.h"
 #include "util/ilogger.h"
 #include "util/null_logger.h"
+#include "util/spdlog_logger.h"
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Summary

- Move `SpdlogLogger` class from `ilogger.h` to new `spdlog_logger.h`
- `ilogger.h` no longer includes any spdlog headers — uses `<fmt/format.h>` directly
- Add `StderrFallbackLogger` as pre-init default (zero spdlog dependency)
- `log_config.h` installs `SpdlogLogger` via `set_logger()` at init
- Add explicit `fmt::fmt` CMake dependency (was transitive via spdlog)
- Fix transitive include deps: `mission_fsm.h` `<vector>`, `gimbal_controller.h` `<algorithm>`

## Test plan
- [x] Build: zero warnings with `-Werror -Wall -Wextra`
- [x] Tests: 1429/1429 pass
- [x] Format: clang-format-18 clean
- [ ] Copilot review

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)