### PR TITLE
fix(#428): prevent false grid promotion from camera-only ground features

### DIFF
--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -220,6 +220,8 @@ inline constexpr const char* RADAR_PROMOTION_HITS =
 inline constexpr const char* MIN_PROMOTION_DEPTH_CONFIDENCE =
     "mission_planner.occupancy_grid.min_promotion_depth_confidence";
 inline constexpr const char* MAX_STATIC_CELLS = "mission_planner.occupancy_grid.max_static_cells";
+inline constexpr const char* REQUIRE_RADAR_FOR_PROMOTION =
+    "mission_planner.occupancy_grid.require_radar_for_promotion";
 inline constexpr const char* PREDICTION_ENABLED =
     "mission_planner.occupancy_grid.prediction_enabled";
 inline constexpr const char* PREDICTION_DT_S = "mission_planner.occupancy_grid.prediction_dt_s";

--- a/config/default.json
+++ b/config/default.json
@@ -176,6 +176,7 @@
             "min_confidence": 0.3,
             "min_promotion_depth_confidence": 0.5,
             "max_static_cells": 0,
+            "require_radar_for_promotion": false,
             "prediction_enabled": true,
             "prediction_dt_s": 2.0
         },

--- a/config/scenarios/18_perception_avoidance.json
+++ b/config/scenarios/18_perception_avoidance.json
@@ -34,8 +34,9 @@
                 "promotion_hits": 8,
                 "min_promotion_depth_confidence": 0.8,
                 "max_static_cells": 800,
+                "require_radar_for_promotion": true,
                 "prediction_enabled": false,
-                "_comment": "2m grid, 2m inflation, 1s TTL. min_promotion_depth_confidence=0.8: blocks camera-only Tier 1-4 (0.01-0.7) while allowing radar-confirmed (1.0) to promote. prediction_enabled=false: camera-only depth/velocity too noisy (Issue #340). max_static_cells=800 safety cap."
+                "_comment": "2m grid, 2m inflation, 1s TTL. require_radar_for_promotion: only radar-touched objects can promote to static — prevents camera-only ground feature false promotions. prediction_enabled=false: camera-only depth/velocity too noisy (Issue #340). max_static_cells=800 safety cap."
             },
             "static_obstacles": [],
             "_comment_static_obstacles": "Empty — no HD-map. All obstacle knowledge comes from camera detections at runtime.",

--- a/config/scenarios/27_perception_depth_accuracy.json
+++ b/config/scenarios/27_perception_depth_accuracy.json
@@ -34,8 +34,9 @@
                 "promotion_hits": 8,
                 "min_promotion_depth_confidence": 0.8,
                 "max_static_cells": 800,
+                "require_radar_for_promotion": true,
                 "prediction_enabled": false,
-                "_comment": "Same occupancy config as scenario 18."
+                "_comment": "Same occupancy config as scenario 18. require_radar_for_promotion prevents camera-only ground feature false promotions."
             },
             "static_obstacles": [],
             "_comment_static_obstacles": "Empty — no HD-map. All obstacle knowledge comes from camera detections at runtime.",

--- a/process4_mission_planner/include/planner/grid_planner_base.h
+++ b/process4_mission_planner/include/planner/grid_planner_base.h
@@ -51,10 +51,12 @@ struct GridPlannerConfig {
     float    min_promotion_depth_confidence = 0.3f;  // Min depth confidence for promotion [0-1]
                                                      // Scenario configs override to 0.8 to block
     // camera-only (0.01-0.7), allowing radar-confirmed (1.0)
-    float look_ahead_m = 0.0f;        // Pure-pursuit look-ahead distance along path
-                                      // (0 = disabled, use cell-by-cell following)
-    int   max_static_cells   = 0;     // Cap on promoted static cells (0 = unlimited)
-    bool  yaw_towards_travel = true;  // Face sensors toward next waypoint during NAVIGATE
+    float look_ahead_m = 0.0f;                 // Pure-pursuit look-ahead distance along path
+                                               // (0 = disabled, use cell-by-cell following)
+    bool require_radar_for_promotion = false;  // Require ≥1 radar update for hit-count promotion
+                                               // (radar-confirmed path always works regardless)
+    int   max_static_cells   = 0;              // Cap on promoted static cells (0 = unlimited)
+    bool  yaw_towards_travel = true;           // Face sensors toward next waypoint during NAVIGATE
     float yaw_smoothing_rate = 0.3f;  // EMA alpha for yaw transitions (0=frozen, 1=instant)
     float snap_approach_bias = 0.5f;  // Approach-direction penalty for snap fallback
     bool  prediction_enabled = true;  // Enable velocity-based obstacle prediction
@@ -99,7 +101,8 @@ public:
         , grid_(config.resolution_m, config.grid_extent_m, config.inflation_radius_m,
                 config.cell_ttl_s, config.min_confidence, config.promotion_hits,
                 config.radar_promotion_hits, config.min_promotion_depth_confidence,
-                config.max_static_cells, config.prediction_enabled, config.prediction_dt_s) {}
+                config.max_static_cells, config.prediction_enabled, config.prediction_dt_s,
+                config.require_radar_for_promotion) {}
 
     void update_obstacles(const drone::ipc::DetectedObjectList& objects,
                           const drone::ipc::Pose&               pose) override {

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -222,10 +222,10 @@ public:
             }
             ++accepted;
 
-            // Per-object inflation: use estimated radius if available (from
-            // camera bbox + radar range back-projection), otherwise fall back
-            // to the configured inflation radius.  This gives accurate grid
-            // footprints for radar-confirmed obstacles.
+            // Per-object inflation: use estimated radius only for radar-confirmed
+            // objects (where range is reliable), otherwise fall back to the
+            // configured inflation radius.  This gives accurate grid footprints
+            // for radar-confirmed obstacles.
             //
             // Cap: camera-only objects use at most the configured inflation
             // radius.  Without radar, estimated_radius is derived from the
@@ -508,6 +508,11 @@ private:
                                     hit_count_.erase(c);
                                     ++promoted_count_;
                                 }
+                            } else {
+                                // Camera-only: clear any stale hit count so a
+                                // later radar-confirmed object in the same cell
+                                // doesn't inherit accumulated hits.
+                                hit_count_.erase(c);
                             }
                         }
                     }

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -108,7 +108,8 @@ public:
                              float cell_ttl_s = 3.0f, float min_confidence = 0.3f,
                              int promotion_hits = 0, uint32_t radar_promotion_hits = 3,
                              float min_promotion_depth_confidence = 0.3f, int max_static_cells = 0,
-                             bool prediction_enabled = true, float prediction_dt_s = 2.0f)
+                             bool prediction_enabled = true, float prediction_dt_s = 2.0f,
+                             bool require_radar_for_promotion = false)
         : resolution_(resolution)
         , half_extent_cells_(static_cast<int>(extent / resolution))
         , inflation_cells_(std::max(1, static_cast<int>(std::ceil(inflation / resolution))))
@@ -119,7 +120,8 @@ public:
         , min_promotion_depth_confidence_(min_promotion_depth_confidence)
         , max_static_cells_(max_static_cells)
         , prediction_enabled_(prediction_enabled)
-        , prediction_dt_s_(prediction_dt_s) {}
+        , prediction_dt_s_(prediction_dt_s)
+        , require_radar_for_promotion_(require_radar_for_promotion) {}
 
     /// Force-clear all *dynamic* (TTL-based) obstacles (for testing / reset).
     /// Static HD-map obstacles are left untouched; call clear_static() to remove those.
@@ -224,11 +226,19 @@ public:
             // camera bbox + radar range back-projection), otherwise fall back
             // to the configured inflation radius.  This gives accurate grid
             // footprints for radar-confirmed obstacles.
-            const int obj_inflation =
-                (obj.estimated_radius_m > 0.0f)
-                    ? std::max(1, static_cast<int>(std::ceil(
+            //
+            // Cap: camera-only objects use at most the configured inflation
+            // radius.  Without radar, estimated_radius is derived from the
+            // (possibly bogus) camera depth — ground features can produce
+            // radii of 10-20m, inflating a single object to 300+ cells and
+            // flooding the dynamic grid.  Radar-confirmed objects have
+            // reliable range, so their back-projected radius is trusted.
+            const bool has_radar_size = obj.radar_update_count > 0 && obj.estimated_radius_m > 0.0f;
+            const int  obj_inflation =
+                has_radar_size
+                     ? std::max(1, static_cast<int>(std::ceil(
                                       (obj.estimated_radius_m + resolution_ * 0.5f) / resolution_)))
-                    : inflation_cells_;
+                     : inflation_cells_;
 
             // Per-object promotion eligibility (invariant across inflated cells).
             const bool depth_ok    = obj.depth_confidence >= min_promotion_depth_confidence_;
@@ -483,13 +493,21 @@ private:
                                 ++promoted_count_;
                             }
                         } else if (promotion_hits_ > 0 && !cap_reached) {
-                            int& hits = hit_count_[c];
-                            ++hits;
-                            if (hits >= promotion_hits_) {
-                                static_occupied_.insert(c);
-                                occupied_.erase(c);
-                                hit_count_.erase(c);
-                                ++promoted_count_;
+                            // When require_radar_for_promotion_ is set, the hit-count
+                            // path requires at least one radar update on the object.
+                            // Camera-only detections stay dynamic (TTL-based) — they
+                            // still provide immediate avoidance but cannot permanently
+                            // pollute the grid with false ground-feature promotions.
+                            const bool has_any_radar = obj->radar_update_count > 0;
+                            if (!require_radar_for_promotion_ || has_any_radar) {
+                                int& hits = hit_count_[c];
+                                ++hits;
+                                if (hits >= promotion_hits_) {
+                                    static_occupied_.insert(c);
+                                    occupied_.erase(c);
+                                    hit_count_.erase(c);
+                                    ++promoted_count_;
+                                }
                             }
                         }
                     }
@@ -512,6 +530,7 @@ private:
     bool     promotion_paused_{false};               // pause promotion during RTL/LAND
     bool     prediction_enabled_{true};              // enable velocity-based prediction inflation
     float    prediction_dt_s_{2.0f};                 // prediction horizon in seconds
+    bool     require_radar_for_promotion_{false};    // hit-count path needs ≥1 radar update
     // Cumulative count of objects with velocity-based prediction applied (never reset).
     int      total_predictions_applied_{0};
     uint64_t diag_tick_{0};  // for periodic diagnostic logging

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -202,6 +202,9 @@ int main(int argc, char* argv[]) {
     planner_cfg.max_static_cells =
         ctx.cfg.get<int>(drone::cfg_key::mission_planner::occupancy_grid::MAX_STATIC_CELLS,
                          planner_cfg.max_static_cells);
+    planner_cfg.require_radar_for_promotion = ctx.cfg.get<bool>(
+        drone::cfg_key::mission_planner::occupancy_grid::REQUIRE_RADAR_FOR_PROMOTION,
+        planner_cfg.require_radar_for_promotion);
     // Prediction config — under occupancy_grid.* for consistency with other grid params
     planner_cfg.prediction_enabled =
         ctx.cfg.get<bool>(drone::cfg_key::mission_planner::occupancy_grid::PREDICTION_ENABLED,

--- a/tests/test_dstar_lite_planner.cpp
+++ b/tests/test_dstar_lite_planner.cpp
@@ -1807,6 +1807,138 @@ TEST(OccupancyGrid3DTest, PromotionPausedBlocksPromotion) {
 }
 
 // ═════════════════════════════════════════════════════════════
+// Issue #428: False grid promotion — radar gate + inflation cap
+// ═════════════════════════════════════════════════════════════
+
+TEST(OccupancyGrid3DTest, RequireRadarBlocksCameraOnlyPromotion) {
+    // Camera-only objects must NOT promote via hit-count when
+    // require_radar_for_promotion is enabled.
+    OccupancyGrid3D grid(1.0f, 20.0f, 1.0f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/2,
+                         /*radar_promotion_hits=*/3,
+                         /*min_promo_depth_conf=*/0.5f, /*max_static_cells=*/0,
+                         /*prediction_enabled=*/false, /*prediction_dt_s=*/2.0f,
+                         /*require_radar_for_promotion=*/true);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 5.0f;
+    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_z         = 5.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 0.9f;
+    objects.objects[0].radar_update_count = 0;  // camera-only
+    drone::ipc::Pose pose{};
+
+    // Many observations — should never promote
+    for (int i = 0; i < 10; ++i) {
+        grid.update_from_objects(objects, pose);
+    }
+    EXPECT_EQ(grid.static_count(), 0u);    // no promotion
+    EXPECT_GT(grid.occupied_count(), 0u);  // dynamic cells exist
+}
+
+TEST(OccupancyGrid3DTest, RequireRadarAllowsRadarTouchedPromotion) {
+    // Objects with ≥1 radar update should still promote via hit-count
+    // even when require_radar_for_promotion is enabled.
+    OccupancyGrid3D grid(1.0f, 20.0f, 1.0f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/2,
+                         /*radar_promotion_hits=*/3,
+                         /*min_promo_depth_conf=*/0.5f, /*max_static_cells=*/0,
+                         /*prediction_enabled=*/false, /*prediction_dt_s=*/2.0f,
+                         /*require_radar_for_promotion=*/true);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 5.0f;
+    objects.objects[0].position_y         = 5.0f;
+    objects.objects[0].position_z         = 5.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].depth_confidence   = 0.9f;
+    objects.objects[0].radar_update_count = 1;  // has radar
+    drone::ipc::Pose pose{};
+
+    for (int i = 0; i < 5; ++i) {
+        grid.update_from_objects(objects, pose);
+    }
+    EXPECT_GT(grid.static_count(), 0u);  // promoted via hit-count
+}
+
+TEST(OccupancyGrid3DTest, CameraOnlyInflationCapped) {
+    // Camera-only objects with large estimated_radius_m must be capped
+    // to the configured inflation radius, not use the back-projected size.
+    // A 2.0m inflation on 1.0m grid = 2 cells.  A bogus 20m radius would
+    // be 20 cells — we must NOT see that many occupied cells.
+    OccupancyGrid3D grid(1.0f, 40.0f, 2.0f);  // 2m inflation
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects                   = 1;
+    objects.objects[0].position_x         = 10.0f;
+    objects.objects[0].position_y         = 10.0f;
+    objects.objects[0].position_z         = 5.0f;
+    objects.objects[0].confidence         = 0.9f;
+    objects.objects[0].estimated_radius_m = 20.0f;  // bogus large radius
+    objects.objects[0].radar_update_count = 0;      // camera-only
+    drone::ipc::Pose pose{};
+
+    grid.update_from_objects(objects, pose);
+
+    // With 2m inflation on 1m grid → inflation_cells_ = 2.
+    // A 2D disk of radius 2 cells ≈ at most 13 cells (π×2²).
+    // If uncapped, 20m radius → 20 cells → π×20² ≈ 1257 cells.
+    EXPECT_LT(grid.occupied_count(), 20u);
+}
+
+TEST(OccupancyGrid3DTest, StaleHitCountClearedWhenRadarGateBlocks) {
+    // When the radar gate blocks camera-only promotion, any accumulated
+    // hit_count for that cell must be cleared so a future radar-confirmed
+    // object doesn't inherit stale hits.
+    OccupancyGrid3D grid(1.0f, 20.0f, 0.0f, /*ttl=*/3.0f,
+                         /*min_conf=*/0.3f, /*promotion_hits=*/3,
+                         /*radar_promotion_hits=*/3,
+                         /*min_promo_depth_conf=*/0.5f, /*max_static_cells=*/0,
+                         /*prediction_enabled=*/false, /*prediction_dt_s=*/2.0f,
+                         /*require_radar_for_promotion=*/true);
+
+    // Phase 1: Camera-only object observes the cell many times.
+    // Hits should be cleared each time (not accumulated).
+    drone::ipc::DetectedObjectList cam_objects{};
+    cam_objects.num_objects                   = 1;
+    cam_objects.objects[0].position_x         = 5.0f;
+    cam_objects.objects[0].position_y         = 5.0f;
+    cam_objects.objects[0].position_z         = 5.0f;
+    cam_objects.objects[0].confidence         = 0.9f;
+    cam_objects.objects[0].depth_confidence   = 0.9f;
+    cam_objects.objects[0].radar_update_count = 0;
+    drone::ipc::Pose pose{};
+
+    for (int i = 0; i < 10; ++i) {
+        grid.update_from_objects(cam_objects, pose);
+    }
+    EXPECT_EQ(grid.static_count(), 0u);  // nothing promoted
+
+    // Phase 2: Now a radar-confirmed object appears at the same cell.
+    // It should need the full promotion_hits (3), not benefit from stale hits.
+    drone::ipc::DetectedObjectList radar_objects{};
+    radar_objects.num_objects                   = 1;
+    radar_objects.objects[0].position_x         = 5.0f;
+    radar_objects.objects[0].position_y         = 5.0f;
+    radar_objects.objects[0].position_z         = 5.0f;
+    radar_objects.objects[0].confidence         = 0.9f;
+    radar_objects.objects[0].depth_confidence   = 0.9f;
+    radar_objects.objects[0].radar_update_count = 1;
+
+    // 2 observations — NOT enough for promotion_hits=3
+    grid.update_from_objects(radar_objects, pose);
+    grid.update_from_objects(radar_objects, pose);
+    EXPECT_EQ(grid.static_count(), 0u);  // should NOT have promoted yet
+
+    // 3rd observation — now it should promote
+    grid.update_from_objects(radar_objects, pose);
+    EXPECT_GT(grid.static_count(), 0u);
+}
+
+// ═════════════════════════════════════════════════════════════
 // Issue #338: Snap goal approach bias tests
 // ═════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

- **Radar-only promotion**: New `require_radar_for_promotion` config flag gates hit-count promotion path on `radar_update_count >= 1`. Camera-only detections stay dynamic (TTL-based).
- **Inflation cap**: Camera-only objects use configured `inflation_cells_` instead of back-projected `estimated_radius_m` (which can be 10-20m for ground features).

Discovered during Gazebo validation of Epic #419 Wave 1 — ColorContour detects ground texture as obstacles with large bboxes, producing high depth confidence (0.89+) that passes the covariance gate. Two fixes prevent both static promotion and dynamic cell flooding.

## Results

| Metric | Before | After |
|--------|--------|-------|
| Survey static cells | 800 (saturated in 10s) | 26 |
| Peak static cells | 800 | 167 |
| Peak dynamic cells | 1088 | 190 |
| Max search time | 5ms | 2ms |
| Landing | Yes | Yes |

## Test plan

- [x] `bash deploy/build.sh` — zero warnings
- [x] `ctest` — 1479/1479 pass
- [x] Scenario 27 (depth accuracy) — PASS, 19/19 checks, full landing
- [x] Scenario 18 (perception avoidance) — PASS, 19/19 checks, regression clean
- [x] Scenario 02 (obstacle avoidance) — PASS, 19/19 checks, regression clean

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)