### PR TITLE
Epic #284 Wave 6: ISerializer abstraction + PluginLoader

### DIFF
--- a/.claude/skills/deploy-issue/SKILL.md
+++ b/.claude/skills/deploy-issue/SKILL.md
@@ -484,6 +484,7 @@ User choices:
 - **accept** → proceed to CP5 (findings are acceptable as-is)
 - **fix** → spawn feature agent with findings, then re-validate, commit, push, and **re-run the FULL Phase 5 review (BOTH Pass 1 AND Pass 2)**. This is mandatory — do NOT skip Pass 2 or go directly to CP5 after fixes. The fix loop always returns to Step 5.1 (roster approval).
 - **fix \<numbers\>** → fix only specific issues by number (e.g., `fix 1 3`), accept the rest as-is. Still re-runs full Phase 5.
+- **defer with rationale** → for P3 findings or comments where we disagree with the recommendation, document the decision in `docs/guides/DESIGN_RATIONALE.md` as a new DR-NNN entry. This creates an audit trail showing the comment was evaluated and the trade-offs weighed — not ignored. Each deferred item needs: the question, arguments for both sides, our decision, and when to revisit.
 - **back** → return to CP3
 - **reject** → go to ABORT
 

--- a/.claude/skills/deploy-wave/SKILL.md
+++ b/.claude/skills/deploy-wave/SKILL.md
@@ -327,7 +327,8 @@ Pass 2: <N> agents, <P1> findings, <P2> findings
 
 User choices:
 - **accept** → proceed to Phase 5
-- **fix** → fix issues, re-validate, re-review (loop back to Phase 3 for affected issues only)
+- **fix** → fix issues, re-validate, re-review. **Always re-run BOTH Pass 1 AND Pass 2** — fixes frequently introduce new issues. Loop back to Step 4.2 (roster approval), not Phase 3.
+- **defer with rationale** → for P3 findings or comments where we disagree with the recommendation, document each decision in `docs/guides/DESIGN_RATIONALE.md` as a new DR-NNN entry. This creates an audit trail showing the comment was evaluated, trade-offs weighed, and the decision was intentional — not an oversight. Each entry needs: the question, arguments for both sides, our decision, and when to revisit.
 - **abort** → stop
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,8 @@ After addressing review comments:
 
 **Codebase-wide scope:** When a review comment identifies an issue that could apply elsewhere in the codebase (e.g., misleading comments, inconsistent log levels, missing test patterns), always search for and fix all occurrences — not just the one the reviewer pointed out. A review comment on one file is a signal to check the whole codebase for the same pattern.
 
+**Disagreeing with review comments:** When declining to fix a review comment (from Copilot, review agents, or humans) based on a justified rationale, **always document the decision in `docs/guides/DESIGN_RATIONALE.md`** as a new DR-NNN entry. This creates an audit trail showing the comment was evaluated, the trade-offs were weighed, and the decision was intentional — not an oversight. Include the question, arguments for both sides, our decision, and when to revisit. This applies to both P3 deferrals and genuine "we disagree" situations.
+
 ### Planning & Self-Correction (from `docs/guides/work_instructions.md`)
 - Enter plan mode for any non-trivial task (3+ steps or architectural decisions)
 - If something goes sideways, stop and re-plan — don't keep pushing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ ctest --test-dir build --output-on-failure -j$(nproc)
 
 **Before reporting "all tests pass" — verify:**
 - [ ] Correct branch? (`git branch --show-current`)
-- [ ] Test count matches baseline? (currently **1259** — see [tests/TESTS.md](tests/TESTS.md))
+- [ ] Test count matches baseline? (currently **1461** — see [tests/TESTS.md](tests/TESTS.md))
 - [ ] Zero compiler warnings? (build uses `-Werror -Wall -Wextra`)
 - [ ] clang-format clean? (`git diff --name-only | xargs clang-format-18 --dry-run --Werror`)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,19 @@ find_package(spdlog        REQUIRED)
 find_package(Eigen3        REQUIRED NO_MODULE)
 find_package(nlohmann_json REQUIRED)
 
+# ── Optional: runtime plugin loading ────────────────────────
+# When enabled, HAL factories gain a "plugin" backend that loads
+# .so files at runtime via dlopen.  OFF by default — only enable
+# in trusted environments (arbitrary .so loading = arbitrary code).
+option(ENABLE_PLUGINS "Enable runtime plugin loading via dlopen" OFF)
+
+if(ENABLE_PLUGINS)
+    add_compile_definitions(HAVE_PLUGINS=1)
+    message(STATUS "  Plugins      : ENABLED (dlopen)")
+else()
+    message(STATUS "  Plugins      : DISABLED")
+endif()
+
 # ── Optional: systemd integration ───────────────────────────
 # When enabled, P7 (system_monitor) calls sd_notify() for watchdog support.
 # Requires libsystemd-dev.  Harmless to enable on non-systemd systems at
@@ -230,6 +243,7 @@ message(STATUS "  MAVSDK       : ${MAVSDK_FOUND}")
 message(STATUS "  Gazebo       : ${GAZEBO_FOUND}")
 message(STATUS "  OpenCV       : ${OPENCV_FOUND}")
 message(STATUS "  Zenoh        : REQUIRED")
+message(STATUS "  Plugins      : ${ENABLE_PLUGINS}")
 message(STATUS "  systemd      : ${ENABLE_SYSTEMD}")
 message(STATUS "  ── Processes ──")
 message(STATUS "  P1 video_capture   : ${ENABLE_PROCESS_VIDEO_CAPTURE}")

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -40,6 +40,10 @@
 #include "hal/gazebo_radar.h"
 #endif
 
+#ifdef HAVE_PLUGINS
+#include "util/plugin_loader.h"
+#endif
+
 #include "util/config.h"
 #include "util/config_keys.h"
 #include "util/ilogger.h"
@@ -67,6 +71,18 @@ namespace drone::hal {
     }
 #endif
     // Future: if (backend == "v4l2") return std::make_unique<V4L2Camera>();
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<ICamera>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
 
     throw std::runtime_error("[HAL] Unknown camera backend: " + backend);
 }
@@ -85,7 +101,19 @@ namespace drone::hal {
 #ifdef HAVE_MAVSDK
     if (backend == "mavlink") return std::make_unique<MavlinkFCLink>();
 #endif
-    // Future: if (backend == "mavlink_v2") return std::make_unique<MavlinkV2Link>();
+        // Future: if (backend == "mavlink_v2") return std::make_unique<MavlinkV2Link>();
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<IFCLink>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
 
     throw std::runtime_error("[HAL] Unknown FC link backend: " + backend);
 }
@@ -102,6 +130,18 @@ namespace drone::hal {
         return std::make_unique<SimulatedGCSLink>();
     }
     // Future: if (backend == "udp") return std::make_unique<UDPGCSLink>();
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<IGCSLink>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
 
     throw std::runtime_error("[HAL] Unknown GCS link backend: " + backend);
 }
@@ -118,6 +158,18 @@ namespace drone::hal {
         return std::make_unique<SimulatedGimbal>();
     }
     // Future: if (backend == "siyi") return std::make_unique<SIYIGimbal>();
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<IGimbal>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
 
     throw std::runtime_error("[HAL] Unknown gimbal backend: " + backend);
 }
@@ -141,6 +193,18 @@ namespace drone::hal {
     }
 #endif
     // Future: if (backend == "bmi088") return std::make_unique<BMI088IMU>();
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<IIMUSource>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
 
     throw std::runtime_error("[HAL] Unknown IMU backend: " + backend);
 }
@@ -160,6 +224,19 @@ namespace drone::hal {
 #ifdef HAVE_GAZEBO
     if (backend == "gazebo") {
         return std::make_unique<GazeboRadarBackend>(cfg, section);
+    }
+#endif
+
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                            "create_instance");
+        auto result  = drone::util::PluginLoader::load<IRadar>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
     }
 #endif
 

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -53,6 +53,33 @@
 
 namespace drone::hal {
 
+#ifdef HAVE_PLUGINS
+/// Load a plugin backend from config.  Centralises the read-config → load →
+/// extract pattern so all create_* functions share the same validation logic.
+/// @param cfg      Loaded configuration
+/// @param section  Config path prefix (e.g. "video_capture.mission_cam")
+/// @param label    Human-readable label for error messages (e.g. "camera")
+template<typename Interface>
+[[nodiscard]] inline std::unique_ptr<Interface> load_plugin(const drone::Config& cfg,
+                                                            const std::string&   section,
+                                                            const std::string&   label) {
+    auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+    auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                        "create_instance");
+    if (so_path.empty()) {
+        throw std::runtime_error("[HAL] " + label +
+                                 " plugin requires a non-empty config value "
+                                 "at '" +
+                                 section + drone::cfg_key::hal::PLUGIN_PATH + "'");
+    }
+    auto result = drone::util::PluginLoader::load<Interface>(so_path, factory);
+    if (result.is_err()) {
+        throw std::runtime_error("[HAL] " + label + " plugin load failed: " + result.error());
+    }
+    return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+}
+#endif
+
 /// Create a camera backend from config.
 /// @param cfg      Loaded configuration
 /// @param section  Config path prefix (e.g. "video_capture.mission_cam")
@@ -73,14 +100,7 @@ namespace drone::hal {
     // Future: if (backend == "v4l2") return std::make_unique<V4L2Camera>();
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<ICamera>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<ICamera>(cfg, section, "camera");
     }
 #endif
 
@@ -104,14 +124,7 @@ namespace drone::hal {
         // Future: if (backend == "mavlink_v2") return std::make_unique<MavlinkV2Link>();
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<IFCLink>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<IFCLink>(cfg, section, "FC link");
     }
 #endif
 
@@ -132,14 +145,7 @@ namespace drone::hal {
     // Future: if (backend == "udp") return std::make_unique<UDPGCSLink>();
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<IGCSLink>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<IGCSLink>(cfg, section, "GCS link");
     }
 #endif
 
@@ -160,14 +166,7 @@ namespace drone::hal {
     // Future: if (backend == "siyi") return std::make_unique<SIYIGimbal>();
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<IGimbal>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<IGimbal>(cfg, section, "gimbal");
     }
 #endif
 
@@ -195,14 +194,7 @@ namespace drone::hal {
     // Future: if (backend == "bmi088") return std::make_unique<BMI088IMU>();
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<IIMUSource>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<IIMUSource>(cfg, section, "IMU source");
     }
 #endif
 
@@ -229,14 +221,7 @@ namespace drone::hal {
 
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
-        auto so_path = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg.get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
-                                            "create_instance");
-        auto result  = drone::util::PluginLoader::load<IRadar>(so_path, factory);
-        if (result.is_err()) {
-            throw std::runtime_error("[HAL] Plugin load failed: " + result.error());
-        }
-        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+        return load_plugin<IRadar>(cfg, section, "radar");
     }
 #endif
 

--- a/common/ipc/include/ipc/iserializer.h
+++ b/common/ipc/include/ipc/iserializer.h
@@ -1,0 +1,75 @@
+// common/ipc/include/ipc/iserializer.h
+// Abstract serialization interface for IPC message types.
+//
+// Decouples wire format from transport:  ZenohPublisher/Subscriber delegate
+// to ISerializer<T> instead of hardcoding reinterpret_cast + std::copy.
+// The default (and currently only) implementation is RawSerializer<T>,
+// which produces byte-identical output to the previous inline code.
+//
+// Virtual dispatch overhead (~1-3 ns per call) is negligible compared to
+// Zenoh transport latency (~10-100 us).  This is a deliberate design
+// choice: the simpler virtual interface wins over CRTP complexity.
+//
+// Part of Epic #284 (Platform Modularity), Issue #294.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace drone::ipc {
+
+/// Abstract serializer for IPC message type T.
+///
+/// Implementations define how a message is converted to/from raw bytes.
+/// The interface supports both buffer-write (for SHM zero-copy) and
+/// vector-return (for standard bytes path) serialization.
+///
+/// Serializers are stateless and const-safe, so a single instance can
+/// be shared (via shared_ptr<const ISerializer<T>>) across multiple
+/// publishers/subscribers for the same message type.
+template<typename T>
+class ISerializer {
+public:
+    virtual ~ISerializer() = default;
+
+    ISerializer()                              = default;
+    ISerializer(const ISerializer&)            = default;
+    ISerializer& operator=(const ISerializer&) = default;
+    ISerializer(ISerializer&&)                 = default;
+    ISerializer& operator=(ISerializer&&)      = default;
+
+    /// Serialize msg into a pre-allocated buffer.
+    /// Used by the SHM zero-copy path where the buffer is a Zenoh SHM region.
+    /// @param msg       Message to serialize.
+    /// @param buf       Destination buffer (caller-owned).
+    /// @param buf_size  Size of the destination buffer in bytes.
+    /// @return Number of bytes written, or 0 on failure (e.g. buffer too small).
+    [[nodiscard]] virtual size_t serialize(const T& msg, uint8_t* buf, size_t buf_size) const = 0;
+
+    /// Serialize msg into a new vector.
+    /// Used by the standard bytes path.
+    /// @param msg  Message to serialize.
+    /// @return Vector of serialized bytes.
+    [[nodiscard]] virtual std::vector<uint8_t> serialize(const T& msg) const = 0;
+
+    /// Deserialize from raw bytes into out.
+    /// @param data  Source bytes.
+    /// @param size  Number of source bytes.
+    /// @param out   Destination message (caller-owned).
+    /// @return true on success, false on size mismatch or format error.
+    [[nodiscard]] virtual bool deserialize(const uint8_t* data, size_t size, T& out) const = 0;
+
+    /// Serialized size for the given message.
+    /// For fixed-size formats (e.g. raw), this is constant.
+    /// For variable-length formats (e.g. protobuf), it may vary per message.
+    /// @param msg  Message to measure.
+    /// @return Serialized size in bytes.
+    [[nodiscard]] virtual size_t serialized_size(const T& msg) const = 0;
+
+    /// Human-readable name for logging (e.g. "raw", "protobuf").
+    [[nodiscard]] virtual std::string_view name() const = 0;
+};
+
+}  // namespace drone::ipc

--- a/common/ipc/include/ipc/iserializer.h
+++ b/common/ipc/include/ipc/iserializer.h
@@ -35,8 +35,8 @@ public:
     virtual ~ISerializer() = default;
 
     ISerializer()                              = default;
-    ISerializer(const ISerializer&)            = default;
-    ISerializer& operator=(const ISerializer&) = default;
+    ISerializer(const ISerializer&)            = delete;
+    ISerializer& operator=(const ISerializer&) = delete;
     ISerializer(ISerializer&&)                 = default;
     ISerializer& operator=(ISerializer&&)      = default;
 

--- a/common/ipc/include/ipc/message_bus_factory.h
+++ b/common/ipc/include/ipc/message_bus_factory.h
@@ -85,6 +85,14 @@ MessageBus create_message_bus(const ConfigT& cfg) {
         zenoh_json = net_cfg.to_json();
     }
 
+    // Validate serializer setting (only "raw" is currently supported)
+    const auto serializer = cfg.template get<std::string>(drone::cfg_key::IPC_SERIALIZER, "raw");
+    if (serializer != "raw") {
+        DRONE_LOG_WARN("[MessageBusFactory] Unknown ipc_serializer '{}' — "
+                       "only 'raw' is currently supported. Using 'raw'.",
+                       serializer);
+    }
+
     auto bus = create_message_bus(backend, shm_pool_mb, zenoh_json);
 
     // Apply vehicle_id topic namespacing if configured

--- a/common/ipc/include/ipc/raw_serializer.h
+++ b/common/ipc/include/ipc/raw_serializer.h
@@ -1,0 +1,73 @@
+// common/ipc/include/ipc/raw_serializer.h
+// Raw binary serializer — trivially-copyable structs via reinterpret_cast.
+//
+// Produces byte-identical output to the previous inline serialization in
+// ZenohPublisher/Subscriber, ensuring wire-format backward compatibility.
+//
+// The static_assert on trivially_copyable lives here (not in ZenohPublisher)
+// so that future serializers (e.g. ProtobufSerializer) can handle
+// non-trivially-copyable types without hitting the constraint.
+//
+// Part of Epic #284 (Platform Modularity), Issue #294.
+#pragma once
+
+#include "ipc/iserializer.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace drone::ipc {
+
+/// Raw binary serializer for trivially-copyable IPC structs.
+///
+/// Uses reinterpret_cast + std::copy — the same mechanism previously
+/// hardcoded in ZenohPublisher/Subscriber.  Wire format is the raw
+/// object representation: sizeof(T) bytes, host byte order.
+template<typename T>
+class RawSerializer final : public ISerializer<T> {
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "RawSerializer requires trivially copyable types");
+
+public:
+    /// Serialize msg into a pre-allocated buffer (SHM zero-copy path).
+    /// @return sizeof(T) on success, 0 if buf_size < sizeof(T).
+    [[nodiscard]] size_t serialize(const T& msg, uint8_t* buf, size_t buf_size) const override {
+        if (buf_size < sizeof(T)) {
+            return 0;
+        }
+        const auto* src = reinterpret_cast<const uint8_t*>(&msg);
+        std::copy(src, src + sizeof(T), buf);
+        return sizeof(T);
+    }
+
+    /// Serialize msg to a new vector (standard bytes path).
+    [[nodiscard]] std::vector<uint8_t> serialize(const T& msg) const override {
+        const auto* ptr = reinterpret_cast<const uint8_t*>(&msg);
+        return std::vector<uint8_t>(ptr, ptr + sizeof(T));
+    }
+
+    /// Deserialize from raw bytes.
+    /// @return false if size != sizeof(T).
+    [[nodiscard]] bool deserialize(const uint8_t* data, size_t size, T& out) const override {
+        if (size != sizeof(T)) {
+            return false;
+        }
+        auto* dst = reinterpret_cast<uint8_t*>(&out);
+        std::copy(data, data + size, dst);
+        return true;
+    }
+
+    /// Serialized size is always sizeof(T) for raw format.
+    [[nodiscard]] size_t serialized_size([[maybe_unused]] const T& msg) const override {
+        return sizeof(T);
+    }
+
+    /// Returns "raw".
+    [[nodiscard]] std::string_view name() const override { return "raw"; }
+};
+
+}  // namespace drone::ipc

--- a/common/ipc/include/ipc/raw_serializer.h
+++ b/common/ipc/include/ipc/raw_serializer.h
@@ -36,7 +36,7 @@ public:
     /// Serialize msg into a pre-allocated buffer (SHM zero-copy path).
     /// @return sizeof(T) on success, 0 if buf_size < sizeof(T).
     [[nodiscard]] size_t serialize(const T& msg, uint8_t* buf, size_t buf_size) const override {
-        if (buf_size < sizeof(T)) {
+        if (!buf || buf_size < sizeof(T)) {
             return 0;
         }
         const auto* src = reinterpret_cast<const uint8_t*>(&msg);
@@ -53,7 +53,7 @@ public:
     /// Deserialize from raw bytes.
     /// @return false if size != sizeof(T).
     [[nodiscard]] bool deserialize(const uint8_t* data, size_t size, T& out) const override {
-        if (size != sizeof(T)) {
+        if (!data || size != sizeof(T)) {
             return false;
         }
         auto* dst = reinterpret_cast<uint8_t*>(&out);

--- a/common/ipc/include/ipc/zenoh_publisher.h
+++ b/common/ipc/include/ipc/zenoh_publisher.h
@@ -46,29 +46,32 @@ public:
     explicit ZenohPublisher(
         const std::string&                    key_expr,
         std::shared_ptr<const ISerializer<T>> serializer = std::make_shared<RawSerializer<T>>())
-        : key_expr_(key_expr), serializer_(std::move(serializer)) {
+        : key_expr_(key_expr)
+        , serializer_(serializer ? std::move(serializer) : std::make_shared<RawSerializer<T>>()) {
         try {
             auto& session = ZenohSession::instance().session();
             publisher_.emplace(session.declare_publisher(zenoh::KeyExpr(key_expr)));
-            ready_ = true;
+            ready_.store(true, std::memory_order_release);
             DRONE_LOG_INFO("[ZenohPublisher] Declared on '{}' "
                            "(size={}, shm={}, serializer={})",
                            key_expr, sizeof(T), sizeof(T) > kShmPublishThreshold ? "yes" : "no",
                            serializer_->name());
         } catch (const std::exception& e) {
             DRONE_LOG_ERROR("[ZenohPublisher] Failed to declare on '{}': {}", key_expr, e.what());
-            ready_ = false;
+            ready_.store(false, std::memory_order_release);
         }
     }
 
     void publish(const T& msg) override {
-        if (!ready_ || !publisher_.has_value()) return;
+        if (!ready_.load(std::memory_order_acquire) || !publisher_.has_value()) return;
 
         if constexpr (sizeof(T) > kShmPublishThreshold) {
             publish_shm(msg);
+            // relaxed: diagnostic-only counter, no dependent data
             shm_publishes_.fetch_add(1, std::memory_order_relaxed);
         } else {
             publish_bytes(msg);
+            // relaxed: diagnostic-only counter, no dependent data
             bytes_publishes_.fetch_add(1, std::memory_order_relaxed);
         }
     }
@@ -85,7 +88,7 @@ public:
 
     [[nodiscard]] const std::string& topic_name() const override { return key_expr_; }
 
-    [[nodiscard]] bool is_ready() const override { return ready_; }
+    [[nodiscard]] bool is_ready() const override { return ready_.load(std::memory_order_acquire); }
 
 private:
     /// Small-message path: serialize to vector<uint8_t>.
@@ -116,8 +119,10 @@ private:
 
         // Zero-copy write: serialize directly into shared memory
         const size_t written = serializer_->serialize(msg, buf->data(), needed);
-        if (written == 0) {
-            DRONE_LOG_WARN("[ZenohPublisher] Serialization into SHM failed on '{}'", key_expr_);
+        if (written == 0 || written != needed) {
+            DRONE_LOG_WARN("[ZenohPublisher] SHM serialization produced {} bytes, expected {} "
+                           "on '{}'; falling back to bytes",
+                           written, needed, key_expr_);
             publish_bytes(msg);
             return;
         }
@@ -131,7 +136,7 @@ private:
     std::string                           key_expr_;
     std::shared_ptr<const ISerializer<T>> serializer_;
     std::optional<zenoh::Publisher>       publisher_;
-    bool                                  ready_ = false;
+    std::atomic<bool>                     ready_{false};
     std::atomic<uint64_t>                 shm_publishes_{0};
     std::atomic<uint64_t>                 bytes_publishes_{0};
 };

--- a/common/ipc/include/ipc/zenoh_publisher.h
+++ b/common/ipc/include/ipc/zenoh_publisher.h
@@ -1,24 +1,32 @@
 // common/ipc/include/ipc/zenoh_publisher.h
 // Zenoh-backed publisher — wraps zenoh::Publisher behind IPublisher<T>.
 //
-// Publishes trivially-copyable T via Zenoh.  For large messages
-// (sizeof(T) > kShmPublishThreshold, e.g. video frames), the payload is
-// written directly into a Zenoh SHM buffer — zero-copy for local
-// subscribers.  Small messages use the regular Bytes path.
+// Publishes T via Zenoh using a pluggable ISerializer<T> for wire-format
+// encoding.  For large messages (sizeof(T) > kShmPublishThreshold, e.g.
+// video frames), the payload is written directly into a Zenoh SHM buffer
+// — zero-copy for local subscribers.  Small messages use the regular
+// Bytes path.
+//
+// The serializer defaults to RawSerializer<T> (byte-identical to the
+// previous inline reinterpret_cast + std::copy), preserving full backward
+// compatibility.  A future ProtobufSerializer<T> can be injected for
+// cross-language interop without changing transport code.
 //
 // Guarded by HAVE_ZENOH.
 #pragma once
 
 
 #include "ipc/ipublisher.h"
+#include "ipc/iserializer.h"
+#include "ipc/raw_serializer.h"
 #include "ipc/zenoh_session.h"
 #include "util/ilogger.h"
 
 #include <algorithm>
 #include <atomic>
+#include <memory>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <variant>
 #include <vector>
 
@@ -29,20 +37,24 @@ namespace drone::ipc {
 /// Zenoh-backed publisher implementing IPublisher<T>.
 template<typename T>
 class ZenohPublisher final : public IPublisher<T> {
-    static_assert(std::is_trivially_copyable_v<T>,
-                  "ZenohPublisher requires trivially copyable types");
-
 public:
     /// Construct and declare a Zenoh publisher on the given key expression.
-    /// @param key_expr  Zenoh key expression (e.g. "drone/slam/pose").
-    explicit ZenohPublisher(const std::string& key_expr) : key_expr_(key_expr) {
+    /// @param key_expr    Zenoh key expression (e.g. "drone/slam/pose").
+    /// @param serializer  Optional serializer (default: RawSerializer<T>).
+    ///                    shared_ptr because MessageBus may share one instance
+    ///                    across multiple publishers for the same type.
+    explicit ZenohPublisher(
+        const std::string&                    key_expr,
+        std::shared_ptr<const ISerializer<T>> serializer = std::make_shared<RawSerializer<T>>())
+        : key_expr_(key_expr), serializer_(std::move(serializer)) {
         try {
             auto& session = ZenohSession::instance().session();
             publisher_.emplace(session.declare_publisher(zenoh::KeyExpr(key_expr)));
             ready_ = true;
             DRONE_LOG_INFO("[ZenohPublisher] Declared on '{}' "
-                           "(size={}, shm={})",
-                           key_expr, sizeof(T), sizeof(T) > kShmPublishThreshold ? "yes" : "no");
+                           "(size={}, shm={}, serializer={})",
+                           key_expr, sizeof(T), sizeof(T) > kShmPublishThreshold ? "yes" : "no",
+                           serializer_->name());
         } catch (const std::exception& e) {
             DRONE_LOG_ERROR("[ZenohPublisher] Failed to declare on '{}': {}", key_expr, e.what());
             ready_ = false;
@@ -78,12 +90,11 @@ public:
 private:
     /// Small-message path: serialize to vector<uint8_t>.
     void publish_bytes(const T& msg) {
-        const auto*          ptr = reinterpret_cast<const uint8_t*>(&msg);
-        std::vector<uint8_t> buf(ptr, ptr + sizeof(T));
+        auto buf = serializer_->serialize(msg);
         publisher_->put(zenoh::Bytes(std::move(buf)));
     }
 
-    /// Large-message path: allocate SHM buffer, copy, publish zero-copy.
+    /// Large-message path: allocate SHM buffer, serialize into it, publish zero-copy.
     void publish_shm(const T& msg) {
         auto* provider = ZenohSession::instance().shm_provider();
         if (!provider) {
@@ -92,8 +103,9 @@ private:
             return;
         }
 
-        auto  result = provider->alloc_gc_defrag_blocking(sizeof(T));
-        auto* buf    = std::get_if<zenoh::ZShmMut>(&result);
+        const size_t needed = serializer_->serialized_size(msg);
+        auto         result = provider->alloc_gc_defrag_blocking(needed);
+        auto*        buf    = std::get_if<zenoh::ZShmMut>(&result);
         if (!buf) {
             DRONE_LOG_WARN("[ZenohPublisher] SHM alloc failed on '{}', "
                            "falling back to bytes",
@@ -102,9 +114,13 @@ private:
             return;
         }
 
-        // Zero-copy write: copy directly into shared memory
-        const auto* src = reinterpret_cast<const uint8_t*>(&msg);
-        std::copy(src, src + sizeof(T), buf->data());
+        // Zero-copy write: serialize directly into shared memory
+        const size_t written = serializer_->serialize(msg, buf->data(), needed);
+        if (written == 0) {
+            DRONE_LOG_WARN("[ZenohPublisher] Serialization into SHM failed on '{}'", key_expr_);
+            publish_bytes(msg);
+            return;
+        }
 
         // Move SHM buffer into Bytes and publish — only a descriptor
         // is sent over the transport; local subscribers receive a
@@ -112,11 +128,12 @@ private:
         publisher_->put(zenoh::Bytes(std::move(*buf)));
     }
 
-    std::string                     key_expr_;
-    std::optional<zenoh::Publisher> publisher_;
-    bool                            ready_ = false;
-    std::atomic<uint64_t>           shm_publishes_{0};
-    std::atomic<uint64_t>           bytes_publishes_{0};
+    std::string                           key_expr_;
+    std::shared_ptr<const ISerializer<T>> serializer_;
+    std::optional<zenoh::Publisher>       publisher_;
+    bool                                  ready_ = false;
+    std::atomic<uint64_t>                 shm_publishes_{0};
+    std::atomic<uint64_t>                 bytes_publishes_{0};
 };
 
 }  // namespace drone::ipc

--- a/common/ipc/include/ipc/zenoh_subscriber.h
+++ b/common/ipc/include/ipc/zenoh_subscriber.h
@@ -1,15 +1,22 @@
 // common/ipc/include/ipc/zenoh_subscriber.h
 // Zenoh-backed subscriber — wraps zenoh::Subscriber behind ISubscriber<T>.
 //
-// Receives trivially-copyable T from raw bytes via Zenoh callback.
-// The Zenoh callback runs on an internal Zenoh thread; receive() is called
-// from the process main loop.  Thread-safety is provided by atomics.
+// Receives T from raw bytes via Zenoh callback, using a pluggable
+// ISerializer<T> for wire-format decoding.  The Zenoh callback runs on
+// an internal Zenoh thread; receive() is called from the process main
+// loop.  Thread-safety is provided by atomics + mutex.
+//
+// The serializer defaults to RawSerializer<T> (byte-identical to the
+// previous inline reinterpret_cast + std::copy), preserving full backward
+// compatibility.
 //
 // Guarded by HAVE_ZENOH.
 #pragma once
 
 
+#include "ipc/iserializer.h"
 #include "ipc/isubscriber.h"
+#include "ipc/raw_serializer.h"
 #include "ipc/zenoh_session.h"
 #include "util/iclock.h"
 #include "util/ilogger.h"
@@ -33,21 +40,25 @@ namespace drone::ipc {
 /// Maintains a latest-value cache updated by the Zenoh callback thread.
 template<typename T>
 class ZenohSubscriber final : public ISubscriber<T> {
-    static_assert(std::is_trivially_copyable_v<T>,
-                  "ZenohSubscriber requires trivially copyable types");
-
 public:
     /// Construct and declare a Zenoh subscriber on the given key expression.
     /// @param key_expr        Zenoh key expression (e.g. "drone/slam/pose").
     /// @param track_latency   Enable IPC latency tracking (default: true).
-    explicit ZenohSubscriber(const std::string& key_expr, bool track_latency = true)
-        : key_expr_(key_expr), track_latency_(track_latency) {
+    /// @param serializer      Optional serializer (default: RawSerializer<T>).
+    ///                        shared_ptr because MessageBus may share one
+    ///                        instance across multiple subscribers for the
+    ///                        same type.
+    explicit ZenohSubscriber(
+        const std::string& key_expr, bool track_latency = true,
+        std::shared_ptr<const ISerializer<T>> serializer = std::make_shared<RawSerializer<T>>())
+        : key_expr_(key_expr), track_latency_(track_latency), serializer_(std::move(serializer)) {
         try {
             auto& session = ZenohSession::instance().session();
             subscriber_.emplace(session.declare_subscriber(
                 zenoh::KeyExpr(key_expr), [this](zenoh::Sample& sample) { on_sample(sample); },
                 []() { /* on_drop — no-op */ }));
-            DRONE_LOG_INFO("[ZenohSubscriber] Subscribed to '{}'", key_expr);
+            DRONE_LOG_INFO("[ZenohSubscriber] Subscribed to '{}' (serializer={})", key_expr,
+                           serializer_->name());
         } catch (const std::exception& e) {
             DRONE_LOG_ERROR("[ZenohSubscriber] Failed to subscribe to '{}': {}", key_expr,
                             e.what());
@@ -111,21 +122,19 @@ private:
     void on_sample(zenoh::Sample& sample) {
         const auto& payload = sample.get_payload();
         auto        bytes   = payload.as_vector();
-        if (bytes.size() != sizeof(T)) {
-            DRONE_LOG_WARN("[ZenohSubscriber] Size mismatch on '{}': "
-                           "expected {} got {}",
-                           key_expr_, sizeof(T), bytes.size());
-            return;
-        }
 
         // Validate into a heap-allocated temporary before committing to
         // latest_msg_, so a failed validation never overwrites a previously
         // good value.  Heap allocation avoids stack overflow for large types
         // (e.g. VideoFrame ~6.2 MB) on Zenoh's callback thread.
         if constexpr (has_validate<T>::value) {
-            auto  temp = std::make_unique<T>();
-            auto* dst  = reinterpret_cast<uint8_t*>(temp.get());
-            std::copy(bytes.begin(), bytes.end(), dst);
+            auto temp = std::make_unique<T>();
+            if (!serializer_->deserialize(bytes.data(), bytes.size(), *temp)) {
+                DRONE_LOG_WARN("[ZenohSubscriber] Deserialization failed on '{}': "
+                               "expected {} got {}",
+                               key_expr_, sizeof(T), bytes.size());
+                return;
+            }
             if (!temp->validate()) {
                 DRONE_LOG_WARN("[ZenohSubscriber] Validation failed on '{}' — "
                                "dropping message",
@@ -136,9 +145,18 @@ private:
             latest_msg_   = *temp;
             timestamp_ns_ = drone::util::get_clock().now_ns();
         } else {
+            // For types without validate(), deserialize directly into latest_msg_
+            // under lock.  A stack temporary is NOT safe here — large types like
+            // VideoFrame (~6.2 MB) would overflow Zenoh's callback thread stack.
+            // The serializer checks size first, so partial writes on failure are
+            // acceptable (the old value was already overwritten by design).
             std::lock_guard<std::mutex> lock(data_mutex_);
-            auto*                       dst = reinterpret_cast<uint8_t*>(&latest_msg_);
-            std::copy(bytes.begin(), bytes.end(), dst);
+            if (!serializer_->deserialize(bytes.data(), bytes.size(), latest_msg_)) {
+                DRONE_LOG_WARN("[ZenohSubscriber] Size mismatch on '{}': "
+                               "expected {} got {}",
+                               key_expr_, sizeof(T), bytes.size());
+                return;
+            }
             timestamp_ns_ = drone::util::get_clock().now_ns();
         }
 
@@ -155,6 +173,8 @@ private:
         : std::true_type {};
 
     std::string                            key_expr_;
+    bool                                   track_latency_ = true;
+    std::shared_ptr<const ISerializer<T>>  serializer_;
     std::optional<zenoh::Subscriber<void>> subscriber_;
 
     // Latest-value cache (protected by data_mutex_ + atomics)
@@ -163,7 +183,6 @@ private:
     uint64_t                            timestamp_ns_{0};
     std::atomic<uint64_t>               seq_{0};
     std::atomic<bool>                   has_data_{false};
-    bool                                track_latency_ = true;
     mutable drone::util::LatencyTracker latency_tracker_{1024};
 };
 

--- a/common/ipc/include/ipc/zenoh_subscriber.h
+++ b/common/ipc/include/ipc/zenoh_subscriber.h
@@ -51,7 +51,9 @@ public:
     explicit ZenohSubscriber(
         const std::string& key_expr, bool track_latency = true,
         std::shared_ptr<const ISerializer<T>> serializer = std::make_shared<RawSerializer<T>>())
-        : key_expr_(key_expr), track_latency_(track_latency), serializer_(std::move(serializer)) {
+        : key_expr_(key_expr)
+        , track_latency_(track_latency)
+        , serializer_(serializer ? std::move(serializer) : std::make_shared<RawSerializer<T>>()) {
         try {
             auto& session = ZenohSession::instance().session();
             subscriber_.emplace(session.declare_subscriber(
@@ -148,19 +150,20 @@ private:
             // For types without validate(), deserialize directly into latest_msg_
             // under lock.  A stack temporary is NOT safe here — large types like
             // VideoFrame (~6.2 MB) would overflow Zenoh's callback thread stack.
-            // The serializer checks size first, so partial writes on failure are
-            // acceptable (the old value was already overwritten by design).
+            // (For validating types, the if-branch above uses make_unique for the
+            // same reason.)  The serializer checks size first, so partial writes
+            // on failure are acceptable (the old value was already overwritten by
+            // design).
             std::lock_guard<std::mutex> lock(data_mutex_);
             if (!serializer_->deserialize(bytes.data(), bytes.size(), latest_msg_)) {
-                DRONE_LOG_WARN("[ZenohSubscriber] Size mismatch on '{}': "
-                               "expected {} got {}",
-                               key_expr_, sizeof(T), bytes.size());
+                DRONE_LOG_WARN("[ZenohSubscriber] Deserialization failed on '{}': "
+                               "payload {} bytes, sizeof(T) {}",
+                               key_expr_, bytes.size(), sizeof(T));
                 return;
             }
             timestamp_ns_ = drone::util::get_clock().now_ns();
         }
 
-        seq_.fetch_add(1, std::memory_order_relaxed);
         has_data_.store(true, std::memory_order_release);
     }
 
@@ -181,7 +184,6 @@ private:
     mutable std::mutex                  data_mutex_;
     T                                   latest_msg_{};
     uint64_t                            timestamp_ns_{0};
-    std::atomic<uint64_t>               seq_{0};
     std::atomic<bool>                   has_data_{false};
     mutable drone::util::LatencyTracker latency_tracker_{1024};
 };

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -360,6 +360,10 @@ namespace hal {
 inline constexpr const char* BACKEND  = ".backend";
 inline constexpr const char* GZ_TOPIC = ".gz_topic";
 
+// Plugin sub-keys (appended to section prefix, used when backend == "plugin")
+inline constexpr const char* PLUGIN_PATH    = ".plugin_path";
+inline constexpr const char* PLUGIN_FACTORY = ".plugin_factory";
+
 // Radar-specific sub-keys (appended to section prefix)
 inline constexpr const char* MAX_RANGE_M         = ".max_range_m";
 inline constexpr const char* FOV_AZIMUTH_RAD     = ".fov_azimuth_rad";

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -15,6 +15,9 @@ namespace drone::cfg_key {
 // ═══════════════════════════════════════════════════════════
 inline constexpr const char* LOG_LEVEL   = "log_level";
 inline constexpr const char* IPC_BACKEND = "ipc_backend";
+/// IPC serialization format. Currently only "raw" is supported.
+/// Future options: "protobuf" (for cross-language GCS interop).
+inline constexpr const char* IPC_SERIALIZER = "ipc_serializer";
 /// Multi-vehicle namespace prefix. When present, must be [a-zA-Z0-9_-] or empty.
 /// When set, all IPC topics are namespaced under "/<vehicle_id>/...".
 inline constexpr const char* VEHICLE_ID = "vehicle_id";

--- a/common/util/include/util/plugin_loader.h
+++ b/common/util/include/util/plugin_loader.h
@@ -1,0 +1,273 @@
+// common/util/include/util/plugin_loader.h
+// Runtime .so plugin loading via dlopen/dlsym/dlclose.
+//
+// RAII wrapper that ensures correct lifetime ordering: the dlopen handle
+// outlives all objects created from the loaded .so.  If the handle is
+// dlclose'd before a plugin object is destroyed, the vtable pointers
+// become dangling => use-after-free.
+//
+// Design:
+//   PluginHandle<I>  — owns both the dl handle and the instance.
+//                      Destruction: instance first, then dlclose.
+//   PluginRegistry   — process-lifetime storage for dl handles when
+//                      the caller needs a unique_ptr<Interface> (e.g.
+//                      HAL factory).  Keeps handles alive until exit.
+//   PluginLoader     — static factory: load() opens a .so, resolves
+//                      a C-linkage factory symbol, creates an instance.
+//
+// Plugin .so requirements:
+//   - Factory function MUST use extern "C" linkage to avoid name mangling.
+//   - Factory function MUST have __attribute__((visibility("default"))).
+//   - Factory signature: Interface* symbol_name();
+//   - The caller takes ownership of the returned raw pointer.
+//
+// Security:
+//   ENABLE_PLUGINS should only be enabled in trusted environments.
+//   Arbitrary .so loading can execute any code.  The path is validated
+//   to be a regular file before dlopen.
+//
+// Thread safety:
+//   Plugin loading should happen at startup only.  dlopen is thread-safe
+//   on glibc, but loaded code's static initializers run synchronously.
+//   PluginRegistry::instance() is initialized thread-safely (C++11 magic
+//   statics) but store() is NOT thread-safe — call only from main thread.
+//
+// Gated behind: #ifdef HAVE_PLUGINS (cmake -DENABLE_PLUGINS=ON)
+#pragma once
+
+#ifdef HAVE_PLUGINS
+
+#include "util/ilogger.h"
+#include "util/result.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <dlfcn.h>
+#include <sys/stat.h>
+
+namespace drone::util {
+
+// ── PluginHandle ───────────────────────────────────────────
+/// RAII handle owning a dlopen'd .so AND the instance created from it.
+/// Destruction order: instance_.reset() first, then dlclose(dl_handle_).
+/// Move-only.
+template<typename Interface>
+class PluginHandle {
+public:
+    ~PluginHandle() noexcept {
+        // Order matters: destroy instance before closing the library.
+        instance_.reset();
+        if (dl_handle_) {
+            ::dlclose(dl_handle_);
+            dl_handle_ = nullptr;
+        }
+    }
+
+    PluginHandle(PluginHandle&& other) noexcept
+        : dl_handle_(other.dl_handle_), instance_(std::move(other.instance_)) {
+        other.dl_handle_ = nullptr;
+    }
+
+    PluginHandle& operator=(PluginHandle&& other) noexcept {
+        if (this != &other) {
+            // Clean up current state
+            instance_.reset();
+            if (dl_handle_) {
+                ::dlclose(dl_handle_);
+            }
+            // Take ownership
+            dl_handle_       = other.dl_handle_;
+            instance_        = std::move(other.instance_);
+            other.dl_handle_ = nullptr;
+        }
+        return *this;
+    }
+
+    PluginHandle(const PluginHandle&)            = delete;
+    PluginHandle& operator=(const PluginHandle&) = delete;
+
+    /// Access the plugin instance.  Returns nullptr if moved-from.
+    [[nodiscard]] Interface* get() const noexcept { return instance_.get(); }
+
+    /// Dereference.  Precondition: get() != nullptr.
+    [[nodiscard]] Interface& operator*() const { return *instance_; }
+
+    /// Arrow access.  Precondition: get() != nullptr.
+    [[nodiscard]] Interface* operator->() const noexcept { return instance_.get(); }
+
+    /// Release the instance as unique_ptr, transferring ownership to the caller.
+    /// The dl_handle remains owned by this PluginHandle — caller must ensure
+    /// this PluginHandle (or a PluginRegistry holding it) outlives the returned ptr.
+    [[nodiscard]] std::unique_ptr<Interface> release_instance() noexcept {
+        return std::move(instance_);
+    }
+
+    /// Release ONLY the dl_handle, returning it as a void*.
+    /// After this call, this PluginHandle no longer owns the dl_handle.
+    /// Caller is responsible for calling dlclose() when done.
+    [[nodiscard]] void* release_dl_handle() noexcept {
+        void* h    = dl_handle_;
+        dl_handle_ = nullptr;
+        return h;
+    }
+
+private:
+    friend class PluginLoader;
+
+    PluginHandle(void* dl_handle, Interface* instance)
+        : dl_handle_(dl_handle), instance_(instance) {}
+
+    void*                      dl_handle_ = nullptr;
+    std::unique_ptr<Interface> instance_;
+};
+
+// ── PluginRegistry ─────────────────────────────────────────
+/// Process-lifetime storage for dl handles.
+///
+/// When HAL factories need to return unique_ptr<Interface> but the dl
+/// handle must outlive the interface object, the registry stores the
+/// handle.  dlclose happens only at process exit (static destructor).
+///
+/// Thread safety: NOT thread-safe.  Call store() from main thread only
+/// during startup.
+class PluginRegistry {
+public:
+    /// Meyer's singleton.
+    static PluginRegistry& instance() {
+        static PluginRegistry reg;
+        return reg;
+    }
+
+    /// Store a dl_handle for process-lifetime retention.
+    /// Returns nothing — the handle will be dlclose'd at process exit.
+    void store_handle(void* dl_handle) {
+        if (dl_handle) {
+            handles_.push_back(dl_handle);
+        }
+    }
+
+    /// Convenience: extract the instance from a PluginHandle as unique_ptr,
+    /// and store the dl_handle in the registry for process-lifetime retention.
+    /// This is the pattern HAL factories should use.
+    template<typename Interface>
+    [[nodiscard]] std::unique_ptr<Interface> extract(PluginHandle<Interface> handle) {
+        auto instance = handle.release_instance();
+        store_handle(handle.release_dl_handle());
+        return instance;
+    }
+
+    /// Number of stored handles (for testing).
+    [[nodiscard]] std::size_t handle_count() const noexcept { return handles_.size(); }
+
+    // Non-copyable, non-movable.
+    PluginRegistry(const PluginRegistry&)            = delete;
+    PluginRegistry& operator=(const PluginRegistry&) = delete;
+    PluginRegistry(PluginRegistry&&)                 = delete;
+    PluginRegistry& operator=(PluginRegistry&&)      = delete;
+
+private:
+    PluginRegistry() = default;
+
+    ~PluginRegistry() {
+        // dlclose in reverse order (LIFO) for safety.
+        for (auto it = handles_.rbegin(); it != handles_.rend(); ++it) {
+            if (*it) {
+                ::dlclose(*it);
+            }
+        }
+        handles_.clear();
+    }
+
+    std::vector<void*> handles_;
+};
+
+// ── PluginLoader ───────────────────────────────────────────
+/// Static factory for loading plugin .so files.
+class PluginLoader {
+public:
+    /// Load a plugin .so and create an instance via the named factory function.
+    ///
+    /// The factory function in the .so must be:
+    ///   extern "C" __attribute__((visibility("default")))
+    ///   Interface* factory_symbol();
+    ///
+    /// @param so_path          Path to the .so file (must exist and be a regular file).
+    /// @param factory_symbol   Name of the C-linkage factory function (default: "create_instance").
+    /// @return PluginHandle owning both the dl handle and the created instance,
+    ///         or an error string on failure.
+    template<typename Interface>
+    [[nodiscard]] static Result<PluginHandle<Interface>, std::string> load(
+        const std::string& so_path, const std::string& factory_symbol = "create_instance") {
+        // Validate path exists and is a regular file.
+        struct stat st {};
+        if (::stat(so_path.c_str(), &st) != 0) {
+            return Result<PluginHandle<Interface>, std::string>::err("Plugin file not found: " +
+                                                                     so_path);
+        }
+        if (!S_ISREG(st.st_mode)) {
+            return Result<PluginHandle<Interface>, std::string>::err(
+                "Plugin path is not a regular file: " + so_path);
+        }
+
+        DRONE_LOG_WARN("[PluginLoader] Loading plugin from '{}' — "
+                       "ensure this .so is from a trusted source",
+                       so_path);
+
+        // Clear any stale dlerror state.
+        ::dlerror();
+
+        // Open the shared library.
+        void* dl_handle = ::dlopen(so_path.c_str(), RTLD_NOW | RTLD_LOCAL);
+        if (!dl_handle) {
+            // Capture dlerror immediately — it's cleared by subsequent dl* calls.
+            const char* err = ::dlerror();
+            std::string msg = err ? std::string(err) : "dlopen failed (unknown error)";
+            return Result<PluginHandle<Interface>, std::string>::err("Failed to load plugin '" +
+                                                                     so_path + "': " + msg);
+        }
+
+        // Clear dlerror before dlsym.
+        ::dlerror();
+
+        // Resolve the factory symbol.
+        void*       sym     = ::dlsym(dl_handle, factory_symbol.c_str());
+        const char* sym_err = ::dlerror();
+        if (sym_err || !sym) {
+            std::string msg = sym_err ? std::string(sym_err)
+                                      : "dlsym returned null for '" + factory_symbol + "'";
+            ::dlclose(dl_handle);
+            return Result<PluginHandle<Interface>, std::string>::err(
+                "Failed to resolve symbol '" + factory_symbol + "' in '" + so_path + "': " + msg);
+        }
+
+        // Cast to factory function pointer.
+        // The factory must return Interface* — the caller takes ownership.
+        using FactoryFunc = Interface* (*)();
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) — required for dlsym
+        auto factory = reinterpret_cast<FactoryFunc>(sym);
+
+        // Call the factory.
+        Interface* instance = factory();
+        if (!instance) {
+            ::dlclose(dl_handle);
+            return Result<PluginHandle<Interface>, std::string>::err(
+                "Factory function '" + factory_symbol + "' in '" + so_path + "' returned null");
+        }
+
+        DRONE_LOG_INFO("[PluginLoader] Successfully loaded plugin from '{}'", so_path);
+
+        return Result<PluginHandle<Interface>, std::string>::ok(
+            PluginHandle<Interface>(dl_handle, instance));
+    }
+
+    // Static-only class.
+    PluginLoader()  = delete;
+    ~PluginLoader() = delete;
+};
+
+}  // namespace drone::util
+
+#endif  // HAVE_PLUGINS

--- a/common/util/include/util/plugin_loader.h
+++ b/common/util/include/util/plugin_loader.h
@@ -105,17 +105,20 @@ public:
         return std::move(instance_);
     }
 
+private:
+    friend class PluginLoader;
+    friend class PluginRegistry;
+
     /// Release ONLY the dl_handle, returning it as a void*.
-    /// After this call, this PluginHandle no longer owns the dl_handle.
-    /// Caller is responsible for calling dlclose() when done.
+    /// Private — only PluginRegistry::extract() should call this to safely
+    /// transfer the dl_handle to process-lifetime storage.  Calling dlclose()
+    /// on the returned handle while a live Interface instance still holds
+    /// vtable pointers from the library causes use-after-free.
     [[nodiscard]] void* release_dl_handle() noexcept {
         void* h    = dl_handle_;
         dl_handle_ = nullptr;
         return h;
     }
-
-private:
-    friend class PluginLoader;
 
     PluginHandle(void* dl_handle, Interface* instance)
         : dl_handle_(dl_handle), instance_(instance) {}
@@ -130,6 +133,12 @@ private:
 /// When HAL factories need to return unique_ptr<Interface> but the dl
 /// handle must outlive the interface object, the registry stores the
 /// handle.  dlclose happens only at process exit (static destructor).
+///
+/// IMPORTANT: All plugin-created instances (unique_ptr<Interface>) must be
+/// destroyed BEFORE static destructors run.  In practice, this means plugin
+/// instances should be held in main() locals or in objects owned by main(),
+/// never in static/global variables.  If a plugin instance outlives
+/// ~PluginRegistry, its vtable pointers will dangle (use-after-free).
 ///
 /// Thread safety: NOT thread-safe.  Call store() from main thread only
 /// during startup.
@@ -249,8 +258,21 @@ public:
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast) — required for dlsym
         auto factory = reinterpret_cast<FactoryFunc>(sym);
 
-        // Call the factory.
-        Interface* instance = factory();
+        // Call the factory — guard against exceptions to avoid leaking dl_handle.
+        Interface* instance = nullptr;
+        try {
+            instance = factory();
+        } catch (const std::exception& e) {
+            ::dlclose(dl_handle);
+            return Result<PluginHandle<Interface>, std::string>::err(
+                "Factory function '" + factory_symbol + "' in '" + so_path +
+                "' threw: " + e.what());
+        } catch (...) {
+            ::dlclose(dl_handle);
+            return Result<PluginHandle<Interface>, std::string>::err(
+                "Factory function '" + factory_symbol + "' in '" + so_path +
+                "' threw unknown exception");
+        }
         if (!instance) {
             ::dlclose(dl_handle);
             return Result<PluginHandle<Interface>, std::string>::err(

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
     "_comment": "Default configuration for Drone Companion Stack",
     "log_level": "info",
     "ipc_backend": "zenoh",
+    "ipc_serializer": "raw",
     "vehicle_id": "",
 
     "zenoh": {

--- a/deploy/count_tests.sh
+++ b/deploy/count_tests.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# deploy/count_tests.sh — Accurate test count audit
+#
+# Counts TEST/TEST_F macros in source files and cross-references against
+# ctest registered tests. Reports per-file, per-category, per-suite, and
+# total counts with compile-guard awareness.
+#
+# Usage:
+#   bash deploy/count_tests.sh              # Full report
+#   bash deploy/count_tests.sh --summary    # One-line summary only
+#   bash deploy/count_tests.sh --check      # Compare against TESTS.md baseline
+#
+# This script is the source of truth for test counts. Use it to verify
+# tests/TESTS.md is accurate before merge.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TESTS_DIR="$PROJECT_ROOT/tests"
+BUILD_DIR="$PROJECT_ROOT/build"
+
+# Colors (if terminal supports it)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BOLD='\033[1m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' BOLD='' NC=''
+fi
+
+# ── Count TEST macros in a file ──────────────────────────────
+count_tests_in_file() {
+    local file="$1"
+    local c
+    c=$(grep -c '^TEST\b\|^TEST_F\b' "$file" 2>/dev/null) || true
+    echo "${c:-0}"
+}
+
+# ── Detect compile guards ────────────────────────────────────
+detect_guards() {
+    local file="$1"
+    local guards=""
+    grep -q "HAVE_PLUGINS" "$file" 2>/dev/null && guards="${guards}PLUGINS " || true
+    grep -q "HAVE_GAZEBO" "$file" 2>/dev/null && guards="${guards}GAZEBO " || true
+    grep -q "HAVE_MAVSDK" "$file" 2>/dev/null && guards="${guards}MAVSDK " || true
+    echo "${guards:-none}"
+}
+
+# ── Categorize a test file ───────────────────────────────────
+categorize_file() {
+    local basename="$1"
+    case "$basename" in
+        test_spsc_ring*|test_message_bus*|test_zenoh_ipc*|test_zenoh_coverage*|test_zenoh_liveliness*|test_zenoh_network*|test_ipc_validation*|test_correlation*|test_topic_resolver*|test_serializer*)
+            echo "IPC" ;;
+        test_hal*|test_gazebo_camera*|test_gazebo_imu*|test_gazebo_radar*|test_mavlink_fc_link*|test_radar_hal*|test_plugin_loader*|test_plugin_mock*)
+            echo "HAL" ;;
+        test_kalman_tracker*|test_bytetrack_tracker*|test_fusion_engine*|test_color_contour*|test_opencv_yolo*|test_simulated_detector*)
+            echo "P2 Perception" ;;
+        test_feature_extractor*|test_stereo_matcher*|test_imu_preintegrator*|test_vio_backend*|test_rate_clamp*)
+            echo "P3 SLAM/VIO" ;;
+        test_mission_fsm*|test_fault_manager*|test_static_obstacle*|test_gcs_command*|test_fault_response*|test_mission_state*|test_dstar_lite*|test_obstacle_avoider*|test_collision_recovery*|test_obstacle_prediction*|test_geofence*|test_event_bus*)
+            echo "P4 Mission" ;;
+        test_comms*)
+            echo "P5 Comms" ;;
+        test_payload_manager*|test_gimbal_auto*)
+            echo "P6 Payload" ;;
+        test_system_monitor*|test_process_manager*|test_process_context*)
+            echo "P7 Monitor" ;;
+        test_thread_heartbeat*|test_thread_health*|test_restart_policy*|test_process_graph*)
+            echo "Watchdog" ;;
+        test_config*|test_result*|test_json_log*|test_latency*|test_triple_buffer*|test_diagnostic*|test_sd_notify*|test_iclock*|test_ilogger*|test_replay_dispatch*)
+            echo "Utility" ;;
+        test_flight_recorder*)
+            echo "Flight Recorder" ;;
+        test_process_interfaces*)
+            echo "Cross-Cutting" ;;
+        *)
+            echo "Other" ;;
+    esac
+}
+
+# ── Main ─────────────────────────────────────────────────────
+
+MODE="${1:-full}"
+
+# Per-file counts
+total_source=0
+total_guarded_files=0
+declare -A category_tests
+declare -A category_files
+
+echo -e "${BOLD}=== Test Count Audit ===${NC}"
+echo ""
+
+if [ "$MODE" != "--summary" ]; then
+    printf "${BOLD}%-45s %6s  %-15s  %s${NC}\n" "File" "Tests" "Category" "Guards"
+    printf "%-45s %6s  %-15s  %s\n" "---------------------------------------------" "------" "---------------" "----------"
+fi
+
+for f in "$TESTS_DIR"/test_*.cpp; do
+    basename=$(basename "$f")
+    count=$(count_tests_in_file "$f")
+    guards=$(detect_guards "$f")
+    category=$(categorize_file "$basename")
+    total_source=$((total_source + count))
+
+    # Accumulate per-category
+    category_tests[$category]=$(( ${category_tests[$category]:-0} + count ))
+    if [ "$count" -gt 0 ]; then
+        category_files[$category]=$(( ${category_files[$category]:-0} + 1 ))
+    fi
+
+    if [ "$guards" != "none" ]; then
+        total_guarded_files=$((total_guarded_files + 1))
+    fi
+
+    if [ "$MODE" != "--summary" ] && [ "$count" -gt 0 ]; then
+        if [ "$guards" != "none" ]; then
+            printf "${YELLOW}%-45s %6d  %-15s  %s${NC}\n" "$basename" "$count" "$category" "$guards"
+        else
+            printf "%-45s %6d  %-15s  %s\n" "$basename" "$count" "$category" "$guards"
+        fi
+    fi
+done
+
+echo ""
+
+# ctest count (if build exists)
+ctest_total=0
+if [ -d "$BUILD_DIR" ]; then
+    ctest_line=$(ctest -N --test-dir "$BUILD_DIR" 2>/dev/null | grep "Total Tests:") || true
+    if [ -n "$ctest_line" ]; then
+        ctest_total=$(echo "$ctest_line" | awk '{print $NF}')
+    fi
+fi
+
+# File counts
+total_files=$(ls "$TESTS_DIR"/test_*.cpp 2>/dev/null | wc -l)
+files_with_tests=0
+for f in "$TESTS_DIR"/test_*.cpp; do
+    c=$(count_tests_in_file "$f")
+    if [ "$c" -gt 0 ]; then
+        files_with_tests=$((files_with_tests + 1))
+    fi
+done
+helper_files=$((total_files - files_with_tests))
+guarded_diff=$((total_source - ctest_total))
+
+# ── Category breakdown ───────────────────────────────────────
+echo -e "${BOLD}=== By Category ===${NC}"
+echo ""
+printf "  ${BOLD}%-20s %6s  %5s${NC}\n" "Category" "Tests" "Files"
+printf "  %-20s %6s  %5s\n" "--------------------" "------" "-----"
+
+# Sort categories by test count (descending) using TAB delimiter for multi-word names
+while IFS=$'\t' read -r tests cat; do
+    files=${category_files[$cat]:-0}
+    printf "  %-20s %6d  %5d\n" "$cat" "$tests" "$files"
+done < <(for k in "${!category_tests[@]}"; do printf '%d\t%s\n' "${category_tests[$k]}" "$k"; done | sort -rn)
+printf "  %-20s %6s  %5s\n" "--------------------" "------" "-----"
+printf "  ${BOLD}%-20s %6d  %5d${NC}\n" "TOTAL" "$total_source" "$files_with_tests"
+
+echo ""
+
+echo -e "${BOLD}=== Summary ===${NC}"
+echo ""
+echo "  Source TEST macros:        $total_source"
+echo "  ctest registered:          $ctest_total"
+echo "  Compile-guarded (delta):   $guarded_diff"
+echo ""
+echo "  Test files (total):        $total_files"
+echo "  Files with tests:          $files_with_tests"
+echo "  Helper files (0 tests):    $helper_files"
+echo "  Files with compile guards: $total_guarded_files"
+
+# ── --check mode: compare against TESTS.md baseline ─────────
+if [ "$MODE" = "--check" ]; then
+    echo ""
+    echo -e "${BOLD}=== Baseline Check ===${NC}"
+
+    tests_md="$PROJECT_ROOT/tests/TESTS.md"
+    if [ ! -f "$tests_md" ]; then
+        echo -e "${RED}ERROR: tests/TESTS.md not found${NC}"
+        exit 1
+    fi
+
+    # Extract baseline from the Total row (third column = test count)
+    # Row format: | **Total** | **65 C++ + 5 shell** | **1461 + 42 + 250+** | |
+    baseline=$(grep -F '| **Total**' "$tests_md" | head -1 | awk -F'|' '{print $4}' | grep -oP '\d+' | head -1) || true
+    if [ -z "$baseline" ]; then
+        echo -e "${YELLOW}WARNING: Could not parse baseline from TESTS.md${NC}"
+    else
+        echo "  TESTS.md baseline:  $baseline"
+        echo "  ctest actual:       $ctest_total"
+        if [ "$ctest_total" -eq "$baseline" ]; then
+            echo -e "  ${GREEN}MATCH${NC}"
+        else
+            diff=$((ctest_total - baseline))
+            echo -e "  ${RED}MISMATCH: delta = $diff${NC}"
+            echo "  Update tests/TESTS.md or investigate missing/extra tests."
+            exit 1
+        fi
+    fi
+
+    # Also check CLAUDE.md baseline
+    claude_md="$PROJECT_ROOT/CLAUDE.md"
+    if [ -f "$claude_md" ]; then
+        claude_baseline=$(grep -oP 'currently \*\*(\d+)\*\*' "$claude_md" | grep -oP '\d+' | head -1) || true
+        if [ -n "$claude_baseline" ]; then
+            echo ""
+            echo "  CLAUDE.md baseline: $claude_baseline"
+            if [ "$ctest_total" -eq "$claude_baseline" ]; then
+                echo -e "  ${GREEN}MATCH${NC}"
+            else
+                echo -e "  ${YELLOW}STALE: CLAUDE.md says $claude_baseline, actual is $ctest_total${NC}"
+            fi
+        fi
+    fi
+fi
+
+echo ""
+
+# ── Per-suite breakdown (full mode only) ─────────────────────
+if [ "$MODE" = "full" ] || [ "$MODE" = "--detail" ]; then
+    echo -e "${BOLD}=== Top 30 Test Suites ===${NC}"
+    echo ""
+    grep -rh '^TEST\b\|^TEST_F\b' "$TESTS_DIR"/test_*.cpp 2>/dev/null \
+        | sed 's/TEST_F(\|TEST(//' \
+        | sed 's/,.*//' \
+        | sort | uniq -c | sort -rn \
+        | head -30
+    remaining=$(grep -rh '^TEST\b\|^TEST_F\b' "$TESTS_DIR"/test_*.cpp 2>/dev/null \
+        | sed 's/TEST_F(\|TEST(//' \
+        | sed 's/,.*//' \
+        | sort -u | wc -l)
+    echo "  ... ($remaining suites total)"
+fi

--- a/docs/guides/DESIGN_RATIONALE.md
+++ b/docs/guides/DESIGN_RATIONALE.md
@@ -199,3 +199,107 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 **When to revisit:** When MDE networks (Depth Anything V2, RTS-Mono) replace geometric depth estimation. Neural depth with ~5-8% error no longer needs a 30% safety margin — reduce to 0.9 or 1.0 with the inflation radius providing the remaining buffer.
 
 **Date:** 2026-04-09
+
+---
+
+## DR-009: PluginRegistry dlclose in Static Destructor vs. Intentional Leak
+
+**Question:** `PluginRegistry` is a Meyer's singleton that calls `dlclose()` on all stored handles in its destructor (static destruction). Copilot suggested intentionally leaking the handles instead, since static destruction order across translation units is unspecified — a plugin instance in another static could outlive the registry, causing vtable UAF.
+
+**Arguments for dlclose in static destructor (current approach):**
+
+- Clean resource release — valgrind/sanitizers don't report leaks
+- LIFO ordering (reverse of load order) is the standard pattern for dlclose
+- Plugin instances are documented to be held in `main()` locals or objects owned by `main()`, never in static/global variables — this is an enforced contract, not a hope
+- The codebase already follows this pattern: all HAL factory results go into process `main()` locals
+- If a plugin instance violates the contract (held in a static), the bug is in the violating code, not the registry
+
+**Arguments for intentional leak:**
+
+- Eliminates the static destruction order fiasco entirely — zero risk regardless of how callers hold instances
+- `dlclose` at process exit is largely pointless — the OS reclaims everything anyway
+- Some frameworks (e.g., LLVM plugin system) intentionally leak for this reason
+- Defensive programming: protect against future callers who don't read the contract
+
+**Our decision:** Keep dlclose in the destructor with LIFO ordering. The contract (plugin instances must not outlive the registry) is documented in the header, enforced by code review, and consistent with the codebase's RAII philosophy. Intentional leaks normalize resource mismanagement and hide bugs that should be caught early.
+
+**When to revisit:** If a use-after-free is traced to static destruction ordering with plugin handles. At that point, the leak approach becomes justified as a pragmatic defense. Also revisit if we add a plugin reload mechanism (unload + reload .so at runtime), where dlclose becomes functionally necessary.
+
+**Date:** 2026-04-13
+
+---
+
+## DR-010: SHM Threshold Based on sizeof(T) vs. serialized_size()
+
+**Question:** `ZenohPublisher` decides whether to use the SHM zero-copy path based on `sizeof(T) > kShmPublishThreshold` (a compile-time check). Copilot noted this will be incorrect for variable-length serializers (e.g., protobuf) where wire size differs from `sizeof(T)`.
+
+**Arguments for sizeof(T) (current approach):**
+
+- Compile-time decision — the `if constexpr` branch is resolved at compile time, so the unused path is eliminated entirely (no dead code, no branch misprediction)
+- With `RawSerializer<T>` (the only serializer today), `sizeof(T) == serialized_size(msg)` is an invariant — there's no divergence
+- Switching to runtime `serialized_size()` would require a runtime branch on every publish, adding overhead to the hot path for a capability we don't use yet
+- The SHM path is specifically optimized for large fixed-size structs (VideoFrame ~6.2 MB) — variable-length messages may not benefit from SHM the same way
+
+**Arguments for serialized_size() (runtime check):**
+
+- Correct for future variable-length serializers (protobuf, flatbuffers)
+- A protobuf message with `sizeof(T)` = 64 bytes but wire size = 2 KB would never hit the SHM path despite benefiting from it
+- Conversely, a sparse protobuf with `sizeof(T)` = 6 MB but wire size = 100 bytes would wastefully allocate SHM
+
+**Our decision:** Keep `sizeof(T)` with `if constexpr`. The compile-time optimization is valuable on the publish hot path, and the only serializer in use (`RawSerializer`) guarantees `sizeof(T) == serialized_size()`. When a variable-length serializer is added, this must be revisited — the SHM decision should then use `serialized_size()` with a runtime branch (the cost is justified when you're already doing non-trivial serialization).
+
+**When to revisit:** When implementing `ProtobufSerializer<T>` or any serializer where wire size != `sizeof(T)`. File as part of that issue's acceptance criteria.
+
+**Date:** 2026-04-13
+
+---
+
+## DR-011: Partial Mutation on Deserialize Failure (Non-Validate Branch)
+
+**Question:** In `ZenohSubscriber::on_sample()`, the non-validate branch deserializes directly into `latest_msg_` under lock. If the serializer fails mid-write, `latest_msg_` may be partially mutated while `has_data_` remains true. Copilot suggested deserializing into a heap temporary (as the validate branch does) and only committing on success.
+
+**Arguments for direct deserialization (current approach):**
+
+- `RawSerializer::deserialize()` checks `size != sizeof(T)` **before** any copy — on size mismatch, zero bytes are written, so partial mutation cannot happen with the current serializer
+- The validate branch uses `make_unique<T>()` because it needs the temporary for `validate()` anyway — the heap allocation is not purely defensive
+- Adding a heap allocation to the non-validate path penalizes **every** message for every type, including small high-frequency types (Pose, FCState at 50-100 Hz) where the cost is measurable
+- For large types (VideoFrame ~6.2 MB), the validate branch already handles them correctly
+- The "partial mutation" scenario requires a serializer that writes some bytes before discovering failure — `RawSerializer` doesn't do this, and any future serializer can be designed to validate-before-write
+
+**Arguments for heap temporary (defensive):**
+
+- Future serializers (protobuf) may fail mid-deserialize, leaving `latest_msg_` in a torn state
+- A subscriber reading `latest_msg_` immediately after a failed deserialize would see corrupted data
+- The heap allocation cost (~100ns for typical IPC structs) is negligible compared to the Zenoh transport overhead (~10-50µs)
+- Defense in depth: don't rely on serializer implementation details for correctness
+
+**Our decision:** Keep direct deserialization for the non-validate branch. The current serializer guarantees atomic-or-nothing behavior (size check before copy). Added a code comment cross-referencing the validate branch's approach and explaining the design trade-off. When a variable-length serializer is added, this decision should be revisited — protobuf deserialize can fail mid-stream, making the heap temporary necessary.
+
+**When to revisit:** When adding `ProtobufSerializer<T>` — at that point, the non-validate branch should adopt the heap-temporary pattern (or better, all types should go through a validate-like path since protobuf has built-in validation).
+
+**Date:** 2026-04-13
+
+---
+
+## DR-012: CMAKE_DL_LIBS Propagation for ENABLE_PLUGINS
+
+**Question:** When `ENABLE_PLUGINS=ON`, code using `dlopen/dlsym/dlclose` (via `plugin_loader.h`) needs to link against `libdl` on platforms where it's separate from libc. The current CMake only defines `HAVE_PLUGINS` without propagating `${CMAKE_DL_LIBS}`. Copilot suggested adding `link_libraries(${CMAKE_DL_LIBS})`.
+
+**Arguments for deferring (current approach):**
+
+- `ENABLE_PLUGINS` defaults to OFF — no current target enables it
+- On glibc >= 2.34 (Ubuntu 22.04+, our primary platform), `dlopen` is in libc — no separate `-ldl` needed
+- Adding `link_libraries()` at top-level scope is a blunt instrument — it links libdl into every target, including those that don't use plugins
+- The proper fix (when needed) is to add `${CMAKE_DL_LIBS}` to specific targets (`drone_util` or `drone_hal`) via `target_link_libraries(... INTERFACE ${CMAKE_DL_LIBS})`, not a global `link_libraries()`
+
+**Arguments for fixing now:**
+
+- Cross-compilation targets (older ARM toolchains, musl-based systems) may have separate libdl
+- If someone enables plugins and gets a linker error, the root cause is non-obvious
+- One line of CMake now prevents a confusing debugging session later
+
+**Our decision:** Defer. The feature is disabled by default, and our target platforms don't need it. When `ENABLE_PLUGINS` is first used in a real deployment (likely Jetson Orin with a custom detector backend), add `${CMAKE_DL_LIBS}` to the specific target at that time — not as a global link.
+
+**When to revisit:** When any real target enables `ENABLE_PLUGINS=ON` and targets a platform with separate libdl (cross-compilation, musl, older glibc).
+
+**Date:** 2026-04-13

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -21,6 +21,41 @@ Sections:
 
 ---
 
+### Fix #346 — Stack Overflow in ZenohSubscriber::on_sample() for Large IPC Types (#294)
+
+**Date:** 2026-04-13
+**Severity:** Critical (segfault in IPC hot path)
+**File:** `common/ipc/include/ipc/zenoh_subscriber.h`
+
+**Bug:** After introducing `ISerializer<T>` (#294), `ZenohSubscriber<VideoFrame>::on_sample()` segfaults on the very first received message. The crash occurs at the function prologue (before any user code executes) with the stack pointer past the guard page.
+
+**Symptoms:**
+- 3 SHM-related tests segfault: `ZenohPubSub.LargeVideoFrameRoundTrip`, `ZenohShmPublish.LargeVideoFrameUsesShmPath`, `ZenohShmPublish.SustainedVideoPublish`
+- Only affects types where `sizeof(T)` is large (VideoFrame = 6.2 MB, StereoFrame = 600 KB)
+- Crash happens during `publisher->put()` — Zenoh delivers to local subscribers **synchronously** on the publisher's thread (intra-process optimization), so the callback runs on the same thread stack, not a separate thread
+
+**Root Cause:** The agent's ISerializer integration added `serializer_->serialized_size(T{})` in error-path log messages inside `on_sample()`. This expression default-constructs a full `T` on the stack — for VideoFrame, that's **6,220,832 bytes (~6.2 MB)**. Even though this code is on an error path that rarely executes, the compiler reserves the maximum stack frame at function entry (especially in Release builds with `-O2`). Combined with the existing stack usage from `payload.as_vector()` (another 6.2 MB vector — though heap-backed, the vector object and return value overhead adds up), plus Zenoh's own call chain depth from `resolve_put()` → `callback`, the total stack demand exceeds the thread's stack limit.
+
+Additionally, the `else` branch (for types without `validate()`) contained `T temp{}` — a 6.2 MB stack-allocated temporary used to avoid corrupting `latest_msg_` on deserialization failure. While this branch isn't taken for VideoFrame (which has `validate()`), it would crash for any future large type added without a `validate()` method.
+
+**Why Debug builds survived:** In `-O0` (debug), the compiler doesn't inline `on_sample()` into the Zenoh call chain and may defer stack allocation for unreachable code paths. In `-O2` (release), aggressive inlining and eager stack frame allocation push the prologue past the stack guard page immediately.
+
+**Fix (two changes):**
+1. Replaced `serializer_->serialized_size(T{})` with `sizeof(T)` in all error log messages — for `RawSerializer`, these are identical (`serialized_size()` just returns `sizeof(T)`), but `sizeof(T)` is a compile-time constant that requires zero stack space.
+2. Removed `T temp{}` stack variable in the non-validate `else` branch — instead, deserialize directly into `latest_msg_` under the mutex lock (matching the original pre-#294 behavior). The serializer already rejects size mismatches before writing, so corruption from partial writes cannot happen.
+
+**Lesson:** Never default-construct a large IPC type on the stack, even in error paths — the compiler reserves stack space at function entry regardless. Use `sizeof(T)` for size reporting, and `std::make_unique<T>()` when an actual instance is needed. This is especially critical in Zenoh callbacks, which may run on the publisher's thread with limited remaining stack.
+
+**Found by:** Integration testing during Wave 6 (Epic #284). GDB backtrace showed `this` at inaccessible address `0x7fffff41e918` (stack overflow) with the crash at the function prologue, confirmed by the call chain: `publish_shm()` → `zenoh::Publisher::put()` → `resolve_put()` → `callback` → `on_sample()`.
+
+**Debugging tools used:**
+- **GDB (GNU Debugger)** — Attached to the failing test binary with `gdb ./build/bin/test_zenoh_pubsub`. Ran with `run --gtest_filter=ZenohShmPublish.LargeVideoFrameUsesShmPath`. GDB caught the SIGSEGV and `bt` (backtrace) showed the crash at the `on_sample()` function prologue with the stack pointer (`$rsp`) past the guard page. The `info registers` command confirmed `this` was at `0x7fffff41e918` — an inaccessible address deep in the stack, proving stack overflow rather than a null pointer or use-after-free. The backtrace also revealed Zenoh's synchronous intra-process delivery path: `publish_shm()` → `zenoh::Publisher::put()` → `resolve_put()` → subscriber callback → `on_sample()`, which was key to understanding why the publisher's thread stack was exhausted.
+- **`sizeof(T)` compile-time checks** — Used `static_assert` and `DRONE_LOG_INFO` to print `sizeof(VideoFrame)` at compile time and runtime to confirm the 6,220,832-byte size that was being default-constructed on the stack.
+
+**Regression test:** The existing `ZenohShmPublish.LargeVideoFrameUsesShmPath` test now passes (was segfaulting). No new test needed — the existing tests cover this path.
+
+---
+
 ### Fix #39 — fault_injector shm_unlink on Exit Breaks Subsequent Runs (#125)
 
 **Date:** 2026-03-12

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -2889,4 +2889,28 @@ Directory lifecycle: `_RUNNING` → `_PASS`/`_FAIL` on completion, `_ABORTED` on
 
 ---
 
-_Last updated after Improvement #67 (PR #346). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._
+---
+
+### Improvement #68 — Epic #284 Wave 6: ISerializer Abstraction + PluginLoader (Issues #294, #295, PR #416)
+
+**Date:** 2026-04-13
+**Category:** Feature / Platform Modularity
+**Issues:** [#294](https://github.com/nmohamaya/companion_software_stack/issues/294), [#295](https://github.com/nmohamaya/companion_software_stack/issues/295)
+**PR:** [#416](https://github.com/nmohamaya/companion_software_stack/pull/416)
+**Epic:** [#284 — Platform Modularity](https://github.com/nmohamaya/companion_software_stack/issues/284)
+
+**What:**
+
+- **ISerializer\<T\> abstraction** (#294) — Virtual interface for pluggable wire-format serialization with `serialize()` (vector + buffer-write), `deserialize()`, `serialized_size()`, `name()`. `RawSerializer<T>` as default (byte-identical to previous inline `reinterpret_cast`). Injected into `ZenohPublisher<T>` and `ZenohSubscriber<T>` via `shared_ptr<const ISerializer<T>>`. SHM zero-copy path uses buffer-write overload.
+- **PluginLoader\<Interface\>** (#295) — Runtime `.so` loading via `dlopen/dlsym/dlclose` behind `#ifdef HAVE_PLUGINS` (cmake `-DENABLE_PLUGINS=ON`). RAII `PluginHandle<I>` ensures destruction order (instance before dlclose). `PluginRegistry` singleton stores handles for process-lifetime retention. `load_plugin<Interface>()` DRY helper used by all 6 HAL factory functions + detector factory.
+- **Design rationale documentation** — 4 new DR entries (DR-009 through DR-012) documenting deferred review findings with full trade-off analysis.
+
+**Files modified:** `iserializer.h` (new), `raw_serializer.h` (new), `plugin_loader.h` (new), `zenoh_publisher.h`, `zenoh_subscriber.h`, `hal_factory.h`, `detector_factory.cpp`, `config_keys.h`, `config_validator.h`, `default.json`, `CMakeLists.txt`, `test_serializer.cpp` (new), `test_plugin_loader.cpp` (new), `test_plugin_mock.cpp` (new), `test_process_interfaces.cpp`, `DESIGN_RATIONALE.md`
+
+**Why:** Final wave of Epic #284 Platform Modularity. ISerializer decouples wire format from transport — enables future protobuf/flatbuffers without changing Zenoh code. PluginLoader enables runtime-swappable HAL/detector backends via `.so` files — critical for customer-specific hardware without recompilation.
+
+**Test count:** 1389 → 1461 (+72 tests across Waves 5a+6). 21 serializer tests, 13 plugin tests (HAVE_PLUGINS only). See [tests/TESTS.md](../../tests/TESTS.md) for current counts.
+
+---
+
+_Last updated after Improvement #68 (PR #416). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._

--- a/docs/tracking/ROADMAP.md
+++ b/docs/tracking/ROADMAP.md
@@ -688,15 +688,15 @@ Add these lines to keep ephemeral/sensitive files local:
 
 ## Metrics History
 
-| Metric | Phase 1 | Phase 3 | Phase 6 | Phase 7 | Phase 8 | Phase 9 | Zenoh A | Zenoh B | Zenoh C | Zenoh D | Zenoh E | Zenoh F | E2E | FaultMgr | Hardening | Watchdog | Epic #110 | Epic #263 | **PR #346 (Current)** |
-|--------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|-----|--------|-------|-------|-------|-------|-------|
-| Unit tests | 58 | 121 | 196 | 262 | 262 | 262 | 295 | 308 | 329 | 348 | 359 | 370 | 377 | 400 | 464 | 701 | 1108 | 1238 | **1259** |
-| Test suites | 6 | 10 | 14 | 18 | 18 | 18 | 19 | 19 | 19 | 19 | 20 | 21 | 22 | 23 | 26 | 31+ | 42 | 47 | **47** |
-| Bug fixes | 6 | 6 | 13 | 13 | 15 | 15 | 17 | 17 | 17 | 17 | 17 | 17 | 19 | 19 | 21 | 21 | 34 | 48 | **48** |
-| Config tunables | 45+ | 45+ | 70+ | 75+ | 75+ | 80+ | 80+ | 80+ | 85+ | 85+ | 90+ | 90+ | 90+ | 95+ | 95+ | 95+ | 110+ | 120+ | **120+** |
-| HAL backends | 0 | 5 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 9 | 9 | **9** |
-| IPC backends | SHM | SHM | SHM | SHM | SHM | SHM | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | Zenoh (sole) | Zenoh (sole) | **Zenoh (sole)** |
-| Perception backends | 0 | 0 | 1 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | **3** |
+| Metric | Phase 1 | Phase 3 | Phase 6 | Phase 7 | Phase 8 | Phase 9 | Zenoh A | Zenoh B | Zenoh C | Zenoh D | Zenoh E | Zenoh F | E2E | FaultMgr | Hardening | Watchdog | Epic #110 | Epic #263 | PR #346 | **Epic #284 (Current)** |
+|--------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|-----|--------|-------|-------|-------|-------|-------|-------|
+| Unit tests | 58 | 121 | 196 | 262 | 262 | 262 | 295 | 308 | 329 | 348 | 359 | 370 | 377 | 400 | 464 | 701 | 1108 | 1238 | 1259 | **1461** |
+| Test suites | 6 | 10 | 14 | 18 | 18 | 18 | 19 | 19 | 19 | 19 | 20 | 21 | 22 | 23 | 26 | 31+ | 42 | 47 | 47 | **65** |
+| Bug fixes | 6 | 6 | 13 | 13 | 15 | 15 | 17 | 17 | 17 | 17 | 17 | 17 | 19 | 19 | 21 | 21 | 34 | 48 | 48 | **48** |
+| Config tunables | 45+ | 45+ | 70+ | 75+ | 75+ | 80+ | 80+ | 80+ | 85+ | 85+ | 90+ | 90+ | 90+ | 95+ | 95+ | 95+ | 110+ | 120+ | 120+ | **125+** |
+| HAL backends | 0 | 5 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 8 | 9 | 9 | 9 | **9+plugin** |
+| IPC backends | SHM | SHM | SHM | SHM | SHM | SHM | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | SHM + Zenoh | Zenoh (sole) | Zenoh (sole) | Zenoh (sole) | **Zenoh (sole)** |
+| Perception backends | 0 | 0 | 1 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | 3 | **3+plugin** |
 | Compiler warnings | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | **0** |
 | Processes on factory | 0/7 | 0/7 | 0/7 | 0/7 | 0/7 | 0/7 | 2/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | 7/7 | **7/7** |
 | Processes w/ real Gazebo data | 0/7 | 0/7 | 4/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | 5/7 | **5/7** |

--- a/process2_perception/src/detector_factory.cpp
+++ b/process2_perception/src/detector_factory.cpp
@@ -83,13 +83,17 @@ std::unique_ptr<IDetector> create_detector(const std::string& backend, const dro
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {
         if (!cfg) {
-            throw std::runtime_error("Plugin detector requires config for .so path");
+            throw std::runtime_error("[Detector] Plugin backend requires config for .so path");
         }
-        const std::string section = "perception.detector";
-        auto so_path = cfg->get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
-        auto factory = cfg->get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+        const std::string det_section = "perception.detector";
+        auto so_path = cfg->get<std::string>(det_section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg->get<std::string>(det_section + drone::cfg_key::hal::PLUGIN_FACTORY,
                                              "create_instance");
-        auto result  = drone::util::PluginLoader::load<IDetector>(so_path, factory);
+        if (so_path.empty()) {
+            throw std::runtime_error("[Detector] Plugin requires a non-empty config value at '" +
+                                     det_section + drone::cfg_key::hal::PLUGIN_PATH + "'");
+        }
+        auto result = drone::util::PluginLoader::load<IDetector>(so_path, factory);
         if (result.is_err()) {
             throw std::runtime_error("[Detector] Plugin load failed: " + result.error());
         }

--- a/process2_perception/src/detector_factory.cpp
+++ b/process2_perception/src/detector_factory.cpp
@@ -9,7 +9,12 @@
 #include "perception/opencv_yolo_detector.h"
 #endif
 
+#ifdef HAVE_PLUGINS
+#include "util/plugin_loader.h"
+#endif
+
 #include "util/config.h"
+#include "util/config_keys.h"
 #include "util/ilogger.h"
 
 #include <algorithm>
@@ -75,6 +80,22 @@ std::unique_ptr<IDetector> create_detector(const std::string& backend, const dro
 
         return std::make_unique<SimulatedDetector>(sim_cfg);
     }
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        if (!cfg) {
+            throw std::runtime_error("Plugin detector requires config for .so path");
+        }
+        const std::string section = "perception.detector";
+        auto so_path = cfg->get<std::string>(section + drone::cfg_key::hal::PLUGIN_PATH, "");
+        auto factory = cfg->get<std::string>(section + drone::cfg_key::hal::PLUGIN_FACTORY,
+                                             "create_instance");
+        auto result  = drone::util::PluginLoader::load<IDetector>(so_path, factory);
+        if (result.is_err()) {
+            throw std::runtime_error("[Detector] Plugin load failed: " + result.error());
+        }
+        return drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+    }
+#endif
     throw std::runtime_error("Unknown detector backend: " + backend);
 }
 

--- a/tasks/agent-changelog.md
+++ b/tasks/agent-changelog.md
@@ -98,3 +98,11 @@ Agents append completed work here. Newest entries at top. Keep 30 days.
 - **Mode:** skill (/deploy-issue)
 - **Fix iterations:** 2 (review fixes + re-review fixes)
 - **Status:** completed
+
+### 2026-04-13 | feature-infra-core | claude-opus-4-6 | PR #416
+
+- **Issues:** #294 — `ISerializer<T>` abstraction + `RawSerializer<T>`, #295 — `PluginLoader<Interface>` runtime .so loading
+- **Branch:** integration/epic-284-wave-6
+- **Mode:** skill (/deploy-wave)
+- **Fix iterations:** 1 (13 P1+P2 review findings fixed, 4 DR entries for deferred P3)
+- **Status:** completed

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -313,6 +313,30 @@ add_drone_test(test_event_bus       test_event_bus.cpp)
 # ── ISerializer / RawSerializer tests (Issue #294) ──────
 add_drone_test(test_serializer      test_serializer.cpp)
 
+# ── PluginLoader tests (Issue #295 — Epic #284) ────────────
+# Only built when ENABLE_PLUGINS=ON.  Builds a mock .so and
+# loads it at runtime to verify PluginLoader / PluginHandle /
+# PluginRegistry lifetime management.
+if(ENABLE_PLUGINS)
+    # Build the mock plugin as a shared library
+    add_library(test_plugin_mock SHARED test_plugin_mock.cpp)
+    target_include_directories(test_plugin_mock PRIVATE
+        ${PROJECT_SOURCE_DIR}/common/hal/include
+    )
+    set_target_properties(test_plugin_mock PROPERTIES
+        PREFIX ""
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+    )
+
+    # Build and register the test
+    add_drone_test(test_plugin_loader test_plugin_loader.cpp)
+    target_link_libraries(test_plugin_loader PRIVATE ${CMAKE_DL_LIBS})
+    target_compile_definitions(test_plugin_loader PRIVATE
+        TEST_PLUGIN_MOCK_PATH="${CMAKE_BINARY_DIR}/lib/test_plugin_mock.so"
+    )
+    add_dependencies(test_plugin_loader test_plugin_mock)
+endif()
+
 # ═══════════════════════════════════════════════════════════
 # Integration tests (Issue #292 — Epic #284 Platform Modularity)
 # ═══════════════════════════════════════════════════════════

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,6 +310,9 @@ target_compile_definitions(test_process_context PRIVATE
 # ── EventBus tests (Issue #293) ─────────────────────────
 add_drone_test(test_event_bus       test_event_bus.cpp)
 
+# ── ISerializer / RawSerializer tests (Issue #294) ──────
+add_drone_test(test_serializer      test_serializer.cpp)
+
 # ═══════════════════════════════════════════════════════════
 # Integration tests (Issue #292 — Epic #284 Platform Modularity)
 # ═══════════════════════════════════════════════════════════

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -47,19 +47,19 @@
 
 | Module | Description | Approx. Tests |
 |--------|-------------|---------------|
-| `ipc` | Zenoh IPC primitives, message bus, wire format | ~150 |
-| `watchdog` | Thread heartbeat, health publisher, restart policy, process graph, supervisor | ~85 |
-| `perception` | Kalman tracker, fusion engine (UKF+camera+radar), color contour, YOLOv8 | ~149 |
-| `mission` | Mission FSM, FaultManager, D* Lite, ObstacleAvoider3D | ~182 |
+| `ipc` | Zenoh IPC primitives, message bus, wire format, serializer | ~296 |
+| `watchdog` | Thread heartbeat, health publisher, restart policy, process graph, supervisor | ~86 |
+| `perception` | Kalman tracker, fusion engine (UKF+camera+radar), color contour, YOLOv8 | ~189 |
+| `mission` | Mission FSM, FaultManager, D* Lite, ObstacleAvoider3D, geofence, event bus | ~287 |
 | `comms` | MavlinkSim and GCSLink | ~13 |
-| `hal` | Simulated, Gazebo, and MAVLink HAL backends | ~44 |
-| `payload` | GimbalController servo simulation | ~9 |
-| `monitor` | P7 system monitor (CPU/memory/thermal) | ~28 |
-| `util` | Config, Result, latency tracker, JSON log, correlation | ~136 |
-| `interfaces` | IProcessMonitor interface tests | ~5 |
-| `zenoh` | All Zenoh-specific tests | ~121 |
-| `network` | Network transport, wire format, liveliness | ~50 |
-| `quick` | All fast unit tests (excludes slow/resource-heavy) | ~600 |
+| `hal` | Simulated, Gazebo, MAVLink, and plugin HAL backends | ~129 |
+| `payload` | GimbalController servo simulation | ~34 |
+| `monitor` | P7 system monitor (CPU/memory/thermal, ISysInfo, process context) | ~64 |
+| `util` | Config, Result, latency tracker, JSON log, correlation, replay dispatch | ~251 |
+| `interfaces` | IProcessMonitor interface tests | ~7 |
+| `zenoh` | All Zenoh-specific tests | ~154 |
+| `network` | Network transport, wire format, liveliness | ~51 |
+| `quick` | All fast unit tests (excludes slow/resource-heavy) | ~1200 |
 | `zenoh-e2e` | Zenoh end-to-end integration smoke test (shell script) | N/A |
 | `gazebo-e2e` | Gazebo SITL integration smoke test (shell script) | N/A |
 
@@ -100,16 +100,16 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — Gazebo](#hal--gazebo) | 2 | 25 | Gazebo camera and IMU backends |
 | [HAL — MAVLink](#hal--mavlink) | 1 | 14 | MavlinkFCLink (MAVSDK-based flight controller) |
 | [HAL — Radar](#hal--radar) | 1 | 29 | IRadar interface, SimulatedRadar, factory, config, topic |
-| [P2 — Perception](#p2--perception) | 5 | 149 | Kalman filter + Hungarian solver, ByteTrack (two-stage IoU), fusion (UKF+camera+radar+dormant re-ID), color contour, YOLOv8 |
-| [P4 — Mission Planner](#p4--mission-planner) | 8 | 182 | Mission FSM, FaultManager, StaticObstacleLayer, GCSCommandHandler, FaultResponseExecutor, MissionStateTick, D* Lite planner, ObstacleAvoider3D |
+| [P2 — Perception](#p2--perception) | 5 | 176 | Kalman filter + Hungarian solver, ByteTrack (two-stage IoU), fusion (UKF+camera+radar+dormant re-ID), color contour, YOLOv8 |
+| [P4 — Mission Planner](#p4--mission-planner) | 8 | 220 | Mission FSM, FaultManager, StaticObstacleLayer, GCSCommandHandler, FaultResponseExecutor, MissionStateTick, D* Lite planner, ObstacleAvoider3D |
 | [P5 — Comms](#p5--comms) | 1 | 13 | MavlinkSim and GCSLink |
 | [P6 — Payload Manager](#p6--payload-manager) | 1 | 9 | GimbalController servo simulation |
-| [P7 — System Monitor](#p7--system-monitor) | 2 | 28 | CPU/memory/thermal monitoring, ProcessManager supervisor |
+| [P7 — System Monitor](#p7--system-monitor) | 2 | 53 | CPU/memory/thermal monitoring, ISysInfo abstraction, ProcessManager supervisor |
 | [Watchdog — Thread Heartbeat](#watchdog--thread-heartbeat) | 1 | 25 | ThreadHeartbeatRegistry, ScopedHeartbeat, ThreadWatchdog |
 | [Watchdog — Thread Health Publisher](#watchdog--thread-health-publisher) | 1 | 15 | ShmThreadHealth struct, ThreadHealthPublisher bridge |
 | [Watchdog — Restart Policy](#watchdog--restart-policy) | 1 | 17 | RestartPolicy backoff/thermal, StackStatus, ProcessConfig from_json |
 | [Watchdog — Process Graph](#watchdog--process-graph) | 1 | 27 | Dual-edge dependency graph, topo sort, cascade targets, cycle detection |
-| [Utility](#utility) | 5 | 136 | Config, Result<T,E>, config validator, JSON log sink, latency tracker |
+| [Utility](#utility) | 5 | 147 | Config, Result<T,E>, config validator, JSON log sink, latency tracker |
 | [P3 — SLAM / VIO](#p3--slam--vio) | 3 | 49 | Feature extractor, stereo matcher, IMU pre-integrator, VIO backend (covariance quality) |
 | [Utility — Diagnostics](#utility--diagnostics) | 1 | 12 | FrameDiagnostics collector, ScopedDiagTimer, merge, severity |
 | [P4 — Collision Recovery](#p4--collision-recovery) | 1 | 14 | Post-collision FSM state, waypoint skip, recovery logic |
@@ -118,7 +118,7 @@ bash deploy/build.sh --test-filter watchdog
 | [P3 — Rate Clamping](#p3--rate-clamping) | 1 | 27 | Config-driven loop rate clamping for P3 threads |
 | [P2 — Simulated Detector](#p2--simulated-detector) | 1 | 13 | SimulatedDetector extraction, detection generation |
 | [Flight Data Recorder](#flight-data-recorder) | 1 | 19 | Ring-buffer flight recorder, IPC replay |
-| [Cross-Cutting Interfaces](#cross-cutting-interfaces) | 1 | 5 | IProcessMonitor |
+| [Cross-Cutting Interfaces](#cross-cutting-interfaces) | 1 | 7 | IProcessMonitor, ISysInfo |
 | [Integration (shell)](#integration-tests) | 2 | 42+ | Full-stack E2E: Zenoh smoke test, Gazebo SITL integration |
 | [IPC — Validation](#ipc--validation) | 1 | 56 | IPC struct validation (dimensions, NaN/Inf, oversized) |
 | [Utility — Triple Buffer](#utility--triple-buffer) | 1 | 10 | Lock-free triple buffer latest-value handoff |
@@ -605,15 +605,17 @@ factory registration.
 
 ## P7 — System Monitor
 
-### test_system_monitor.cpp — 27 tests
+### test_system_monitor.cpp — 36 tests
 
 **What it tests:** System resource monitoring via Linux `/proc` filesystem.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
 | `SysInfo` | 11 | `CpuTimes` struct arithmetic (total/active), parsing `/proc/stat`, CPU usage percentage, zero-delta edge case, memory info, thermal zone reading, process enumeration |
+| `ISysInfo` | 15 | ISysInfo interface abstraction — LinuxSysInfo (name, CPU, memory, thermal, process alive, repeated reads), MockSysInfo (name, injected values), JetsonSysInfo (name, thermal zones, millideg conversion), SysInfoFactory (platform detection, config override) |
+| `ProcessMonitor` | 10 | IProcessMonitor threshold monitoring — default/custom thresholds, CPU/memory/thermal alerts, battery voltage/remaining, critical battery, overlapping thresholds |
 
-**Key files under test:** `monitor/sys_info.h`
+**Key files under test:** `monitor/sys_info.h`, `util/isys_info.h`, `util/linux_sys_info.h`, `util/mock_sys_info.h`, `util/jetson_sys_info.h`, `util/sys_info_factory.h`, `monitor/iprocess_monitor.h`
 
 ---
 
@@ -967,7 +969,7 @@ explicitly guard against this.
 
 ## Cross-Cutting Interfaces
 
-### test_process_interfaces.cpp — 6 tests
+### test_process_interfaces.cpp — 7 tests
 
 **What it tests:** Internal strategy interfaces used across multiple
 processes — tested via their simulated backends.
@@ -976,9 +978,9 @@ Path planner and obstacle avoider tests removed in Issue #207 (covered by
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
-| `ProcessMonitorTest` | 5 | `IProcessMonitor` — Linux process monitoring interface, CPU/memory query |
+| `ProcessMonitorTest` | 7 | `IProcessMonitor` — Linux process monitoring interface, CPU/memory query, ISysInfo integration |
 
-**Key files under test:** `monitor/iprocess_monitor.h`
+**Key files under test:** `monitor/iprocess_monitor.h`, `util/isys_info.h`
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -125,7 +125,9 @@ bash deploy/build.sh --test-filter watchdog
 | [Utility — sd_notify](#utility--sd_notify) | 1 | 9 | systemd sd_notify wrapper (ready, watchdog, stopping, status) |
 | [Scenario Integration](#run_scenariosh--scenario-driven-integration-runner) | 2 | 250+ | 25 scenarios via `run_scenario.sh` + `run_scenario_gazebo.sh` (20 Tier 1 + 5 Tier 2) |
 | [IPC — TopicResolver](#ipc--topicresolver) | 1 | 17 | Vehicle_id namespace resolution, validation, Zenoh pub/sub round-trip |
-| **Total** | **57 C++ + 5 shell** | **1389 + 42 + 250+** | |
+| [IPC — Serializer](#ipc--serializer) | 1 | 21 | ISerializer<T> interface, RawSerializer round-trip, wire-format compat, null safety |
+| [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
+| **Total** | **65 C++ + 5 shell** | **1461 + 42 + 250+** | |
 
 ---
 
@@ -1244,4 +1246,4 @@ pytest test suite, separate from the C++ GTest suite tracked by ctest.
 
 ---
 
-*Last updated: April 2026 — 1386 C++ unit tests across 57 files + 77 Python orchestrator tests across 3 files + 42 E2E checks (5 shell scripts) + 250+ scenario checks across 25 scenarios (20 Tier 1 + 5 Tier 2). All Tier 1 scenarios passing. PR #401 (Epic #284 Wave 2): ISysInfo platform abstraction, TopicResolver + vehicle_id, CMake enable options (+127 tests from 1259). All 1389 C++ tests passing (re-review fixes: +3 tests for battery critical, overlapping thresholds, custom MonitorThresholds).*
+*Last updated: April 2026 — 1461 C++ unit tests across 65 files + 77 Python orchestrator tests across 3 files + 42 E2E checks (5 shell scripts) + 250+ scenario checks across 25 scenarios (20 Tier 1 + 5 Tier 2). All Tier 1 scenarios passing. PR #416 (Epic #284 Wave 6): ISerializer\<T\> abstraction + RawSerializer\<T\> (21 tests), PluginLoader\<Interface\> for runtime .so loading (13 tests, HAVE_PLUGINS only). All 1461 C++ tests passing.*

--- a/tests/test_plugin_loader.cpp
+++ b/tests/test_plugin_loader.cpp
@@ -1,0 +1,205 @@
+// tests/test_plugin_loader.cpp
+// Unit tests for PluginLoader, PluginHandle, and PluginRegistry.
+//
+// These tests load the test_plugin_mock.so shared library at runtime
+// and verify correct lifetime management, error handling, and
+// move semantics.
+//
+// Requires: cmake -DENABLE_PLUGINS=ON
+
+#ifdef HAVE_PLUGINS
+
+#include "hal/icamera.h"
+#include "util/plugin_loader.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Path to the mock plugin .so — injected via CMake compile definition.
+#ifndef TEST_PLUGIN_MOCK_PATH
+#error "TEST_PLUGIN_MOCK_PATH must be defined by CMake"
+#endif
+const std::string kMockPluginPath = TEST_PLUGIN_MOCK_PATH;
+
+}  // namespace
+
+// ── PluginLoader::load — success cases ─────────────────────
+
+TEST(PluginLoaderTest, LoadSucceeds) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok()) << "Expected success, got: " << result.error();
+
+    auto& handle = result.value();
+    ASSERT_NE(handle.get(), nullptr);
+    EXPECT_EQ(handle->name(), "MockPluginCamera");
+}
+
+TEST(PluginLoaderTest, LoadWithCustomSymbol) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath,
+                                                                       "create_camera_v2");
+    ASSERT_TRUE(result.is_ok()) << "Expected success, got: " << result.error();
+    EXPECT_EQ(result.value()->name(), "MockPluginCamera");
+}
+
+TEST(PluginLoaderTest, LoadedPluginIsUsable) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& cam = result.value();
+    EXPECT_TRUE(cam->open(640, 480, 30));
+    EXPECT_TRUE(cam->is_open());
+
+    auto frame = cam->capture();
+    EXPECT_TRUE(frame.valid);
+    EXPECT_EQ(frame.width, 640u);
+    EXPECT_EQ(frame.height, 480u);
+
+    cam->close();
+    EXPECT_FALSE(cam->is_open());
+}
+
+// ── PluginLoader::load — error cases ───────────────────────
+
+TEST(PluginLoaderTest, MissingFileReturnsError) {
+    auto result =
+        drone::util::PluginLoader::load<drone::hal::ICamera>("/nonexistent/path/plugin.so");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_NE(result.error().find("not found"), std::string::npos) << "Error: " << result.error();
+}
+
+TEST(PluginLoaderTest, MissingSymbolReturnsError) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath,
+                                                                       "nonexistent_symbol");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_NE(result.error().find("nonexistent_symbol"), std::string::npos)
+        << "Error: " << result.error();
+}
+
+TEST(PluginLoaderTest, NotARegularFileReturnsError) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>("/tmp");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_NE(result.error().find("not a regular file"), std::string::npos)
+        << "Error: " << result.error();
+}
+
+// ── PluginHandle — move semantics ──────────────────────────
+
+TEST(PluginHandleTest, MoveConstructor) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok());
+
+    auto handle1 = std::move(result.value());
+    ASSERT_NE(handle1.get(), nullptr);
+    EXPECT_EQ(handle1->name(), "MockPluginCamera");
+
+    // Move to handle2
+    auto handle2(std::move(handle1));
+    EXPECT_EQ(handle1.get(), nullptr);  // NOLINT — testing moved-from state
+    ASSERT_NE(handle2.get(), nullptr);
+    EXPECT_EQ(handle2->name(), "MockPluginCamera");
+}
+
+TEST(PluginHandleTest, MoveAssignment) {
+    auto result1 = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    auto result2 = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    auto handle = std::move(result1.value());
+    handle      = std::move(result2.value());
+
+    ASSERT_NE(handle.get(), nullptr);
+    EXPECT_EQ(handle->name(), "MockPluginCamera");
+}
+
+// ── PluginHandle — release_instance ────────────────────────
+
+TEST(PluginHandleTest, ReleaseInstance) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& handle   = result.value();
+    auto  instance = handle.release_instance();
+
+    // Handle no longer owns the instance
+    EXPECT_EQ(handle.get(), nullptr);
+
+    // Instance is still valid
+    ASSERT_NE(instance, nullptr);
+    EXPECT_EQ(instance->name(), "MockPluginCamera");
+
+    // The dl_handle is still alive in the PluginHandle, so the instance
+    // can safely call virtual methods.
+    EXPECT_TRUE(instance->open(320, 240, 15));
+    instance->close();
+}
+
+// ── PluginRegistry ─────────────────────────────────────────
+
+TEST(PluginRegistryTest, ExtractReturnsValidUniquePtr) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok());
+
+    const auto count_before = drone::util::PluginRegistry::instance().handle_count();
+    auto instance = drone::util::PluginRegistry::instance().extract(std::move(result.value()));
+
+    ASSERT_NE(instance, nullptr);
+    EXPECT_EQ(instance->name(), "MockPluginCamera");
+    EXPECT_EQ(drone::util::PluginRegistry::instance().handle_count(), count_before + 1);
+
+    // Instance can be used normally through unique_ptr
+    EXPECT_TRUE(instance->open(640, 480, 30));
+    auto frame = instance->capture();
+    EXPECT_TRUE(frame.valid);
+    instance->close();
+}
+
+TEST(PluginRegistryTest, MultipleHandlesStored) {
+    const auto count_before = drone::util::PluginRegistry::instance().handle_count();
+
+    auto r1 = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    auto r2 = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(r1.is_ok());
+    ASSERT_TRUE(r2.is_ok());
+
+    auto i1 = drone::util::PluginRegistry::instance().extract(std::move(r1.value()));
+    auto i2 = drone::util::PluginRegistry::instance().extract(std::move(r2.value()));
+
+    EXPECT_EQ(drone::util::PluginRegistry::instance().handle_count(), count_before + 2);
+    EXPECT_EQ(i1->name(), "MockPluginCamera");
+    EXPECT_EQ(i2->name(), "MockPluginCamera");
+}
+
+// ── PluginHandle — dereference operators ───────────────────
+
+TEST(PluginHandleTest, DereferenceOperators) {
+    auto result = drone::util::PluginLoader::load<drone::hal::ICamera>(kMockPluginPath);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& handle = result.value();
+
+    // operator*
+    drone::hal::ICamera& ref = *handle;
+    EXPECT_EQ(ref.name(), "MockPluginCamera");
+
+    // operator->
+    EXPECT_EQ(handle->name(), "MockPluginCamera");
+
+    // get()
+    EXPECT_NE(handle.get(), nullptr);
+}
+
+#else  // !HAVE_PLUGINS
+
+#include <gtest/gtest.h>
+
+TEST(PluginLoaderTest, PluginsDisabled) {
+    // This test exists so the binary always has at least one test.
+    // When HAVE_PLUGINS is not defined, plugin loading is not available.
+    GTEST_SKIP() << "Plugin loading is disabled (ENABLE_PLUGINS=OFF)";
+}
+
+#endif  // HAVE_PLUGINS

--- a/tests/test_plugin_mock.cpp
+++ b/tests/test_plugin_mock.cpp
@@ -1,0 +1,59 @@
+// tests/test_plugin_mock.cpp
+// Mock plugin .so for testing PluginLoader.
+// Compiled as a shared library (test_plugin_mock.so) by CMake when ENABLE_PLUGINS=ON.
+//
+// Provides a minimal ICamera implementation that can be loaded at runtime
+// via dlopen/dlsym.
+
+#include "hal/icamera.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+class MockPluginCamera final : public drone::hal::ICamera {
+public:
+    [[nodiscard]] bool open(uint32_t /*width*/, uint32_t /*height*/, int /*fps*/) override {
+        opened_ = true;
+        return true;
+    }
+
+    void close() override { opened_ = false; }
+
+    [[nodiscard]] drone::hal::CapturedFrame capture() override {
+        drone::hal::CapturedFrame frame;
+        frame.width        = 640;
+        frame.height       = 480;
+        frame.channels     = 3;
+        frame.stride       = 640 * 3;
+        frame.timestamp_ns = 12345;
+        frame.sequence     = seq_++;
+        frame.data         = dummy_data_.data();
+        frame.valid        = opened_;
+        return frame;
+    }
+
+    [[nodiscard]] bool is_open() const override { return opened_; }
+
+    [[nodiscard]] std::string name() const override { return "MockPluginCamera"; }
+
+private:
+    bool                 opened_ = false;
+    uint64_t             seq_    = 0;
+    std::vector<uint8_t> dummy_data_{std::vector<uint8_t>(640 * 480 * 3, 128)};
+};
+
+}  // namespace
+
+// The factory function: extern "C" with default visibility.
+// PluginLoader::load<ICamera>() calls this to create an instance.
+extern "C" __attribute__((visibility("default"))) drone::hal::ICamera* create_instance() {
+    return new MockPluginCamera();  // NOLINT — ownership transferred to PluginHandle
+}
+
+// Second factory with a custom name, for testing custom factory_symbol.
+extern "C" __attribute__((visibility("default"))) drone::hal::ICamera* create_camera_v2() {
+    return new MockPluginCamera();  // NOLINT — ownership transferred to PluginHandle
+}

--- a/tests/test_serializer.cpp
+++ b/tests/test_serializer.cpp
@@ -13,6 +13,7 @@
 #include "ipc/iserializer.h"
 #include "ipc/raw_serializer.h"
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
@@ -363,4 +364,25 @@ TEST(RawSerializerTest, OversizedBufferWorks) {
     SimpleMsg decoded{};
     ASSERT_TRUE(ser.deserialize(big_buf.data(), sizeof(SimpleMsg), decoded));
     EXPECT_EQ(decoded.id, 42u);
+}
+
+// ── Null pointer safety ───────────────────────────────────
+
+TEST(RawSerializerTest, SerializeNullBufferNonZeroSizeReturnsZero) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id = 1;
+
+    // Null buf with non-zero size must return 0, not dereference
+    EXPECT_EQ(ser.serialize(msg, nullptr, sizeof(SimpleMsg)), 0u);
+    EXPECT_EQ(ser.serialize(msg, nullptr, 1024), 0u);
+}
+
+TEST(RawSerializerTest, DeserializeNullDataReturnsFailure) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                out{};
+
+    // Null data with valid size must return false, not dereference
+    EXPECT_FALSE(ser.deserialize(nullptr, sizeof(SimpleMsg), out));
+    EXPECT_FALSE(ser.deserialize(nullptr, 0, out));
 }

--- a/tests/test_serializer.cpp
+++ b/tests/test_serializer.cpp
@@ -1,0 +1,366 @@
+// tests/test_serializer.cpp
+// Tests for ISerializer<T> interface and RawSerializer<T> implementation.
+//
+// Verifies:
+//   - Round-trip fidelity for multiple IPC struct types
+//   - Size mismatch rejection
+//   - Buffer overrun protection
+//   - Serialized size correctness
+//   - Wire-format backward compatibility (byte-identical to raw reinterpret_cast)
+//
+// Part of Epic #284 (Platform Modularity), Issue #294.
+#include "ipc/ipc_types.h"
+#include "ipc/iserializer.h"
+#include "ipc/raw_serializer.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace drone::ipc;
+
+// ═══════════════════════════════════════════════════════════
+// Test fixture with factory helper
+// ═══════════════════════════════════════════════════════════
+
+/// Simple trivially-copyable test struct (no validate method).
+struct SimpleMsg {
+    uint64_t id{0};
+    float    value{0.0f};
+    char     tag[16]{};
+};
+static_assert(std::is_trivially_copyable_v<SimpleMsg>);
+
+// ═══════════════════════════════════════════════════════════
+// RawSerializer — name and basics
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, NameReturnsRaw) {
+    RawSerializer<SimpleMsg> ser;
+    EXPECT_EQ(ser.name(), "raw");
+}
+
+TEST(RawSerializerTest, SerializedSizeMatchesSizeof) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    EXPECT_EQ(ser.serialized_size(msg), sizeof(SimpleMsg));
+}
+
+// ═══════════════════════════════════════════════════════════
+// Round-trip: SimpleMsg
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, RoundTripSimpleMsg) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                original{};
+    original.id    = 42;
+    original.value = 3.14f;
+    std::strncpy(original.tag, "hello", sizeof(original.tag) - 1);
+
+    auto vec = ser.serialize(original);
+    ASSERT_EQ(vec.size(), sizeof(SimpleMsg));
+
+    SimpleMsg decoded{};
+    ASSERT_TRUE(ser.deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.id, 42u);
+    EXPECT_FLOAT_EQ(decoded.value, 3.14f);
+    EXPECT_STREQ(decoded.tag, "hello");
+}
+
+TEST(RawSerializerTest, RoundTripBufferSimpleMsg) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                original{};
+    original.id    = 99;
+    original.value = -1.5f;
+
+    std::vector<uint8_t> buf(sizeof(SimpleMsg));
+    size_t               written = ser.serialize(original, buf.data(), buf.size());
+    ASSERT_EQ(written, sizeof(SimpleMsg));
+
+    SimpleMsg decoded{};
+    ASSERT_TRUE(ser.deserialize(buf.data(), written, decoded));
+    EXPECT_EQ(decoded.id, 99u);
+    EXPECT_FLOAT_EQ(decoded.value, -1.5f);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Round-trip: SlamPose (Pose)
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, RoundTripPose) {
+    RawSerializer<Pose> ser;
+    Pose                original{};
+    original.timestamp_ns   = 1234567890;
+    original.translation[0] = 1.0;
+    original.translation[1] = 2.0;
+    original.translation[2] = 3.0;
+    original.quaternion[0]  = 1.0;
+    original.quality        = 2;
+
+    auto vec = ser.serialize(original);
+    ASSERT_EQ(vec.size(), sizeof(Pose));
+
+    Pose decoded{};
+    ASSERT_TRUE(ser.deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.timestamp_ns, 1234567890u);
+    EXPECT_DOUBLE_EQ(decoded.translation[0], 1.0);
+    EXPECT_DOUBLE_EQ(decoded.translation[1], 2.0);
+    EXPECT_DOUBLE_EQ(decoded.translation[2], 3.0);
+    EXPECT_DOUBLE_EQ(decoded.quaternion[0], 1.0);
+    EXPECT_EQ(decoded.quality, 2u);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Round-trip: FCState
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, RoundTripFCState) {
+    RawSerializer<FCState> ser;
+    FCState                original{};
+    original.timestamp_ns       = 9999;
+    original.battery_voltage    = 12.6f;
+    original.battery_remaining  = 85.0f;
+    original.armed              = true;
+    original.connected          = true;
+    original.gps_fix_type       = 3;
+    original.satellites_visible = 12;
+
+    auto vec = ser.serialize(original);
+    ASSERT_EQ(vec.size(), sizeof(FCState));
+
+    FCState decoded{};
+    ASSERT_TRUE(ser.deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.timestamp_ns, 9999u);
+    EXPECT_FLOAT_EQ(decoded.battery_voltage, 12.6f);
+    EXPECT_FLOAT_EQ(decoded.battery_remaining, 85.0f);
+    EXPECT_TRUE(decoded.armed);
+    EXPECT_TRUE(decoded.connected);
+    EXPECT_EQ(decoded.gps_fix_type, 3);
+    EXPECT_EQ(decoded.satellites_visible, 12);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Round-trip: SystemHealth
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, RoundTripSystemHealth) {
+    RawSerializer<SystemHealth> ser;
+    SystemHealth                original{};
+    original.timestamp_ns         = 42000;
+    original.cpu_usage_percent    = 55.5f;
+    original.memory_usage_percent = 70.0f;
+    original.thermal_zone         = 1;
+
+    auto vec = ser.serialize(original);
+    ASSERT_EQ(vec.size(), sizeof(SystemHealth));
+
+    SystemHealth decoded{};
+    ASSERT_TRUE(ser.deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.timestamp_ns, 42000u);
+    EXPECT_FLOAT_EQ(decoded.cpu_usage_percent, 55.5f);
+    EXPECT_FLOAT_EQ(decoded.memory_usage_percent, 70.0f);
+    EXPECT_EQ(decoded.thermal_zone, 1);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Round-trip: DetectedObjectList
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, RoundTripDetectedObjectList) {
+    RawSerializer<DetectedObjectList> ser;
+    DetectedObjectList                original{};
+    original.timestamp_ns          = 77777;
+    original.frame_sequence        = 10;
+    original.num_objects           = 1;
+    original.objects[0].track_id   = 5;
+    original.objects[0].confidence = 0.95f;
+    original.objects[0].position_x = 10.0f;
+
+    auto vec = ser.serialize(original);
+    ASSERT_EQ(vec.size(), sizeof(DetectedObjectList));
+
+    DetectedObjectList decoded{};
+    ASSERT_TRUE(ser.deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.timestamp_ns, 77777u);
+    EXPECT_EQ(decoded.frame_sequence, 10u);
+    EXPECT_EQ(decoded.num_objects, 1u);
+    EXPECT_EQ(decoded.objects[0].track_id, 5u);
+    EXPECT_FLOAT_EQ(decoded.objects[0].confidence, 0.95f);
+    EXPECT_FLOAT_EQ(decoded.objects[0].position_x, 10.0f);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Deserialization failure: size mismatch
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, DeserializeSizeMismatchTooSmall) {
+    RawSerializer<SimpleMsg> ser;
+    std::vector<uint8_t>     bad_data(sizeof(SimpleMsg) - 1, 0);
+    SimpleMsg                out{};
+    EXPECT_FALSE(ser.deserialize(bad_data.data(), bad_data.size(), out));
+}
+
+TEST(RawSerializerTest, DeserializeSizeMismatchTooLarge) {
+    RawSerializer<SimpleMsg> ser;
+    std::vector<uint8_t>     bad_data(sizeof(SimpleMsg) + 1, 0);
+    SimpleMsg                out{};
+    EXPECT_FALSE(ser.deserialize(bad_data.data(), bad_data.size(), out));
+}
+
+TEST(RawSerializerTest, DeserializeSizeMismatchZero) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                out{};
+    EXPECT_FALSE(ser.deserialize(nullptr, 0, out));
+}
+
+// ═══════════════════════════════════════════════════════════
+// Buffer overrun protection: serialize into too-small buffer
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, SerializeBufferTooSmallReturnsZero) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id = 1;
+
+    std::vector<uint8_t> small_buf(sizeof(SimpleMsg) - 1, 0xFF);
+    size_t               written = ser.serialize(msg, small_buf.data(), small_buf.size());
+    EXPECT_EQ(written, 0u);
+}
+
+TEST(RawSerializerTest, SerializeBufferZeroSizeReturnsZero) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    EXPECT_EQ(ser.serialize(msg, nullptr, 0), 0u);
+}
+
+TEST(RawSerializerTest, SerializeBufferExactSize) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id = 123;
+
+    std::vector<uint8_t> exact_buf(sizeof(SimpleMsg));
+    size_t               written = ser.serialize(msg, exact_buf.data(), exact_buf.size());
+    EXPECT_EQ(written, sizeof(SimpleMsg));
+
+    // Verify data is correct
+    SimpleMsg decoded{};
+    ASSERT_TRUE(ser.deserialize(exact_buf.data(), written, decoded));
+    EXPECT_EQ(decoded.id, 123u);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Wire-format backward compatibility
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, WireFormatByteIdentical) {
+    // Verify RawSerializer produces exactly the same bytes as raw
+    // reinterpret_cast — this ensures backward compatibility with
+    // messages published by the old inline code.
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id    = 0xDEADBEEF;
+    msg.value = 2.718f;
+    std::strncpy(msg.tag, "wire_test", sizeof(msg.tag) - 1);
+
+    // Old inline method (what ZenohPublisher used to do)
+    const auto*          raw_ptr = reinterpret_cast<const uint8_t*>(&msg);
+    std::vector<uint8_t> old_bytes(raw_ptr, raw_ptr + sizeof(SimpleMsg));
+
+    // New serializer method
+    auto new_bytes = ser.serialize(msg);
+
+    ASSERT_EQ(old_bytes.size(), new_bytes.size());
+    EXPECT_EQ(old_bytes, new_bytes);
+}
+
+TEST(RawSerializerTest, WireFormatBufferByteIdentical) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id    = 0xCAFEBABE;
+    msg.value = 1.414f;
+
+    // Old inline SHM method
+    const auto*          raw_ptr = reinterpret_cast<const uint8_t*>(&msg);
+    std::vector<uint8_t> old_bytes(sizeof(SimpleMsg));
+    std::copy(raw_ptr, raw_ptr + sizeof(SimpleMsg), old_bytes.data());
+
+    // New serializer buffer method
+    std::vector<uint8_t> new_bytes(sizeof(SimpleMsg));
+    size_t               written = ser.serialize(msg, new_bytes.data(), new_bytes.size());
+    ASSERT_EQ(written, sizeof(SimpleMsg));
+
+    EXPECT_EQ(old_bytes, new_bytes);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Polymorphism: use through ISerializer<T>* base pointer
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, PolymorphicUsage) {
+    auto serializer = std::make_shared<const RawSerializer<SimpleMsg>>();
+
+    // Use through base interface pointer
+    const ISerializer<SimpleMsg>* base = serializer.get();
+    EXPECT_EQ(base->name(), "raw");
+
+    SimpleMsg msg{};
+    msg.id = 777;
+    EXPECT_EQ(base->serialized_size(msg), sizeof(SimpleMsg));
+
+    auto vec = base->serialize(msg);
+    ASSERT_EQ(vec.size(), sizeof(SimpleMsg));
+
+    SimpleMsg decoded{};
+    ASSERT_TRUE(base->deserialize(vec.data(), vec.size(), decoded));
+    EXPECT_EQ(decoded.id, 777u);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Both serialize overloads produce identical bytes
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, BothSerializeOverloadsMatch) {
+    RawSerializer<Pose> ser;
+    Pose                msg{};
+    msg.timestamp_ns   = 555;
+    msg.translation[0] = 100.0;
+
+    auto vec = ser.serialize(msg);
+
+    std::vector<uint8_t> buf(sizeof(Pose));
+    size_t               written = ser.serialize(msg, buf.data(), buf.size());
+    ASSERT_EQ(written, sizeof(Pose));
+    ASSERT_EQ(vec.size(), buf.size());
+    EXPECT_EQ(vec, buf);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Oversized buffer still works (extra space ignored)
+// ═══════════════════════════════════════════════════════════
+
+TEST(RawSerializerTest, OversizedBufferWorks) {
+    RawSerializer<SimpleMsg> ser;
+    SimpleMsg                msg{};
+    msg.id = 42;
+
+    // Buffer is bigger than needed
+    std::vector<uint8_t> big_buf(sizeof(SimpleMsg) * 2, 0xAA);
+    size_t               written = ser.serialize(msg, big_buf.data(), big_buf.size());
+    EXPECT_EQ(written, sizeof(SimpleMsg));
+
+    // Extra bytes should be untouched (still 0xAA)
+    for (size_t i = sizeof(SimpleMsg); i < big_buf.size(); ++i) {
+        EXPECT_EQ(big_buf[i], 0xAA) << "Extra byte at index " << i << " was modified";
+    }
+
+    // Data portion should deserialize correctly
+    SimpleMsg decoded{};
+    ASSERT_TRUE(ser.deserialize(big_buf.data(), sizeof(SimpleMsg), decoded));
+    EXPECT_EQ(decoded.id, 42u);
+}


### PR DESCRIPTION
## Summary

Final wave of Epic #284 (Platform Modularity), completing the last two issues:

- **#294 — ISerializer\<T\> abstraction**: Virtual interface for pluggable wire-format serialization. `RawSerializer<T>` as default (byte-identical to previous inline code). Integrated into `ZenohPublisher<T>` and `ZenohSubscriber<T>`. Includes fix for critical SHM stack overflow bug (Fix #346) where `serialized_size(T{})` default-constructed 6.2 MB VideoFrame on stack.
- **#295 — PluginLoader\<Interface\>**: RAII runtime .so loading via `dlopen/dlsym/dlclose`. `PluginHandle<I>` owns dl_handle + instance with correct destruction order. `PluginRegistry` for process-lifetime dl_handle storage. All HAL factory functions support `backend="plugin"`. Gated behind `ENABLE_PLUGINS` cmake option (default OFF).

### Changes

| File | What |
|------|------|
| `common/ipc/include/ipc/iserializer.h` | NEW — Virtual serializer interface |
| `common/ipc/include/ipc/raw_serializer.h` | NEW — Trivially-copyable raw binary serializer |
| `common/ipc/include/ipc/zenoh_publisher.h` | Serializer integration, SHM zero-copy path |
| `common/ipc/include/ipc/zenoh_subscriber.h` | Serializer integration, Fix #346 stack overflow |
| `common/util/include/util/plugin_loader.h` | NEW — PluginHandle, PluginRegistry, PluginLoader |
| `common/hal/include/hal/hal_factory.h` | Plugin backend support in all 6 create_* functions |
| `process2_perception/src/detector_factory.cpp` | Plugin backend support for detector |
| `config/default.json` | `ipc_serializer: "raw"` key |
| `tests/test_serializer.cpp` | NEW — 19 serializer tests |
| `tests/test_plugin_loader.cpp` | NEW — 12 plugin tests (conditional) |
| `tests/test_plugin_mock.cpp` | NEW — Mock .so for plugin testing |
| `docs/tracking/BUG_FIXES.md` | Fix #346 documentation with GDB debugging methodology |

### Test counts

- Default build (ENABLE_PLUGINS=OFF): **1459 tests** — all pass
- Plugin build (ENABLE_PLUGINS=ON): **1471 tests** (+12) — all pass

Closes #294, Closes #295

## Test plan

- [x] Build with ENABLE_PLUGINS=OFF — zero warnings
- [x] Build with ENABLE_PLUGINS=ON — zero warnings
- [x] 1459/1459 tests pass (default)
- [x] 1471/1471 tests pass (plugins)
- [x] SHM tests pass (Fix #346 verified)
- [x] clang-format clean
- [x] All new includes resolve
- [x] Config keys consistent (cfg_key:: constants used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)