### PR TITLE
docs(#417): update design docs for Epic #284 modularity interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ export_claude_context.sh
 
 # Agent artifacts (transient reports from deploy-issue/deploy-wave pipelines)
 AGENT_REPORT.md
+
+# Local-only deep documentation (not committed — personal reference)
+docs/design/modularity_guide.md

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Expected: drone takes off, navigates 3 waypoints, returns home.
 | [payload_manager_design.md](docs/design/payload_manager_design.md) | P6 gimbal control, payload actions, rate-limited slew |
 | [system_monitor_design.md](docs/design/system_monitor_design.md) | P7 health metrics, thermal zones, battery monitoring |
 | **Cross-Cutting** | |
-| [modularity_guide.md](docs/design/modularity_guide.md) | Platform modularity: architecture, usage, extension guide (Epic #284) |
 | [API.md](docs/design/API.md) | IPC interfaces, Zenoh pub/sub, HAL interfaces, message types |
 | [hal_design.md](docs/design/hal_design.md) | Hardware Abstraction Layer: interfaces, backends, factory pattern |
 | [ipc_design.md](docs/design/ipc_design.md) | IPC architecture: Zenoh message bus, TripleBuffer, channel design |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Expected: drone takes off, navigates 3 waypoints, returns home.
 | [payload_manager_design.md](docs/design/payload_manager_design.md) | P6 gimbal control, payload actions, rate-limited slew |
 | [system_monitor_design.md](docs/design/system_monitor_design.md) | P7 health metrics, thermal zones, battery monitoring |
 | **Cross-Cutting** | |
+| [modularity_guide.md](docs/design/modularity_guide.md) | Platform modularity: architecture, usage, extension guide (Epic #284) |
 | [API.md](docs/design/API.md) | IPC interfaces, Zenoh pub/sub, HAL interfaces, message types |
 | [hal_design.md](docs/design/hal_design.md) | Hardware Abstraction Layer: interfaces, backends, factory pattern |
 | [ipc_design.md](docs/design/ipc_design.md) | IPC architecture: Zenoh message bus, TripleBuffer, channel design |

--- a/docs/design/API.md
+++ b/docs/design/API.md
@@ -187,6 +187,94 @@ sub->receive(out);
 - Liveliness tokens for process death detection
 - Configurable QoS (reliable/best-effort, history depth)
 
+### `ISerializer<T>` — `drone::ipc` — Epic #284, Issue #294
+
+> **File:** `common/ipc/include/ipc/iserializer.h`
+
+Abstract serialization interface decoupling wire format from transport.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `serialize(msg, buf, buf_size)` | `size_t` | Serialize into pre-allocated buffer (SHM path) |
+| `serialize(msg)` | `vector<uint8_t>` | Serialize into new vector (bytes path) |
+| `deserialize(data, size, out)` | `bool` | Deserialize from raw bytes |
+| `serialized_size(msg)` | `size_t` | Query serialized size |
+| `name()` | `string_view` | Human-readable name (e.g. "raw") |
+
+**Implementation:** `RawSerializer<T>` (`raw_serializer.h`) — byte-identical memcpy with `static_assert(is_trivially_copyable_v<T>)`.
+
+### `TopicResolver` — `drone::ipc` — Epic #284, Issue #289
+
+> **File:** `common/ipc/include/ipc/topic_resolver.h`
+
+Multi-vehicle topic namespacing. Prepends `/<vehicle_id>` to topic names.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `TopicResolver(vehicle_id)` | — | Constructor; empty = no prefix (backward compat) |
+| `resolve(base_topic)` | `string` | Namespace a topic: `"/slam_pose"` → `"/drone42/slam_pose"` |
+| `vehicle_id()` | `const string&` | Configured vehicle ID |
+| `has_prefix()` | `bool` | True if vehicle_id is non-empty |
+
+Validation: `[a-zA-Z0-9_-]` only. Throws `invalid_argument` at construction.
+
+---
+
+## 1.6 Intra-Process Infrastructure — Epic #284
+
+### `EventBus<Event>` — `drone::util` — Issue #293
+
+> **File:** `common/util/include/util/event_bus.h`
+
+Lightweight typed intra-process pub/sub with RAII subscriptions.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `subscribe(handler)` | `Subscription<Event>` | Subscribe; returns RAII token |
+| `publish(event)` | `void` | Notify all subscribers (snapshot-copy, re-entrant safe) |
+| `subscriber_count()` | `size_t` | Active subscription count |
+
+Thread-safe: subscribe/publish/unsubscribe from any thread. Lifetime: bus must outlive all subscriptions.
+
+### `PluginLoader` — `drone::util` — Epic #284, Issue #295
+
+> **File:** `common/util/include/util/plugin_loader.h`
+> **Gate:** `#ifdef HAVE_PLUGINS`
+
+Runtime .so loading via dlopen with RAII lifetime management.
+
+| Class | Purpose |
+|-------|---------|
+| `PluginLoader` | Static factory: `load<Interface>(so_path, factory_symbol)` → `Result<PluginHandle<I>>` |
+| `PluginHandle<I>` | RAII: owns dl handle + instance. Destroys instance before dlclose. |
+| `PluginRegistry` | Process-lifetime singleton storing dl handles when caller needs `unique_ptr<I>` |
+
+Plugin .so contract: `extern "C" __attribute__((visibility("default"))) Interface* create_instance();`
+
+### Config Key Registry — `drone::cfg_key` — Issue #287
+
+> **File:** `common/util/include/util/config_keys.h`
+
+~130 `inline constexpr const char*` constants organized per-process namespace. Eliminates string typos in `cfg.get<>()` calls. Namespaces: `zenoh::`, `perception::`, `slam::`, `mission_planner::`, `comms::`, `payload_manager::`, `system_monitor::`, `watchdog::`, `recorder::`, `hal::`, `fault_manager::`.
+
+### ConfigValidator — `drone::util` — Issue #298
+
+> **File:** `common/util/include/util/config_validator.h`
+
+Fluent schema builder for config validation at startup.
+
+| Method | Description |
+|--------|-------------|
+| `required<T>(key)` | Key must exist with correct type |
+| `optional<T>(key)` | Key may exist; if present, must match type |
+| `.range(lo, hi)` | Value must be in [lo, hi] |
+| `.one_of({...})` | Value must be in set |
+| `.satisfies(predicate, desc)` | Custom validation |
+| `required_section(key)` | JSON object must exist |
+| `custom(rule)` | Arbitrary validation lambda |
+
+Pre-built schemas: `common_schema()`, `video_capture_schema()`, ..., `system_monitor_schema()`.
+
 ---
 
 ## 1.5 IPC Message Types (`common/ipc/include/ipc/ipc_types.h`)

--- a/docs/design/API.md
+++ b/docs/design/API.md
@@ -220,7 +220,7 @@ Validation: `[a-zA-Z0-9_-]` only. Throws `invalid_argument` at construction.
 
 ---
 
-## 1.6 Intra-Process Infrastructure — Epic #284
+## 1.5 Intra-Process Infrastructure — Epic #284
 
 ### `EventBus<Event>` — `drone::util` — Issue #293
 
@@ -277,7 +277,7 @@ Pre-built schemas: `common_schema()`, `video_capture_schema()`, ..., `system_mon
 
 ---
 
-## 1.5 IPC Message Types (`common/ipc/include/ipc/ipc_types.h`)
+## 1.6 IPC Message Types (`common/ipc/include/ipc/ipc_types.h`)
 
 Key wire-format structs used across pub/sub topics. All must be trivially copyable.
 

--- a/docs/design/hal_design.md
+++ b/docs/design/hal_design.md
@@ -412,14 +412,44 @@ file for clarity.
 
 ## 5. Backend Availability Matrix
 
-| Interface | Simulated | Gazebo | Real |
-|-----------|-----------|--------|------|
-| `ICamera` | ✓ | ✓ (HAVE_GAZEBO) | V4L2 (future) |
-| `IFCLink` | ✓ | ✓ via `mavlink` + PX4 SITL | MAVSDK (`HAVE_MAVSDK`) |
-| `IGCSLink` | ✓ | ✓ (via FC) | UDP (future) |
-| `IGimbal` | ✓ | — | SIYI (future) |
-| `IIMUSource` | ✓ | ✓ (HAVE_GAZEBO) | BMI088 (future) |
-| `IRadar` | ✓ | ✓ (HAVE_GAZEBO) | TI AWR1843 (future) |
+| Interface | Simulated | Gazebo | Real | Plugin |
+|-----------|-----------|--------|------|--------|
+| `ICamera` | ✓ | ✓ (HAVE_GAZEBO) | V4L2 (future) | ✓ (HAVE_PLUGINS) |
+| `IFCLink` | ✓ | ✓ via `mavlink` + PX4 SITL | MAVSDK (`HAVE_MAVSDK`) | ✓ (HAVE_PLUGINS) |
+| `IGCSLink` | ✓ | ✓ (via FC) | UDP (future) | ✓ (HAVE_PLUGINS) |
+| `IGimbal` | ✓ | — | SIYI (future) | ✓ (HAVE_PLUGINS) |
+| `IIMUSource` | ✓ | ✓ (HAVE_GAZEBO) | BMI088 (future) | ✓ (HAVE_PLUGINS) |
+| `IRadar` | ✓ | ✓ (HAVE_GAZEBO) | TI AWR1843 (future) | ✓ (HAVE_PLUGINS) |
+
+---
+
+## 5.5 Plugin Backend Support — Epic #284, Issue #295
+
+> **Gate:** `ENABLE_PLUGINS=ON` → `HAVE_PLUGINS` compile definition
+> **File:** `common/hal/include/hal/hal_factory.h` (plugin dispatch), `common/util/include/util/plugin_loader.h` (loader)
+
+When `ENABLE_PLUGINS` is enabled, all 6 HAL factory functions gain a `"plugin"` backend that loads a `.so` at runtime via `dlopen`. This enables third-party or hardware-specific backends without recompiling the stack.
+
+**Config example:**
+
+```json
+{
+  "video_capture.mission_cam.backend": "plugin",
+  "video_capture.mission_cam.plugin_path": "/opt/drone/plugins/libv4l2_camera.so",
+  "video_capture.mission_cam.plugin_factory": "create_camera"
+}
+```
+
+**Plugin .so contract:**
+
+- Factory function must use `extern "C"` linkage (no name mangling)
+- Factory must have `__attribute__((visibility("default")))`
+- Signature: `Interface* symbol_name();` — caller takes ownership
+- Default factory symbol: `"create_instance"` (configurable via `plugin_factory` config key)
+
+**Lifetime management:** `PluginHandle<I>` (RAII) ensures the dlopen handle outlives the instance. `PluginRegistry` provides process-lifetime storage for handles when the HAL factory needs to return `unique_ptr<Interface>`.
+
+**Security:** `ENABLE_PLUGINS` is OFF by default. Arbitrary .so loading can execute any code — only enable in trusted environments.
 
 ---
 

--- a/docs/design/ipc_design.md
+++ b/docs/design/ipc_design.md
@@ -22,11 +22,13 @@
 7. [Wire Format](#wire-format)
 8. [Topic Mapping](#topic-mapping)
 9. [MessageBus Abstraction](#messagebus-abstraction)
-10. [Service Channels](#service-channels)
-11. [Liveliness Monitoring](#liveliness-monitoring)
-12. [Configuration Reference](#configuration-reference)
-13. [Testing](#testing)
-14. [Known Limitations](#known-limitations)
+10. [ISerializer\<T\> — Serialization Abstraction](#iserializert--serialization-abstraction)
+11. [TopicResolver — Multi-Vehicle Namespacing](#topicresolver--multi-vehicle-namespacing)
+12. [Service Channels](#service-channels)
+13. [Liveliness Monitoring](#liveliness-monitoring)
+14. [Configuration Reference](#configuration-reference)
+15. [Testing](#testing)
+16. [Known Limitations](#known-limitations)
 
 ---
 
@@ -382,6 +384,52 @@ MessageBus create_message_bus(const Config& cfg);
 
 The factory is the **only** place backend selection happens. Process code never
 references Zenoh directly — it only uses the `IPublisher`/`ISubscriber` interfaces.
+
+---
+
+## ISerializer\<T\> — Serialization Abstraction
+
+> **File:** `common/ipc/include/ipc/iserializer.h` — Epic #284, Issue #294
+
+Decouples wire format from transport. ZenohPublisher/Subscriber delegate serialization to `ISerializer<T>` instead of hardcoding `reinterpret_cast` + `std::copy`.
+
+```cpp
+template<typename T>
+class ISerializer {
+public:
+    virtual size_t serialize(const T& msg, uint8_t* buf, size_t buf_size) const = 0;
+    virtual std::vector<uint8_t> serialize(const T& msg) const = 0;
+    virtual bool deserialize(const uint8_t* data, size_t size, T& out) const = 0;
+    virtual size_t serialized_size(const T& msg) const = 0;
+    virtual std::string_view name() const = 0;
+};
+```
+
+**Current implementation:** `RawSerializer<T>` (`raw_serializer.h`) — byte-identical memcpy with `static_assert(is_trivially_copyable_v<T>)`. Produces identical output to the previous inline code.
+
+**Design choice:** Virtual dispatch (~1-3 ns) is negligible vs Zenoh transport latency (~10-100 us). Simple virtual interface preferred over CRTP complexity.
+
+**Future:** `ProtobufSerializer<T>` for cross-language GCS communication.
+
+---
+
+## TopicResolver — Multi-Vehicle Namespacing
+
+> **File:** `common/ipc/include/ipc/topic_resolver.h` — Epic #284, Issue #289
+
+Enables multiple vehicles on the same Zenoh network by namespacing topics under `/<vehicle_id>/...`.
+
+```cpp
+TopicResolver r("drone42");
+r.resolve("/slam_pose")     // → "/drone42/slam_pose"
+
+TopicResolver r_default;    // empty vehicle_id
+r_default.resolve("/slam_pose")  // → "/slam_pose" (unchanged)
+```
+
+- **Validation:** `[a-zA-Z0-9_-]` only; throws `invalid_argument` at construction
+- **Integration:** Set via config key `zenoh.vehicle_id`; `create_message_bus(cfg)` installs it
+- **Backward compatible:** Empty `vehicle_id` (default) produces identical behavior to pre-TopicResolver code
 
 ---
 

--- a/docs/design/ipc_design.md
+++ b/docs/design/ipc_design.md
@@ -428,7 +428,7 @@ r_default.resolve("/slam_pose")  // → "/slam_pose" (unchanged)
 ```
 
 - **Validation:** `[a-zA-Z0-9_-]` only; throws `invalid_argument` at construction
-- **Integration:** Set via config key `zenoh.vehicle_id`; `create_message_bus(cfg)` installs it
+- **Integration:** Set via top-level config key `vehicle_id`; `create_message_bus(cfg)` installs it
 - **Backward compatible:** Empty `vehicle_id` (default) produces identical behavior to pre-TopicResolver code
 
 ---

--- a/docs/design/system_monitor_design.md
+++ b/docs/design/system_monitor_design.md
@@ -150,11 +150,39 @@ to prevent thermal runaway from crash loops.
 
 ---
 
-## System Info Parsers
+## System Info — ISysInfo Interface (Epic #284, Issue #290)
 
-- **Header:** [`sys_info.h`](../common/util/include/util/sys_info.h)
+> **Interface:** [`isys_info.h`](../../common/util/include/util/isys_info.h)
+> **Factory:** [`sys_info_factory.h`](../../common/util/include/util/sys_info_factory.h)
 
-### CpuTimes
+System metrics are accessed through the `ISysInfo` interface, abstracting platform-specific paths (`/proc`, `/sys`) behind a testable contract:
+
+```cpp
+class ISysInfo {
+    virtual CpuTimes read_cpu_times() const = 0;
+    virtual MemInfo  read_meminfo() const = 0;
+    virtual float    read_cpu_temp() const = 0;
+    virtual DiskInfo read_disk_usage() const = 0;
+    virtual bool     is_process_alive(pid_t pid) const = 0;
+    virtual std::string name() const = 0;
+};
+```
+
+**Implementations:**
+
+| Class | File | Platform |
+|-------|------|----------|
+| `LinuxSysInfo` | `linux_sys_info.h` | Generic Linux (`/proc/stat`, `/sys/class/thermal/thermal_zone0`) |
+| `JetsonSysInfo` | `jetson_sys_info.h` | NVIDIA Jetson (Tegra thermal zone1) |
+| `MockSysInfo` | `mock_sys_info.h` | Tests (injectable fields, requires `DRONE_ENABLE_MOCK`) |
+
+**Factory:** `create_sys_info("linux" | "jetson" | "mock")` — selected via config key `system_monitor.platform`.
+
+**Caching:** Both `LinuxSysInfo` and `JetsonSysInfo` cache file reads with a configurable TTL (default 500ms) to avoid excessive `/proc` and `/sys` I/O per collection cycle.
+
+### Data Structures
+
+#### CpuTimes
 
 Parsed from `/proc/stat` first line. Two-sample delta method for CPU usage:
 ```

--- a/docs/design/system_monitor_design.md
+++ b/docs/design/system_monitor_design.md
@@ -13,7 +13,7 @@
 3. [Thread Architecture](#thread-architecture)
 4. [IPC Channels](#ipc-channels)
 5. [Health Collection: LinuxProcessMonitor](#health-collection-linuxprocessmonitor)
-6. [System Info Parsers](#system-info-parsers)
+6. [System Info — ISysInfo Interface](#system-info--isysinfo-interface-epic-284-issue-290)
 7. [ProcessManager (Layer 2)](#processmanager-layer-2)
 8. [ProcessGraph](#processgraph)
 9. [RestartPolicy](#restartpolicy)
@@ -159,11 +159,13 @@ System metrics are accessed through the `ISysInfo` interface, abstracting platfo
 
 ```cpp
 class ISysInfo {
-    virtual CpuTimes read_cpu_times() const = 0;
-    virtual MemInfo  read_meminfo() const = 0;
-    virtual float    read_cpu_temp() const = 0;
-    virtual DiskInfo read_disk_usage() const = 0;
-    virtual bool     is_process_alive(pid_t pid) const = 0;
+public:
+    virtual ~ISysInfo() = default;
+    virtual CpuTimes    read_cpu_times() const = 0;
+    virtual MemInfo     read_meminfo() const = 0;
+    virtual float       read_cpu_temp() const = 0;
+    virtual DiskInfo    read_disk_usage() const = 0;
+    virtual bool        is_process_alive(pid_t pid) const = 0;
     virtual std::string name() const = 0;
 };
 ```
@@ -173,12 +175,12 @@ class ISysInfo {
 | Class | File | Platform |
 |-------|------|----------|
 | `LinuxSysInfo` | `linux_sys_info.h` | Generic Linux (`/proc/stat`, `/sys/class/thermal/thermal_zone0`) |
-| `JetsonSysInfo` | `jetson_sys_info.h` | NVIDIA Jetson (Tegra thermal zone1) |
+| `JetsonSysInfo` | `jetson_sys_info.h` | NVIDIA Jetson (discovers CPU thermal zone by `type`, caches zone index) |
 | `MockSysInfo` | `mock_sys_info.h` | Tests (injectable fields, requires `DRONE_ENABLE_MOCK`) |
 
 **Factory:** `create_sys_info("linux" | "jetson" | "mock")` — selected via config key `system_monitor.platform`.
 
-**Caching:** Both `LinuxSysInfo` and `JetsonSysInfo` cache file reads with a configurable TTL (default 500ms) to avoid excessive `/proc` and `/sys` I/O per collection cycle.
+**Caching:** `LinuxSysInfo` reuses cached file handles for `/proc` and `/sys` reads by rewinding and rereading them on each collection cycle. `JetsonSysInfo` follows the same approach and additionally caches the discovered thermal zone index. No configurable TTL-based read cache is currently used.
 
 ### Data Structures
 


### PR DESCRIPTION
## Summary

- Add 6 new interface entries to `API.md`: ISerializer, TopicResolver, EventBus, PluginLoader, Config Key Registry, ConfigValidator
- Add ISerializer and TopicResolver sections to `ipc_design.md` with TOC updates
- Add plugin backend support column and Section 5.5 to `hal_design.md`
- Update `system_monitor_design.md` with ISysInfo interface, implementations table, and factory
- Add `modularity_guide.md` to README doc index and `.gitignore` (local-only deep reference)

## Test plan

- [ ] All links in updated docs resolve to existing files
- [ ] No build impact (docs-only change)
- [ ] `.gitignore` correctly excludes `docs/design/modularity_guide.md`

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)