### PR TITLE
fix(#453): fix agent definitions — frontmatter must start at line 1

### DIFF
--- a/.claude/agents/feature-infra-core.md
+++ b/.claude/agents/feature-infra-core.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: feature-infra-core
 description: Implements core infrastructure — utilities, config, IPC factories, modularity epic
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Feature Agent — Infrastructure Core
 

--- a/.claude/agents/feature-infra-platform.md
+++ b/.claude/agents/feature-infra-platform.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: feature-infra-platform
 description: Implements platform infrastructure — deployment, CI/CD, systemd, cross-compilation, customer configs
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Feature Agent — Infrastructure Platform
 

--- a/.claude/agents/feature-integration.md
+++ b/.claude/agents/feature-integration.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: feature-integration
 description: Implements comms, payload, and system monitor features — FC/GCS links, gimbal, health monitoring
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Feature Agent — Integration (Comms, Payload, Monitor)
 

--- a/.claude/agents/feature-nav.md
+++ b/.claude/agents/feature-nav.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: feature-nav
 description: Implements navigation and mission planning features — SLAM/VIO, FSM, path planning, obstacle avoidance
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Feature Agent — Navigation and Mission Planning
 

--- a/.claude/agents/feature-perception.md
+++ b/.claude/agents/feature-perception.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: feature-perception
 description: Implements perception pipeline features — video capture, detection, tracking, sensor fusion
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Feature Agent — Perception Pipeline
 

--- a/.claude/agents/ops-github.md
+++ b/.claude/agents/ops-github.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: ops-github
 description: GitHub operations — issue triage, label management, milestone tracking, stale cleanup, epic progress
-tools: [Read, Glob, Grep, Bash]
+tools: Read, Glob, Grep, Bash
 model: haiku
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Ops Agent — GitHub Operations
 

--- a/.claude/agents/review-api-contract.md
+++ b/.claude/agents/review-api-contract.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-api-contract
 description: Reviews code for API contract accuracy — docstrings match implementation, data consistency, naming conventions, code completeness
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — API Contract & Data Consistency
 

--- a/.claude/agents/review-code-quality.md
+++ b/.claude/agents/review-code-quality.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-code-quality
 description: Reviews code for quality and maintainability — dead code, DRY violations, complexity, naming, unnecessary abstractions
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Code Quality & Maintainability
 

--- a/.claude/agents/review-concurrency.md
+++ b/.claude/agents/review-concurrency.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-concurrency
 description: Reviews code for concurrency bugs — data races, lock ordering, incorrect atomics, missing synchronization
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Concurrency
 

--- a/.claude/agents/review-fault-recovery.md
+++ b/.claude/agents/review-fault-recovery.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-fault-recovery
 description: Reviews code for fault recovery correctness — error propagation, watchdog integration, graceful degradation
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Fault Recovery
 

--- a/.claude/agents/review-memory-safety.md
+++ b/.claude/agents/review-memory-safety.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-memory-safety
 description: Reviews code for memory safety violations — raw pointers, uninitialized vars, unsafe casts, missing RAII
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Memory Safety
 

--- a/.claude/agents/review-performance.md
+++ b/.claude/agents/review-performance.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-performance
 description: Reviews code for performance issues — unnecessary copies, allocation in hot paths, algorithmic complexity, cache efficiency
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Performance
 

--- a/.claude/agents/review-security.md
+++ b/.claude/agents/review-security.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-security
 description: Reviews code for security vulnerabilities — input validation, IPC bounds checks, authentication, secrets
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Security
 

--- a/.claude/agents/review-test-quality.md
+++ b/.claude/agents/review-test-quality.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: review-test-quality
 description: Reviews test code for quality — verifies new tests exercise new code paths, assertions are meaningful, boundary conditions covered
-tools: [Read, Glob, Grep]
+tools: Read, Glob, Grep
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Review Agent — Test Quality & Design
 

--- a/.claude/agents/tech-lead.md
+++ b/.claude/agents/tech-lead.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: tech-lead
 description: Orchestrator agent that routes work, manages reviews, and coordinates multi-agent sessions
-tools: [Read, Glob, Grep, Bash, Agent]
+tools: Read, Glob, Grep, Bash, Agent
 model: opus
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Tech Lead — Orchestrator Agent
 

--- a/.claude/agents/test-scenario.md
+++ b/.claude/agents/test-scenario.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: test-scenario
 description: Runs and maintains scenario integration tests — Gazebo SITL, JSON scenario configs, stack coverage
-tools: [Read, Edit, Bash, Glob, Grep]
+tools: Read, Edit, Bash, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Test Agent — Scenario Integration Tests
 

--- a/.claude/agents/test-unit.md
+++ b/.claude/agents/test-unit.md
@@ -1,12 +1,12 @@
-<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
-<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
-
 ---
 name: test-unit
 description: Writes and maintains unit tests — GTest framework, coverage verification, test count tracking
-tools: [Read, Edit, Write, Bash, Glob, Grep]
+tools: Read, Edit, Write, Bash, Glob, Grep
 model: sonnet
 ---
+
+<!-- SPDX-License-Identifier: LicenseRef-Pipeline-Proprietary -->
+<!-- Copyright (c) 2025-2026 Naveen Mohanan. All Rights Reserved. See PIPELINE_LICENSE.md. -->
 
 # Test Agent — Unit Tests
 


### PR DESCRIPTION
## Summary

All 17 custom agent definitions in .claude/agents/*.md had HTML license comments before the YAML frontmatter delimiter (---). Claude Code requires frontmatter to start at line 1 for subagent discovery — content before it silently prevents parsing, causing "Agent type not found" errors when using subagent_type in the Agent tool.

## Changes

- Move license comments from before frontmatter into the body (after closing ---)
- Change tools field from YAML array syntax [Read, Edit, ...] to comma-separated Read, Edit, ... (matching official docs)

17 files changed, no functional changes to agent behavior — only file format.

## Root Cause

The subagent loader parses YAML frontmatter by looking for --- at line 1. HTML comments before it meant zero agent definitions were discovered at session start, so all 17 custom agents were invisible.

Ref: https://code.claude.com/docs/en/sub-agents
> Subagents are loaded at session start. If you create a subagent by manually adding a file, restart your session or use /agents to load it immediately.

## Test plan

- [ ] Start a new Claude Code session in this project
- [ ] Verify /agents shows all 17 custom agents in the Library tab
- [ ] Test Agent(subagent_type: "feature-perception") resolves correctly
- [ ] Test Agent(subagent_type: "review-memory-safety") resolves correctly

Closes #453