### PR TITLE
feat(#384): RCU-style logger/clock swap — eliminate use-after-free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 
 # ── Find system dependencies ────────────────────────────────
 find_package(Threads       REQUIRED)
+find_package(fmt           REQUIRED)
 find_package(spdlog        REQUIRED)
 find_package(Eigen3        REQUIRED NO_MODULE)
 find_package(nlohmann_json REQUIRED)

--- a/common/util/CMakeLists.txt
+++ b/common/util/CMakeLists.txt
@@ -5,6 +5,7 @@ target_include_directories(drone_util INTERFACE
     $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(drone_util INTERFACE
+    fmt::fmt
     spdlog::spdlog
     nlohmann_json::nlohmann_json
     pthread

--- a/common/util/include/util/iclock.h
+++ b/common/util/include/util/iclock.h
@@ -14,8 +14,10 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <thread>
+#include <vector>
 
 namespace drone::util {
 
@@ -80,11 +82,12 @@ public:
 // read), so it uses an atomic load (acquire).  set_clock() is cold-path
 // (startup / tests) and holds a mutex to protect ownership.
 //
-// SAFETY CONTRACT: set_clock() must only be called during single-threaded
-// startup or in test fixture setup/teardown (before/after worker threads
-// are running).  Calling it while other threads are actively reading the
-// clock is a data race on the pointed-to object's lifetime.
-// See issue #384 for a planned RCU-style fix.
+// RCU-style retirement (Issue #384): When set_clock() replaces the active
+// clock, the OLD clock is moved into a retirement vector rather than
+// destroyed.  This eliminates use-after-free: any thread that loaded the
+// old pointer via get_clock() can safely finish its operation even if
+// another thread concurrently swaps the clock.  The cost is a few leaked
+// clock objects (2-3 per process lifetime max), which is negligible.
 
 namespace detail {
 
@@ -98,6 +101,20 @@ inline IClock& default_clock() {
 inline std::mutex& clock_mutex() {
     static std::mutex mtx;
     return mtx;
+}
+
+/// Owning pointer to the user-installed clock (null = use default).
+/// Must hold clock_mutex() to read or write.
+inline std::unique_ptr<IClock>& clock_owner() {
+    static std::unique_ptr<IClock> owner;
+    return owner;
+}
+
+/// Retired clocks — kept alive to prevent use-after-free.
+/// Only accessed under clock_mutex().
+inline std::vector<std::unique_ptr<IClock>>& retired_clocks() {
+    static std::vector<std::unique_ptr<IClock>> vec;
+    return vec;
 }
 
 /// Atomic raw pointer cache for hot-path reads (null = use default).
@@ -117,14 +134,30 @@ inline std::atomic<IClock*>& clock_ptr() {
     return detail::default_clock();
 }
 
-/// Set the global clock.  Call once at startup or in test setup.
+/// Set the global clock (owning overload).  Takes ownership of the clock.
 /// Thread-safe: serialized by mutex, atomic store visible to all readers.
-///
-/// @param clk  Pointer to clock instance.  Caller retains ownership
-///             and must ensure the clock outlives all users.
-///             Pass nullptr to restore the default SteadyClock.
+/// The previous clock is retired (kept alive) to prevent use-after-free.
+inline void set_clock(std::unique_ptr<IClock> clk) {
+    std::lock_guard<std::mutex> lock(detail::clock_mutex());
+    // Retire the old clock — do NOT destroy it.
+    if (detail::clock_owner()) {
+        detail::retired_clocks().push_back(std::move(detail::clock_owner()));
+    }
+    detail::clock_owner() = std::move(clk);
+    detail::clock_ptr().store(detail::clock_owner().get(), std::memory_order_release);
+}
+
+/// Set the global clock (non-owning overload for stack-allocated clocks).
+/// The caller retains ownership and must ensure the clock outlives all users.
+/// Pass nullptr to restore the default SteadyClock.
+/// The previous owned clock (if any) is retired, not destroyed.
 inline void set_clock(IClock* clk) {
     std::lock_guard<std::mutex> lock(detail::clock_mutex());
+    // Retire the old owned clock — do NOT destroy it.
+    if (detail::clock_owner()) {
+        detail::retired_clocks().push_back(std::move(detail::clock_owner()));
+    }
+    // No ownership transfer — clock_owner remains null.
     detail::clock_ptr().store(clk, std::memory_order_release);
 }
 

--- a/common/util/include/util/ilogger.h
+++ b/common/util/include/util/ilogger.h
@@ -6,7 +6,9 @@
 //   - Global accessor: drone::log::logger() / set_logger()
 //   - DRONE_LOG_DEBUG/INFO/WARN/ERROR/CRITICAL macros (fmt-style)
 //
-// Default implementation: SpdlogLogger (delegates to spdlog default logger).
+// Default fallback: StderrFallbackLogger (writes to stderr, no spdlog needed).
+// Production logger: SpdlogLogger (in spdlog_logger.h) — installed via
+//   init_process() / LogConfig::init() during startup.
 // Test implementations: NullLogger, CapturingLogger (separate headers).
 //
 // Usage:
@@ -26,13 +28,13 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <string_view>
 
-#include <spdlog/fmt/fmt.h>
-#include <spdlog/spdlog.h>
+#include <fmt/format.h>
 
 namespace drone::log {
 
@@ -67,29 +69,21 @@ public:
     ILogger& operator=(ILogger&&)      = delete;
 };
 
-// ── SpdlogLogger (default) ─────────────────────────────────
-/// Production logger that delegates to spdlog's default logger.
-/// This is the default when no custom logger is installed.
-class SpdlogLogger final : public ILogger {
+// ── StderrFallbackLogger ───────────────────────────────────
+/// Minimal fallback logger that writes to stderr.  Used as the
+/// default before SpdlogLogger is installed via init_process().
+/// Has no dependency on spdlog — keeps ilogger.h decoupled.
+class StderrFallbackLogger final : public ILogger {
 public:
     void log(Level level, std::string_view msg) override {
-        spdlog::log(to_spdlog_level(level), "{}", msg);
+        static constexpr const char* kLevelNames[] = {"DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"};
+        const auto                   idx           = static_cast<uint8_t>(level);
+        const char*                  name          = (idx < 5) ? kLevelNames[idx] : "UNKNOWN";
+        std::fprintf(stderr, "[%s] %.*s\n", name, static_cast<int>(msg.size()), msg.data());
     }
 
-    [[nodiscard]] bool should_log(Level level) const override {
-        return spdlog::should_log(to_spdlog_level(level));
-    }
-
-private:
-    static spdlog::level::level_enum to_spdlog_level(Level level) {
-        switch (level) {
-            case Level::Debug: return spdlog::level::debug;
-            case Level::Info: return spdlog::level::info;
-            case Level::Warn: return spdlog::level::warn;
-            case Level::Error: return spdlog::level::err;
-            case Level::Critical: return spdlog::level::critical;
-        }
-        return spdlog::level::info;  // unreachable, but silences -Wreturn-type
+    [[nodiscard]] bool should_log(Level /*level*/) const override {
+        return true;  // Fallback logger emits everything.
     }
 };
 
@@ -126,9 +120,10 @@ inline std::atomic<ILogger*>& logger_ptr() {
     return ptr;
 }
 
-/// Process-wide default SpdlogLogger instance.
+/// Process-wide fallback logger (stderr).  Used when no SpdlogLogger
+/// has been installed yet (before init_process) or after reset_logger().
 inline ILogger& default_logger() {
-    static SpdlogLogger instance;
+    static StderrFallbackLogger instance;
     return instance;
 }
 
@@ -142,8 +137,8 @@ inline ILogger& logger() {
     return detail::default_logger();
 }
 
-/// Install a custom logger (e.g. CapturingLogger for tests).
-/// Pass nullptr or call reset_logger() to revert to default.
+/// Install a custom logger (e.g. SpdlogLogger, CapturingLogger).
+/// Pass nullptr or call reset_logger() to revert to fallback.
 /// Thread-safe: serialized by mutex, atomic store visible to all readers.
 inline void set_logger(std::unique_ptr<ILogger> l) {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
@@ -151,7 +146,7 @@ inline void set_logger(std::unique_ptr<ILogger> l) {
     detail::logger_ptr().store(detail::logger_owner().get(), std::memory_order_release);
 }
 
-/// Revert to the default SpdlogLogger.
+/// Revert to the StderrFallbackLogger.
 inline void reset_logger() {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
     detail::logger_owner().reset();

--- a/common/util/include/util/ilogger.h
+++ b/common/util/include/util/ilogger.h
@@ -30,6 +30,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
@@ -99,11 +100,13 @@ private:
 // reset_logger() are cold-path (startup / tests) and hold a mutex to
 // protect the owning unique_ptr.
 //
-// SAFETY CONTRACT: set_logger() / reset_logger() must only be called
-// during single-threaded startup or in test fixture setup/teardown
-// (before/after worker threads are running).  Calling them while other
-// threads are actively logging is a use-after-free.  See issue #384
-// for a planned RCU-style fix that eliminates this constraint.
+// RCU-style retirement (Issue #384): When set_logger() or reset_logger()
+// replaces the active logger, the OLD logger is moved into a retirement
+// vector rather than destroyed.  This eliminates use-after-free: any
+// thread that loaded the old pointer via logger() can safely finish its
+// log call even if another thread concurrently swaps the logger.  The
+// cost is a few leaked logger objects (2-3 per process lifetime max),
+// which is negligible for a process that runs for hours/days.
 
 namespace detail {
 
@@ -118,6 +121,13 @@ inline std::mutex& logger_mutex() {
 inline std::unique_ptr<ILogger>& logger_owner() {
     static std::unique_ptr<ILogger> owner;
     return owner;
+}
+
+/// Retired loggers — kept alive to prevent use-after-free.
+/// Only accessed under logger_mutex().
+inline std::vector<std::unique_ptr<ILogger>>& retired_loggers() {
+    static std::vector<std::unique_ptr<ILogger>> vec;
+    return vec;
 }
 
 /// Atomic raw pointer cache for hot-path reads (null = use default).
@@ -145,16 +155,26 @@ inline ILogger& logger() {
 /// Install a custom logger (e.g. CapturingLogger for tests).
 /// Pass nullptr or call reset_logger() to revert to default.
 /// Thread-safe: serialized by mutex, atomic store visible to all readers.
+/// The previous logger is retired (kept alive) to prevent use-after-free
+/// if another thread is still using it.
 inline void set_logger(std::unique_ptr<ILogger> l) {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
+    // Retire the old logger — do NOT destroy it.
+    if (detail::logger_owner()) {
+        detail::retired_loggers().push_back(std::move(detail::logger_owner()));
+    }
     detail::logger_owner() = std::move(l);
     detail::logger_ptr().store(detail::logger_owner().get(), std::memory_order_release);
 }
 
 /// Revert to the default SpdlogLogger.
+/// The previous logger is retired (kept alive) to prevent use-after-free.
 inline void reset_logger() {
     std::lock_guard<std::mutex> lock(detail::logger_mutex());
-    detail::logger_owner().reset();
+    // Retire the old logger — do NOT destroy it.
+    if (detail::logger_owner()) {
+        detail::retired_loggers().push_back(std::move(detail::logger_owner()));
+    }
     detail::logger_ptr().store(nullptr, std::memory_order_release);
 }
 

--- a/common/util/include/util/log_config.h
+++ b/common/util/include/util/log_config.h
@@ -1,10 +1,15 @@
 // common/util/include/util/log_config.h
 // Logging initialisation using spdlog.
+//
+// After configuring spdlog sinks and levels, installs a SpdlogLogger as the
+// global ILogger so that all DRONE_LOG_* macros route through spdlog.
 #pragma once
 #include "util/ilogger.h"
 #include "util/json_log_sink.h"
+#include "util/spdlog_logger.h"
 
 #include <cstdlib>
+#include <memory>
 #include <string>
 
 #include <spdlog/sinks/rotating_file_sink.h>
@@ -58,6 +63,11 @@ inline void init(const std::string& process_name, const std::string& log_dir,
             logger->set_level(spdlog::level::info);
 
         spdlog::set_default_logger(logger);
+
+        // Install SpdlogLogger as the global ILogger so DRONE_LOG_* macros
+        // route through the spdlog logger we just configured.
+        drone::log::set_logger(std::make_unique<drone::log::SpdlogLogger>());
+
         DRONE_LOG_INFO("Logger '{}' initialised — level={}, json={}", process_name, level_str,
                        json_mode ? "on" : "off");
     } catch (const spdlog::spdlog_ex& ex) {

--- a/common/util/include/util/spdlog_logger.h
+++ b/common/util/include/util/spdlog_logger.h
@@ -1,10 +1,48 @@
 // common/util/include/util/spdlog_logger.h
-// Convenience header — re-exports SpdlogLogger from ilogger.h.
+// Production ILogger implementation that delegates to spdlog.
 //
-// SpdlogLogger is the default ILogger implementation, defined in
-// ilogger.h to make the DRONE_LOG macros self-contained.
-// Include this header if you need to explicitly reference SpdlogLogger
-// (e.g. to construct one for a non-default spdlog logger instance).
+// Separated from ilogger.h (Issue #385) so that the 60+ files including
+// ilogger.h do not transitively depend on spdlog headers.
+//
+// Include this header only where SpdlogLogger is explicitly constructed:
+//   - log_config.h (LogConfig::init installs SpdlogLogger via set_logger)
+//   - process_context.h (includes log_config.h)
+//   - Tests that directly exercise SpdlogLogger behaviour
+//
+// All other code should include only ilogger.h and use the DRONE_LOG_* macros.
 #pragma once
 
 #include "util/ilogger.h"
+
+#include <spdlog/spdlog.h>
+
+namespace drone::log {
+
+// ── Level conversion ───────────────────────────────────────
+/// Map drone::log::Level to spdlog::level::level_enum.
+inline spdlog::level::level_enum to_spdlog_level(Level level) {
+    switch (level) {
+        case Level::Debug: return spdlog::level::debug;
+        case Level::Info: return spdlog::level::info;
+        case Level::Warn: return spdlog::level::warn;
+        case Level::Error: return spdlog::level::err;
+        case Level::Critical: return spdlog::level::critical;
+    }
+    return spdlog::level::info;  // unreachable, but silences -Wreturn-type
+}
+
+// ── SpdlogLogger ───────────────────────────────────────────
+/// Production logger that delegates to spdlog's default logger.
+/// Installed during init_process() via LogConfig::init().
+class SpdlogLogger final : public ILogger {
+public:
+    void log(Level level, std::string_view msg) override {
+        spdlog::log(to_spdlog_level(level), "{}", msg);
+    }
+
+    [[nodiscard]] bool should_log(Level level) const override {
+        return spdlog::should_log(to_spdlog_level(level));
+    }
+};
+
+}  // namespace drone::log

--- a/process4_mission_planner/include/planner/mission_fsm.h
+++ b/process4_mission_planner/include/planner/mission_fsm.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <string>
+#include <vector>
 
 namespace drone::planner {
 

--- a/process6_payload_manager/include/payload/gimbal_controller.h
+++ b/process6_payload_manager/include/payload/gimbal_controller.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "util/ilogger.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cstdint>

--- a/tests/test_iclock.cpp
+++ b/tests/test_iclock.cpp
@@ -7,7 +7,9 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -308,4 +310,89 @@ TEST(IClockPolymorphismTest, NowSecondsConvenienceMethod) {
     MockClock     mock(1'500'000'000ULL);
     const IClock& ref = mock;
     EXPECT_DOUBLE_EQ(ref.now_seconds(), 1.5);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  RCU-style retirement tests (Issue #384)
+// ════════════════════════════════════════════════════════════════════
+
+TEST(ClockRCUTest, SetClockOwningOverload) {
+    // Test the unique_ptr overload of set_clock.
+    auto  mock = std::make_unique<MockClock>(42'000'000ULL);
+    auto* ptr  = mock.get();
+    set_clock(std::move(mock));
+
+    EXPECT_EQ(get_clock().now_ns(), 42'000'000ULL);
+
+    // Advance via the raw pointer we kept.
+    ptr->advance_ms(10);
+    EXPECT_EQ(get_clock().now_ns(), 52'000'000ULL);
+
+    // Restore default.
+    set_clock(nullptr);
+}
+
+TEST(ClockRCUTest, OldClockSurvivesAfterReplacement) {
+    // The old clock must remain callable after set_clock() replaces it,
+    // because the retirement vector keeps owned clocks alive.
+    auto  mock1 = std::make_unique<MockClock>(100ULL);
+    auto* ptr1  = mock1.get();
+    set_clock(std::move(mock1));
+
+    EXPECT_EQ(get_clock().now_ns(), 100ULL);
+
+    // Replace with a second clock — ptr1 should still be alive (retired).
+    auto mock2 = std::make_unique<MockClock>(200ULL);
+    set_clock(std::move(mock2));
+
+    // The old clock (ptr1) must still be callable — not destroyed.
+    EXPECT_EQ(ptr1->now_ns(), 100ULL);
+    ptr1->advance_ns(50);
+    EXPECT_EQ(ptr1->now_ns(), 150ULL);
+
+    // Restore default.
+    set_clock(nullptr);
+}
+
+TEST(ClockRCUTest, ConcurrentClockAccessDuringSwap) {
+    // Stress test: multiple threads call get_clock() while another thread
+    // swaps clocks.  Must not crash or trigger TSAN/ASAN.
+    constexpr int kIterations = 5000;
+    constexpr int kReaders    = 4;
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> stop{false};
+
+    // Reader threads: continuously call get_clock().now_ns().
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int i = 0; i < kReaders; ++i) {
+        readers.emplace_back([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            while (!stop.load(std::memory_order_acquire)) {
+                auto t = get_clock().now_ns();
+                (void)t;  // Just ensure no crash/TSAN race
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    // Writer thread: swap clocks repeatedly using the non-owning overload
+    // (stack-allocated MockClocks).
+    MockClock clocks[2]{MockClock(1'000'000ULL), MockClock(2'000'000ULL)};
+    for (int i = 0; i < kIterations; ++i) {
+        set_clock(&clocks[i % 2]);
+    }
+
+    stop.store(true, std::memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    // Restore default.
+    set_clock(nullptr);
+    // If we get here without crash/TSAN flag, the test passes.
 }

--- a/tests/test_ilogger.cpp
+++ b/tests/test_ilogger.cpp
@@ -7,6 +7,7 @@
 #include "util/capturing_logger.h"
 #include "util/ilogger.h"
 #include "util/null_logger.h"
+#include "util/spdlog_logger.h"
 
 #include <memory>
 #include <string>

--- a/tests/test_ilogger.cpp
+++ b/tests/test_ilogger.cpp
@@ -8,8 +8,11 @@
 #include "util/ilogger.h"
 #include "util/null_logger.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -249,4 +252,103 @@ TEST(ILoggerTest, LevelOrdering) {
     EXPECT_LT(static_cast<uint8_t>(L::Info), static_cast<uint8_t>(L::Warn));
     EXPECT_LT(static_cast<uint8_t>(L::Warn), static_cast<uint8_t>(L::Error));
     EXPECT_LT(static_cast<uint8_t>(L::Error), static_cast<uint8_t>(L::Critical));
+}
+
+// ═══════════════════════════════════════════════════════════════
+// RCU-style retirement (Issue #384)
+// ═══════════════════════════════════════════════════════════════
+
+TEST(ILoggerRCUTest, OldLoggerSurvivesAfterSetLogger) {
+    // The old logger must remain callable after set_logger() replaces it,
+    // because the retirement vector keeps it alive.
+    LoggerGuard guard;
+
+    auto  cap1 = std::make_unique<drone::log::CapturingLogger>();
+    auto* ptr1 = cap1.get();
+    drone::log::set_logger(std::move(cap1));
+
+    DRONE_LOG_INFO("msg1");
+    EXPECT_EQ(ptr1->count(), 1u);
+
+    // Replace with a second logger — ptr1 should still be alive (retired).
+    auto  cap2 = std::make_unique<drone::log::CapturingLogger>();
+    auto* ptr2 = cap2.get();
+    drone::log::set_logger(std::move(cap2));
+
+    // The old logger (ptr1) must still be callable — not destroyed.
+    EXPECT_EQ(ptr1->count(), 1u);
+    ptr1->log(drone::log::Level::Info, "still alive");
+    EXPECT_EQ(ptr1->count(), 2u);
+
+    // New logger works too.
+    DRONE_LOG_INFO("msg2");
+    EXPECT_EQ(ptr2->count(), 1u);
+}
+
+TEST(ILoggerRCUTest, OldLoggerSurvivesAfterResetLogger) {
+    LoggerGuard guard;
+
+    auto  cap = std::make_unique<drone::log::CapturingLogger>();
+    auto* ptr = cap.get();
+    drone::log::set_logger(std::move(cap));
+
+    DRONE_LOG_INFO("before reset");
+    EXPECT_EQ(ptr->count(), 1u);
+
+    // Reset to default — old logger must survive (retired).
+    drone::log::reset_logger();
+
+    // The old logger (ptr) must still be callable.
+    EXPECT_EQ(ptr->count(), 1u);
+    ptr->log(drone::log::Level::Info, "still alive after reset");
+    EXPECT_EQ(ptr->count(), 2u);
+}
+
+TEST(ILoggerRCUTest, ConcurrentLoggerAccessDuringSwap) {
+    // Stress test: multiple threads call logger() while another thread
+    // swaps loggers.  Must not crash or trigger TSAN/ASAN.
+    //
+    // Uses NullLogger (thread-safe, no-op) rather than CapturingLogger
+    // (not thread-safe) since we are testing the swap mechanism, not
+    // the logger implementation.
+    LoggerGuard guard;
+
+    constexpr int kIterations = 5000;
+    constexpr int kReaders    = 4;
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> stop{false};
+
+    // Reader threads: continuously call logger() and invoke should_log().
+    // NullLogger::should_log() returns false, so log() is never called.
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for (int i = 0; i < kReaders; ++i) {
+        readers.emplace_back([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            while (!stop.load(std::memory_order_acquire)) {
+                auto& lg = drone::log::logger();
+                // Exercise the pointer dereference — the key safety property.
+                auto can_log = lg.should_log(drone::log::Level::Debug);
+                (void)can_log;
+            }
+        });
+    }
+
+    start.store(true, std::memory_order_release);
+
+    // Writer thread: swap loggers repeatedly.
+    for (int i = 0; i < kIterations; ++i) {
+        drone::log::set_logger(std::make_unique<drone::log::NullLogger>());
+    }
+
+    stop.store(true, std::memory_order_release);
+    for (auto& t : readers) {
+        t.join();
+    }
+
+    // If we get here without crash/TSAN flag, the test passes.
+    drone::log::reset_logger();
 }


### PR DESCRIPTION
## Summary

- `set_logger()` / `reset_logger()` now retire old loggers into a static vector instead of destroying them — eliminates use-after-free when another thread holds a reference from `logger()`
- Same pattern applied to `IClock`: new `set_clock(unique_ptr)` overload, old clocks retired on swap
- Hot path unchanged: `logger()` and `get_clock()` cost one atomic load + one branch
- 6 new tests: retirement survival + concurrent stress for both APIs

## Test plan
- [x] Build: zero warnings
- [x] Tests: 1435/1435 pass (+6 new)
- [x] Format: clang-format-18 clean
- [ ] Copilot review

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)