### PR TITLE
feat(#455): Depth Anything V2 OpenCV DNN backend + Gazebo ML depth scenario

### DIFF
--- a/common/hal/CMakeLists.txt
+++ b/common/hal/CMakeLists.txt
@@ -43,3 +43,17 @@ if(COSYS_AIRSIM_FOUND)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cosys_depth.cpp
     )
 endif()
+
+# ── Optional: Depth Anything V2 (OpenCV DNN) ──────────────
+# Uses OpenCV DNN to run DA V2 ONNX model for monocular metric depth estimation.
+# Issue #455.
+# NOTE: HAS_OPENCV is NOT defined here (INTERFACE would leak to all consumers,
+# breaking tests that compile detector_factory.cpp without YOLO sources).
+# HAS_OPENCV stays per-target: process2_perception and specific test targets.
+# The DA V2 source compiles safely without HAS_OPENCV (returns error at runtime).
+if(OPENCV_FOUND)
+    target_sources(drone_hal INTERFACE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/depth_anything_v2.cpp
+    )
+    target_link_libraries(drone_hal INTERFACE ${OpenCV_LIBS})
+endif()

--- a/common/hal/CMakeLists.txt
+++ b/common/hal/CMakeLists.txt
@@ -51,6 +51,9 @@ endif()
 # breaking tests that compile detector_factory.cpp without YOLO sources).
 # HAS_OPENCV stays per-target: process2_perception and specific test targets.
 # The DA V2 source compiles safely without HAS_OPENCV (returns error at runtime).
+# TODO: When more OpenCV-dependent HAL backends accumulate, split into a separate
+# drone_hal_opencv STATIC library to avoid INTERFACE link leaking ${OpenCV_LIBS}
+# to all consumers. See PR #456 review discussion.
 if(OPENCV_FOUND)
     target_sources(drone_hal INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/depth_anything_v2.cpp

--- a/common/hal/include/hal/depth_anything_v2.h
+++ b/common/hal/include/hal/depth_anything_v2.h
@@ -1,0 +1,70 @@
+// common/hal/include/hal/depth_anything_v2.h
+// Depth Anything V2 depth estimator backend using OpenCV DNN.
+// Loads a DA V2 ViT-S ONNX model and performs monocular metric depth estimation.
+// Implements Issue #455.
+#pragma once
+
+#include "hal/idepth_estimator.h"
+#include "util/config.h"
+#include "util/config_keys.h"
+#include "util/ilogger.h"
+
+#ifdef HAS_OPENCV
+#include <opencv2/core.hpp>
+#include <opencv2/dnn.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
+#include <atomic>
+#include <chrono>
+#include <string>
+
+namespace drone::hal {
+
+/// Depth Anything V2 monocular depth estimator using OpenCV DNN.
+///
+/// Loads a DA V2 ONNX model (ViT-S ~100MB) and produces per-pixel metric depth.
+/// The model outputs relative inverse depth which is converted to metric depth via:
+///   metric_depth = max_depth / (normalized_output + epsilon)
+///
+/// NOT thread-safe: net_ is mutated on each estimate() call.
+/// Only call from a single thread (the depth thread in P2).
+///
+/// Config keys:
+///   perception.depth_estimator.backend      = "depth_anything_v2"
+///   perception.depth_estimator.model_path   (default "models/depth_anything_v2_vits.onnx")
+///   perception.depth_estimator.input_size   (default 518)
+///   perception.depth_estimator.max_fps      (default 15)
+///   perception.depth_estimator.max_depth_m  (default 20.0 — metric conversion ceiling)
+class DepthAnythingV2Estimator : public IDepthEstimator {
+public:
+    /// Construct from config.
+    explicit DepthAnythingV2Estimator(const drone::Config& cfg, const std::string& section);
+
+    /// Construct with explicit parameters (for testing / direct use).
+    explicit DepthAnythingV2Estimator(const std::string& model_path, int input_size = 518,
+                                      float max_depth_m = 20.0f);
+
+    [[nodiscard]] drone::util::Result<DepthMap, std::string> estimate(const uint8_t* frame_data,
+                                                                      uint32_t       width,
+                                                                      uint32_t       height,
+                                                                      uint32_t       channels,
+                                                                      uint32_t stride = 0) override;
+
+    [[nodiscard]] std::string name() const override { return "DepthAnythingV2Estimator"; }
+
+    /// Check if ONNX model was loaded successfully.
+    [[nodiscard]] bool is_loaded() const { return model_loaded_; }
+
+private:
+    void load_model(const std::string& model_path);
+
+#ifdef HAS_OPENCV
+    cv::dnn::Net net_;
+#endif
+    bool  model_loaded_ = false;
+    int   input_size_   = 518;
+    float max_depth_m_  = 20.0f;  // metric conversion: depth = max_depth / (inv_depth + eps)
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -277,6 +277,12 @@ template<typename Interface>
     if (backend == "depth_anything_v2") {
         return std::make_unique<DepthAnythingV2Estimator>(cfg, section);
     }
+#else
+    if (backend == "depth_anything_v2") {
+        throw std::runtime_error(
+            "[HAL] Depth estimator backend 'depth_anything_v2' requires OpenCV "
+            "(HAS_OPENCV), but this build was compiled without it");
+    }
 #endif
     // Future: if (backend == "gazebo") return std::make_unique<GazeboDepthEstimator>(cfg, section);
 #ifdef HAVE_PLUGINS

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -48,6 +48,10 @@
 #include "hal/cosys_radar.h"
 #endif
 
+#ifdef HAS_OPENCV
+#include "hal/depth_anything_v2.h"
+#endif
+
 #ifdef HAVE_PLUGINS
 #include "util/plugin_loader.h"
 #endif
@@ -269,7 +273,11 @@ template<typename Interface>
         return std::make_unique<CosysDepthBackend>(cfg, section);
     }
 #endif
-    // Future: if (backend == "depth_anything_v2") return std::make_unique<DepthAnythingV2>(cfg, section);
+#ifdef HAS_OPENCV
+    if (backend == "depth_anything_v2") {
+        return std::make_unique<DepthAnythingV2Estimator>(cfg, section);
+    }
+#endif
     // Future: if (backend == "gazebo") return std::make_unique<GazeboDepthEstimator>(cfg, section);
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -78,15 +78,14 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 [[nodiscard]] drone::util::Result<DepthMap, std::string> DepthAnythingV2Estimator::estimate(
     const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
     uint32_t stride) {
-    (void)stride;  // OpenCV DNN handles layout internally via blobFromImage
-
     if (frame_data == nullptr || width == 0 || height == 0) {
         return drone::util::Result<DepthMap, std::string>::err(
             "DepthAnythingV2: invalid frame (null data or zero dimensions)");
     }
-    if (channels == 0 || channels < 3) {
+    if (channels < 3 || channels > 4) {
         return drone::util::Result<DepthMap, std::string>::err(
-            "DepthAnythingV2: requires at least 3 channels (RGB), got " + std::to_string(channels));
+            "DepthAnythingV2: requires 3 (RGB) or 4 (RGBA) channels, got " +
+            std::to_string(channels));
     }
 
 #ifdef HAS_OPENCV
@@ -98,8 +97,9 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
     // ── Step 1: Wrap raw pixel data as cv::Mat ──────────────
     int     cv_type = (channels == 4) ? CV_8UC4 : CV_8UC3;
+    size_t  step    = (stride > 0) ? static_cast<size_t>(stride) : cv::Mat::AUTO_STEP;
     cv::Mat frame(static_cast<int>(height), static_cast<int>(width), cv_type,
-                  const_cast<uint8_t*>(frame_data));
+                  const_cast<uint8_t*>(frame_data), step);
 
     // If RGBA, convert to RGB
     cv::Mat rgb;
@@ -164,8 +164,13 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     const auto  num_pixels = static_cast<size_t>(out_h) * static_cast<size_t>(out_w);
 
     // ── Step 5: Convert relative inverse depth → metric depth ──
-    // DA V2 outputs relative (unnormalized) inverse depth values.
-    // Find min/max to normalize, then convert: depth = max_depth / (normalized + eps)
+    // DA V2 outputs unnormalized inverse depth: higher values = closer objects.
+    // We normalize to [0,1] then invert: depth = max_depth / (normalized + eps).
+    // This maps: normalized≈1 (closest) → depth≈max_depth/(1+eps)≈max_depth,
+    //            normalized≈0 (farthest) → depth≈max_depth/eps (clamped to max_depth).
+    // The final clamp to [0.1, max_depth_m_] ensures valid metric range.
+    // Note: inverse depth means the "closest" pixel gets the highest raw value,
+    // so after inversion the depth spread depends on the scene's actual depth range.
     float min_val = raw_data[0];
     float max_val = raw_data[0];
     for (size_t i = 1; i < num_pixels; ++i) {

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -1,0 +1,220 @@
+// common/hal/src/depth_anything_v2.cpp
+// Depth Anything V2 depth estimator implementation using OpenCV DNN module.
+// Issue #455.
+
+#include "hal/depth_anything_v2.h"
+
+#include "util/config_keys.h"
+#include "util/ilogger.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+
+namespace drone::hal {
+
+// ── Config constructor ──────────────────────────────────────
+DepthAnythingV2Estimator::DepthAnythingV2Estimator(const drone::Config& cfg,
+                                                   const std::string&   section) {
+    std::string model_path = cfg.get<std::string>(section + ".model_path",
+                                                  "models/depth_anything_v2_vits.onnx");
+    input_size_            = cfg.get<int>(section + ".input_size", 518);
+    max_depth_m_           = cfg.get<float>(section + ".max_depth_m", 20.0f);
+
+    DRONE_LOG_INFO("[DepthAnythingV2] Config: input_size={}, max_depth_m={:.1f}", input_size_,
+                   max_depth_m_);
+    load_model(model_path);
+}
+
+// ── Explicit constructor ────────────────────────────────────
+DepthAnythingV2Estimator::DepthAnythingV2Estimator(const std::string& model_path, int input_size,
+                                                   float max_depth_m)
+    : input_size_(input_size), max_depth_m_(max_depth_m) {
+    load_model(model_path);
+}
+
+// ── Model loading ───────────────────────────────────────────
+void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
+    // Path traversal guard: reject paths containing ".." components.
+    // Prevents directory traversal from config-injected paths.
+    if (model_path.find("..") != std::string::npos) {
+        DRONE_LOG_ERROR("[DepthAnythingV2] Rejected model path with '..': {}", model_path);
+        model_loaded_ = false;
+        return;
+    }
+
+    // Canonicalize path — weakly_canonical can throw on invalid paths or IO errors
+    std::filesystem::path canonical;
+    try {
+        canonical = std::filesystem::weakly_canonical(model_path);
+    } catch (const std::filesystem::filesystem_error& e) {
+        DRONE_LOG_ERROR("[DepthAnythingV2] Invalid model path '{}': {}", model_path, e.what());
+        model_loaded_ = false;
+        return;
+    }
+
+#ifdef HAS_OPENCV
+    try {
+        net_ = cv::dnn::readNetFromONNX(canonical.string());
+        net_.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);
+        net_.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+        model_loaded_ = true;
+
+        DRONE_LOG_INFO("[DepthAnythingV2] Model loaded: {} (input={}x{})", model_path, input_size_,
+                       input_size_);
+    } catch (const cv::Exception& e) {
+        DRONE_LOG_ERROR("[DepthAnythingV2] Failed to load model '{}': {}", model_path, e.what());
+        model_loaded_ = false;
+    }
+#else
+    (void)canonical;
+    DRONE_LOG_WARN("[DepthAnythingV2] OpenCV not available — model not loaded");
+    model_loaded_ = false;
+#endif
+}
+
+// ── Depth estimation ────────────────────────────────────────
+[[nodiscard]] drone::util::Result<DepthMap, std::string> DepthAnythingV2Estimator::estimate(
+    const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
+    uint32_t stride) {
+    (void)stride;  // OpenCV DNN handles layout internally via blobFromImage
+
+    if (frame_data == nullptr || width == 0 || height == 0) {
+        return drone::util::Result<DepthMap, std::string>::err(
+            "DepthAnythingV2: invalid frame (null data or zero dimensions)");
+    }
+    if (channels == 0 || channels < 3) {
+        return drone::util::Result<DepthMap, std::string>::err(
+            "DepthAnythingV2: requires at least 3 channels (RGB), got " + std::to_string(channels));
+    }
+
+#ifdef HAS_OPENCV
+    if (!model_loaded_) {
+        return drone::util::Result<DepthMap, std::string>::err("DepthAnythingV2: model not loaded");
+    }
+
+    auto t0 = std::chrono::steady_clock::now();
+
+    // ── Step 1: Wrap raw pixel data as cv::Mat ──────────────
+    int     cv_type = (channels == 4) ? CV_8UC4 : CV_8UC3;
+    cv::Mat frame(static_cast<int>(height), static_cast<int>(width), cv_type,
+                  const_cast<uint8_t*>(frame_data));
+
+    // If RGBA, convert to RGB
+    cv::Mat rgb;
+    if (channels == 4) {
+        cv::cvtColor(frame, rgb, cv::COLOR_RGBA2RGB);
+    } else {
+        rgb = frame;  // Already RGB, no copy
+    }
+
+    // ── Step 2: Create blob (resize + normalize) ────────────
+    // DA V2 expects [1, 3, H, W] normalized to [0, 1]
+    cv::Mat blob;
+    cv::dnn::blobFromImage(rgb, blob,
+                           1.0 / 255.0,                         // scale
+                           cv::Size(input_size_, input_size_),  // target size
+                           cv::Scalar(0, 0, 0),                 // mean subtraction
+                           false,                               // swapRB (input is RGB)
+                           false);                              // crop
+
+    // ── Step 3: Forward pass ────────────────────────────────
+    net_.setInput(blob);
+    cv::Mat output;
+    try {
+        output = net_.forward();
+    } catch (const cv::Exception& e) {
+        return drone::util::Result<DepthMap, std::string>::err(
+            std::string("DepthAnythingV2: forward() failed: ") + e.what());
+    }
+
+    // ── Step 4: Parse output ────────────────────────────────
+    // DA V2 output: [1, 1, H, W] or [1, H, W] — relative inverse depth (float32)
+    // Reshape to 2D if needed
+    const int out_dims = output.dims;
+    int       out_h    = 0;
+    int       out_w    = 0;
+
+    if (out_dims == 4) {
+        // [1, 1, H, W]
+        out_h = output.size[2];
+        out_w = output.size[3];
+    } else if (out_dims == 3) {
+        // [1, H, W]
+        out_h = output.size[1];
+        out_w = output.size[2];
+    } else if (out_dims == 2) {
+        // [H, W]
+        out_h = output.size[0];
+        out_w = output.size[1];
+    } else {
+        return drone::util::Result<DepthMap, std::string>::err(
+            "DepthAnythingV2: unexpected output dims=" + std::to_string(out_dims));
+    }
+
+    if (out_h <= 0 || out_w <= 0) {
+        return drone::util::Result<DepthMap, std::string>::err(
+            "DepthAnythingV2: invalid output dimensions " + std::to_string(out_h) + "x" +
+            std::to_string(out_w));
+    }
+
+    CV_Assert(output.type() == CV_32F);
+    const auto* raw_data   = reinterpret_cast<const float*>(output.data);
+    const auto  num_pixels = static_cast<size_t>(out_h) * static_cast<size_t>(out_w);
+
+    // ── Step 5: Convert relative inverse depth → metric depth ──
+    // DA V2 outputs relative (unnormalized) inverse depth values.
+    // Find min/max to normalize, then convert: depth = max_depth / (normalized + eps)
+    float min_val = raw_data[0];
+    float max_val = raw_data[0];
+    for (size_t i = 1; i < num_pixels; ++i) {
+        min_val = std::min(min_val, raw_data[i]);
+        max_val = std::max(max_val, raw_data[i]);
+    }
+
+    constexpr float eps   = 1e-6f;
+    const float     range = max_val - min_val;
+
+    DepthMap map;
+    map.width         = static_cast<uint32_t>(out_w);
+    map.height        = static_cast<uint32_t>(out_h);
+    map.source_width  = width;  // Original frame dimensions — critical for fusion bbox mapping
+    map.source_height = height;
+    map.scale         = 1.0f;
+    map.confidence    = 0.7f;  // ML model confidence — higher than simulated (0.5)
+    map.data.resize(num_pixels);
+
+    if (range < eps) {
+        // Flat output (all pixels same depth) — return uniform max_depth
+        std::fill(map.data.begin(), map.data.end(), max_depth_m_);
+    } else {
+        for (size_t i = 0; i < num_pixels; ++i) {
+            // Normalize inverse depth to [0, 1]
+            const float normalized = (raw_data[i] - min_val) / range;
+            // Convert: high inverse depth → close, low inverse depth → far
+            // Clamp metric depth to [0.1, max_depth_m_]
+            const float metric = max_depth_m_ / (normalized + eps);
+            map.data[i]        = std::clamp(metric, 0.1f, max_depth_m_);
+        }
+    }
+
+    auto t1 = std::chrono::steady_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+    static std::atomic<uint64_t> call_count{0};
+    if (++call_count % 30 == 0) {
+        DRONE_LOG_INFO("[DepthAnythingV2] {}x{} depth map in {}ms (inv_depth range: [{:.3f}, "
+                       "{:.3f}])",
+                       out_w, out_h, ms, min_val, max_val);
+    }
+
+    return drone::util::Result<DepthMap, std::string>::ok(std::move(map));
+
+#else
+    return drone::util::Result<DepthMap, std::string>::err(
+        "DepthAnythingV2: OpenCV not available (compiled without HAS_OPENCV)");
+#endif
+}
+
+}  // namespace drone::hal

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -168,13 +168,13 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     const auto  num_pixels = static_cast<size_t>(out_h) * static_cast<size_t>(out_w);
 
     // ── Step 5: Convert relative inverse depth → metric depth ──
-    // DA V2 outputs unnormalized inverse depth: higher values = closer objects.
-    // We normalize to [0,1] then invert: depth = max_depth / (normalized + eps).
-    // This maps: normalized≈1 (closest) → depth≈max_depth/(1+eps)≈max_depth,
-    //            normalized≈0 (farthest) → depth≈max_depth/eps (clamped to max_depth).
-    // The final clamp to [0.1, max_depth_m_] ensures valid metric range.
-    // Note: inverse depth means the "closest" pixel gets the highest raw value,
-    // so after inversion the depth spread depends on the scene's actual depth range.
+    // DA V2 outputs unnormalized inverse depth: higher raw value = closer object.
+    // We normalize to [0,1] then linearly map to metric depth:
+    //   normalized=1 (closest object, highest inverse depth) → min_depth (0.1m)
+    //   normalized=0 (farthest object, lowest inverse depth) → max_depth
+    // This provides full utilization of the [min_depth, max_depth] range.
+    // Note: DA V2 is a relative (not metric) model — the absolute scale depends
+    // on the scene. The linear mapping is the simplest correct conversion.
     float min_val = raw_data[0];
     float max_val = raw_data[0];
     for (size_t i = 1; i < num_pixels; ++i) {
@@ -182,8 +182,9 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
         max_val = std::max(max_val, raw_data[i]);
     }
 
-    constexpr float eps   = 1e-6f;
-    const float     range = max_val - min_val;
+    constexpr float eps       = 1e-6f;
+    constexpr float min_depth = 0.1f;  // Minimum metric depth (closest objects)
+    const float     range     = max_val - min_val;
 
     DepthMap map;
     map.width         = static_cast<uint32_t>(out_w);
@@ -199,12 +200,11 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
         std::fill(map.data.begin(), map.data.end(), max_depth_m_);
     } else {
         for (size_t i = 0; i < num_pixels; ++i) {
-            // Normalize inverse depth to [0, 1]
+            // Normalize inverse depth to [0, 1]: 1 = closest, 0 = farthest
             const float normalized = (raw_data[i] - min_val) / range;
-            // Convert: high inverse depth → close, low inverse depth → far
-            // Clamp metric depth to [0.1, max_depth_m_]
-            const float metric = max_depth_m_ / (normalized + eps);
-            map.data[i]        = std::clamp(metric, 0.1f, max_depth_m_);
+            // Linear map: high inverse depth (close) → small depth, low → large depth
+            const float metric = min_depth + (max_depth_m_ - min_depth) * (1.0f - normalized);
+            map.data[i]        = metric;
         }
     }
 

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -159,7 +159,11 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
             std::to_string(out_w));
     }
 
-    CV_Assert(output.type() == CV_32F);
+    if (output.type() != CV_32F) {
+        return drone::util::Result<DepthMap, std::string>::err(
+            "DepthAnythingV2: unexpected output type=" + std::to_string(output.type()) +
+            ", expected CV_32F (" + std::to_string(CV_32F) + ")");
+    }
     const auto* raw_data   = reinterpret_cast<const float*>(output.data);
     const auto  num_pixels = static_cast<size_t>(out_h) * static_cast<size_t>(out_w);
 

--- a/config/scenarios/28_ml_depth_estimation.json
+++ b/config/scenarios/28_ml_depth_estimation.json
@@ -66,7 +66,7 @@
                 "input_size": 518,
                 "max_fps": 15,
                 "max_depth_m": 20.0,
-                "_comment": "Depth Anything V2 ViT-S ONNX via OpenCV DNN. CPU inference ~60-80ms/frame."
+                "_comment": "Depth Anything V2 ViT-S ONNX via OpenCV DNN at 518x518. CPU inference ~1s/frame (hardware-dependent)."
             },
             "tracker": {
                 "backend": "bytetrack",

--- a/config/scenarios/28_ml_depth_estimation.json
+++ b/config/scenarios/28_ml_depth_estimation.json
@@ -1,0 +1,127 @@
+{
+    "_comment": "Scenario 28: ML Depth Estimation in Gazebo — validates Depth Anything V2 backend with full perception pipeline. Uses color_contour (works on Gazebo cylinders) for detection + DA V2 for metric depth + radar for range confirmation. Compare with scenario 27 (simulated depth) and scenario 18 (perception avoidance).",
+    "scenario": {
+        "name": "ml_depth_estimation",
+        "description": "ML depth estimation validation: color_contour + Depth Anything V2 + radar UKF fusion",
+        "tier": 2,
+        "timeout_s": 240,
+        "requires_gazebo": true
+    },
+    "config_overrides": {
+        "mission_planner": {
+            "takeoff_altitude_m": 5.0,
+            "acceptance_radius_m": 3.0,
+            "overshoot_proximity_factor": 5.0,
+            "cruise_speed_mps": 2.0,
+            "survey_duration_s": 26.0,
+            "survey_yaw_rate": 0.5,
+            "path_planner": {"backend": "dstar_lite", "max_search_time_ms": 1500, "max_iterations": 200000, "z_band_cells": 0, "replan_interval_s": 0.5, "look_ahead_m": 0.0, "smoothing_alpha": 0.5, "yaw_towards_travel": true, "yaw_smoothing_rate": 0.3, "snap_approach_bias": 1.0},
+            "obstacle_avoider": {"backend": "potential_field_3d"},
+            "obstacle_avoidance": {
+                "min_distance_m": 2.0,
+                "influence_radius_m": 8.0,
+                "repulsive_gain": 3.0,
+                "max_correction_mps": 1.5,
+                "vertical_gain": 0.0,
+                "path_aware": true,
+                "_comment": "Same avoidance config as scenarios 18/27."
+            },
+            "occupancy_grid": {
+                "resolution_m": 2.0,
+                "inflation_radius_m": 2.0,
+                "dynamic_obstacle_ttl_s": 1.0,
+                "min_confidence": 0.4,
+                "promotion_hits": 12,
+                "min_promotion_depth_confidence": 0.85,
+                "max_static_cells": 800,
+                "require_radar_for_promotion": true,
+                "prediction_enabled": false,
+                "_comment": "Higher promotion_hits (12 vs 8) and depth confidence (0.85 vs 0.8) than scenario 27 — ML depth produces real values for more scene elements, need stricter promotion to avoid grid saturation."
+            },
+            "static_obstacles": [],
+            "geofence": {
+                "enabled": false,
+                "_comment": "Geofence disabled — D* Lite replanning may push drone toward boundary when avoiding detected obstacles"
+            },
+            "waypoints": [
+                {"x": 0,  "y": 15, "z": 4, "yaw": 1.57,  "speed": 1.5, "payload_trigger": false, "_comment": "WP1: Fly north — near RED(3,15) PERSON 1.7m"},
+                {"x": 10, "y": 15, "z": 4, "yaw": 0,      "speed": 1.5, "payload_trigger": false, "_comment": "WP2: Fly east — near GREEN(10,10) TREE 6.0m"},
+                {"x": 18, "y": 10, "z": 4, "yaw": -1.0,   "speed": 1.5, "payload_trigger": false, "_comment": "WP3: Fly southeast — near BLUE(18,5) VEHICLE_CAR 2.0m"},
+                {"x": 5,  "y": 5,  "z": 4, "yaw": -2.36,  "speed": 1.5, "payload_trigger": false, "_comment": "WP4: Fly southwest — near ORANGE(5,3) BUILDING 10.0m"},
+                {"x": 0,  "y": 0,  "z": 4, "yaw": -2.36,  "speed": 1.5, "payload_trigger": false, "_comment": "WP5: Return home"}
+            ],
+            "_comment_waypoints": "Same waypoint route as scenario 27 — flies past all 4 varied-height obstacles."
+        },
+        "perception": {
+            "detector": {
+                "backend": "color_contour",
+                "confidence_threshold": 0.3,
+                "max_detections": 64,
+                "_comment": "color_contour detects Gazebo's colored cylinders. DA V2 provides depth."
+            },
+            "depth_estimator": {
+                "backend": "depth_anything_v2",
+                "enabled": true,
+                "model_path": "models/depth_anything_v2_vits.onnx",
+                "input_size": 518,
+                "max_fps": 15,
+                "max_depth_m": 20.0,
+                "_comment": "Depth Anything V2 ViT-S ONNX via OpenCV DNN. CPU inference ~60-80ms/frame."
+            },
+            "tracker": {
+                "backend": "bytetrack",
+                "high_conf_threshold": 0.5,
+                "low_conf_threshold": 0.1,
+                "max_iou_cost": 0.7
+            },
+            "radar": {
+                "backend": "gazebo",
+                "enabled": true,
+                "update_rate_hz": 20,
+                "ground_filter_alt_m": 2.0,
+                "_comment": "Radar enabled — HAL ground filter at 2.0m AGL"
+            },
+            "fusion": {
+                "backend": "ukf",
+                "rate_hz": 30,
+                "depth_scale": 1.0,
+                "assumed_obstacle_height_m": 3.0,
+                "height_priors": {"unknown": 3.0, "person": 1.7, "vehicle_car": 2.0, "vehicle_truck": 3.5, "drone": 0.3, "animal": 0.8, "building": 10.0, "tree": 6.0},
+                "radar": {
+                    "enabled": true,
+                    "ground_filter_enabled": true,
+                    "min_object_altitude_m": 1.5,
+                    "altitude_gate_m": 2.0,
+                    "orphan_proximity_m": 5.0,
+                    "max_orphan_range_m": 25.0,
+                    "promotion_hits": 8,
+                    "_comment": "Camera+radar UKF fusion with ML depth from DA V2 feeding Tier 3.5."
+                }
+            }
+        }
+    },
+    "fault_sequence": {
+        "steps": []
+    },
+    "pass_criteria": {
+        "log_contains": [
+            "Path planner: DStarLitePlanner",
+            "Obstacle avoider: ObstacleAvoider3D",
+            "Depth estimator: DepthAnythingV2Estimator",
+            "backend: bytetrack",
+            "ground_filter_alt_m",
+            "TAKEOFF",
+            "Survey complete",
+            "EXECUTING",
+            "Mission complete"
+        ],
+        "log_must_not_contain": [
+            "EMERGENCY_LAND",
+            "OBSTACLE COLLISION"
+        ],
+        "processes_alive": [
+            "video_capture", "perception", "slam_vio_nav",
+            "mission_planner", "comms", "payload_manager", "system_monitor"
+        ]
+    }
+}

--- a/docs/architecture/SIMULATION_ARCHITECTURE.md
+++ b/docs/architecture/SIMULATION_ARCHITECTURE.md
@@ -1750,8 +1750,10 @@ Twenty-five pre-defined scenarios in `config/scenarios/`:
 | 24 | Gimbal Auto Track | 1 | No | Gimbal auto-tracking smoke test |
 | 25 | Flight Recorder Replay | 1 | No | 2-waypoint mission with flight recorder enabled, verifies replay |
 | 26 | Gazebo Full VIO | 2 | Yes | Short mission with full VIO pipeline on Gazebo stereo+IMU data |
+| 27 | Perception Depth Accuracy | 2 | Yes | Simulated depth + radar UKF fusion accuracy with varied-height obstacles |
+| 28 | ML Depth Estimation | 2 | Yes | Depth Anything V2 (OpenCV DNN) + color_contour + radar UKF fusion |
 
-**Counts:** 20 Tier 1 scenarios + 5 Tier 2 (Gazebo) scenarios = 25 total.
+**Counts:** 20 Tier 1 scenarios + 7 Tier 2 (Gazebo) scenarios = 27 total.
 
 ### Scenario JSON Structure
 
@@ -1813,6 +1815,8 @@ Which pluggable backends are exercised by each scenario:
 | 24 Gimbal Track | `dstar_lite` | `potential_field_3d` | `simulated` | `bytetrack` | `camera_only` |
 | 25 Flight Recorder | `dstar_lite` | `potential_field_3d` | `simulated` | `bytetrack` | `camera_only` |
 | 26 Gazebo Full VIO | `dstar_lite` | `potential_field_3d` | `simulated` | `bytetrack` | `camera_only` |
+| 27 Depth Accuracy | `dstar_lite` | `potential_field_3d` | `color_contour` | `bytetrack` | `ukf` + radar + simulated depth |
+| 28 ML Depth | `dstar_lite` | `potential_field_3d` | `color_contour` | `bytetrack` | `ukf` + radar + `depth_anything_v2` |
 
 ### Per-Scenario Fault Coverage
 
@@ -1845,6 +1849,48 @@ Which fault types and FSM states are exercised:
 | 24 Gimbal Track | None | NAVIGATE -> RTL -> LAND | — |
 | 25 Flight Recorder | None | IDLE -> TAKEOFF -> NAVIGATE -> RTL -> LAND | — |
 | 26 Gazebo Full VIO | None | IDLE -> TAKEOFF -> NAVIGATE -> RTL -> LAND | — |
+| 27 Depth Accuracy | None | IDLE -> TAKEOFF -> SURVEY -> NAVIGATE -> RTL -> LAND | — |
+| 28 ML Depth | None | IDLE -> TAKEOFF -> SURVEY -> NAVIGATE -> RTL -> LAND | — |
+
+---
+
+## Scenario Design Principles
+
+### One Capability Per Scenario
+
+Each scenario should test **one primary capability** in isolation. When a scenario fails, you should be able to identify the failing component immediately without ambiguity.
+
+| Scenario | Primary capability under test | Why isolated |
+| --- | --- | --- |
+| 02 Obstacle Avoidance | D* Lite + HD-map + potential field avoidance | Tests path planning with known obstacles. Depth estimator disabled — avoidance failures trace to planner/avoider, not depth. |
+| 18 Perception Avoidance | Camera-detected obstacle avoidance (no HD-map) | Tests perception-to-planner pipeline. Uses simulated depth — avoidance failures trace to detection/fusion, not ML model. |
+| 27 Depth Accuracy | Simulated depth + radar fusion accuracy | Tests UKF fusion with controlled depth values. Uses simulated depth (constant, predictable) — fusion failures trace to the UKF, not model inference. |
+| 28 ML Depth Estimation | Depth Anything V2 ONNX model inference | Tests the ML depth backend end-to-end. If it fails, you know the model loading, inference, or depth-to-fusion integration broke. |
+
+**Anti-pattern:** Enabling ML depth in scenario 02. If that scenario fails, is it the avoidance logic? The ML model? The grid saturation from ML depth noise? Layering multiple capabilities makes failures harder to attribute. Instead, scenario 28 validates ML depth independently.
+
+### Progressive Complexity
+
+Scenarios build on each other in a chain of increasing capability:
+
+```text
+02 (avoidance + HD-map)
+ └─ 18 (avoidance + perception, no HD-map)
+     └─ 27 (+ simulated depth + radar fusion)
+         └─ 28 (+ ML depth replacing simulated)
+```
+
+If scenario 28 fails but 27 passes, the problem is in the DA V2 backend or its config tuning — not the fusion pipeline. If 27 fails but 18 passes, the problem is in depth estimation integration — not detection or tracking.
+
+### Optional Backend Dependencies
+
+Scenarios that require optional backends (ML models, Gazebo, etc.) must degrade gracefully:
+
+- **Scenario 21 (YOLOv8):** Requires `yolov8n.onnx` model file. Without it, the test runner skips.
+- **Scenario 28 (ML Depth):** Requires `depth_anything_v2_vits.onnx` model file. Without it, the depth estimator fails to load and the backend returns errors.
+- **All Tier 2 scenarios:** Require Gazebo + PX4 SITL installed. Use `run_scenario_gazebo.sh` (not `run_scenario.sh`).
+
+When adding a new scenario with an optional dependency, document the prerequisite in the scenario JSON `_comment` field and in this table.
 
 ---
 

--- a/docs/architecture/SIMULATION_ARCHITECTURE.md
+++ b/docs/architecture/SIMULATION_ARCHITECTURE.md
@@ -16,9 +16,13 @@
 12. [Debugging Workflow](#debugging-workflow)
 13. [Fault Injection Tool](#fault-injection-tool)
 14. [Test Scenarios](#test-scenarios)
-15. [Simulation Coverage Gaps](#simulation-coverage-gaps)
-16. [Data Flow Diagram](#data-flow-diagram)
-17. [File Layout](#file-layout)
+15. [Scenario Design Principles](#scenario-design-principles)
+16. [Scenario Dependency Map](#scenario-dependency-map)
+17. [Scenario Runtime and Tuning Guide](#scenario-runtime-and-tuning-guide)
+18. [Known Flaky Scenarios](#known-flaky-scenarios)
+19. [Simulation Coverage Gaps](#simulation-coverage-gaps)
+20. [Data Flow Diagram](#data-flow-diagram)
+21. [File Layout](#file-layout)
 
 ---
 
@@ -1894,6 +1898,152 @@ When adding a new scenario with an optional dependency, document the prerequisit
 
 ---
 
+## Scenario Dependency Map
+
+Scenarios are grouped by the capability family they test. Within each family, scenarios build on each other — if a later scenario fails but an earlier one passes, the problem is in the delta between them.
+
+### Perception and Avoidance Family
+
+```text
+02 Obstacle Avoidance (HD-map + D* Lite)
+ └─ 18 Perception Avoidance (camera + radar, no HD-map)
+     └─ 27 Depth Accuracy (+ simulated depth + radar fusion)
+         └─ 28 ML Depth (+ Depth Anything V2 replacing simulated)
+```
+
+**Triage logic:** If 28 fails but 27 passes → DA V2 model or config tuning. If 27 fails but 18 passes → depth estimation or UKF integration. If 18 fails but 02 passes → color_contour detection or radar fusion. If 02 fails → path planner or avoidance core.
+
+### Detection Backend Family
+
+```text
+09 Perception Tracking (simulated detector + ByteTrack)
+ └─ 02 Obstacle Avoidance (color_contour detector)
+     └─ 21 YOLOv8 Detection (yolov8 detector, ONNX model)
+```
+
+**Triage logic:** If 21 fails but 02 passes → YOLO model loading or OpenCV DNN inference. If 02 fails but 09 passes → color_contour detector or Gazebo rendering.
+
+### Fault Handling Family
+
+```text
+04 FC Link Loss (basic loss → LOITER → RTL)
+ └─ 15 FC Quick Recovery (loss → quick reconnect before RTL)
+     └─ 08 Full Stack Stress (concurrent faults: battery + thermal + FC)
+```
+
+### GCS Command Family
+
+```text
+10 GCS Pause/Resume (LOITER ↔ NAVIGATE)
+11 GCS Abort (→ RTL)
+12 GCS RTL (direct RTL command)
+13 GCS Land (land at current position)
+06 Mission Upload (mid-flight waypoint change)
+```
+
+These are independent — each tests a single GCS command path. No dependency chain.
+
+### Sensor Pipeline Family
+
+```text
+17 Radar Gazebo (radar HAL + UKF fusion)
+20 Radar Degraded (camera dropout, radar primary)
+26 Gazebo Full VIO (stereo + IMU → VIO pipeline)
+16 VIO Failure (VIO quality degradation)
+```
+
+---
+
+## Scenario Runtime and Tuning Guide
+
+### Expected Runtime
+
+Times include process startup, mission execution, and verification. Tier 2 adds ~15-20s for Gazebo + PX4 SITL launch.
+
+| Scenario | Tier | Timeout | Typical Runtime | Notes |
+| --- | --- | --- | --- | --- |
+| 01 Nominal | 1 | 90s | ~30s | Baseline — fastest mission |
+| 02 Obstacles | 2 | 150s | ~120s | D* Lite replanning adds latency |
+| 03 Battery | 1 | 80s | ~40s | Fault injection at fixed delays |
+| 04 FC Link | 1 | 60s | ~25s | Short: loss + timeout + RTL |
+| 05 Geofence | 1 | 60s | ~25s | Short: breach + RTL |
+| 06 Upload | 1 | 120s | ~50s | Mid-flight waypoint swap |
+| 07 Thermal | 1 | 90s | ~45s | Zone escalation ramp |
+| 08 Stress | 1 | 180s | ~90s | Longest Tier 1 — concurrent faults |
+| 09 Tracking | 1 | 90s | ~35s | ByteTrack association test |
+| 10-13 GCS | 1 | 90-120s | ~30-40s | Single GCS command each |
+| 14 Alt Ceiling | 1 | 60s | ~25s | Quick breach + RTL |
+| 15 FC Recover | 1 | 120s | ~50s | Loss + reconnect before timeout |
+| 16 VIO Failure | 1 | 60s | ~25s | Quality drop + LOITER |
+| 17 Radar | 2 | 150s | ~100s | Radar fusion validation |
+| 18 Perc. Avoid | 2 | 160s | ~130s | Full perception pipeline |
+| 19 Collision | 1 | 120s | ~45s | Post-collision recovery |
+| 20 Radar Deg. | 1 | 30s | ~15s | Shortest — camera dropout |
+| 21 YOLOv8 | 2 | 160s | ~130s | Requires ONNX model download |
+| 23 Dyn. Predict | 1 | 90s | ~35s | Occupancy grid prediction |
+| 24 Gimbal | 1 | 90s | ~30s | Auto-track smoke test |
+| 25 Recorder | 1 | 60s | ~25s | Flight recorder + replay |
+| 26 Full VIO | 2 | 50s | ~40s | Short Gazebo VIO validation |
+| 27 Depth Acc. | 2 | 160s | ~130s | Simulated depth + radar fusion |
+| 28 ML Depth | 2 | 240s | ~180s | Slowest — DA V2 CPU inference ~1.7s/frame |
+
+**Batch runtimes:**
+
+- All Tier 1 (20 scenarios): ~12 minutes sequential, ~4 minutes with `run_scenario.sh --all -j4`
+- All Tier 2 (7 scenarios): ~14 minutes sequential (Gazebo startup overhead per run)
+- Full suite: ~26 minutes sequential
+
+> **Note:** Scenario 22 was never created — the numbering gap is intentional (a planned scenario was descoped). Do not renumber existing scenarios; config paths and log directories use the number as a stable identifier.
+
+### Tuning Guide — Common Failures and Knobs
+
+When a scenario fails, diagnose from the logs before changing config. The table below maps symptoms to the most likely knob.
+
+| Symptom | Log pattern to look for | Likely cause | Config knob | Typical fix |
+| --- | --- | --- | --- | --- |
+| Drone stuck, no path found | `No path: g(start)=1000000000` | Occupancy grid saturated with static cells | `occupancy_grid.promotion_hits` | Increase from 8 to 12-16 |
+| Drone stuck, no path found | `occupied=N` where N > 400 | Too many promoted cells blocking the grid | `occupancy_grid.max_static_cells` | Increase cap, or enable `require_radar_for_promotion` |
+| Path keeps getting rejected | `Rejecting backward path (dot=...)` | Planner finds paths away from goal | `path_planner.max_search_time_ms` | Increase to give D* Lite more time |
+| Scenario times out | `Mission complete` missing from logs | Drone too slow or avoidance adds detours | `timeout_s`, `cruise_speed_mps` | Increase timeout or speed |
+| False obstacle detections | `[Grid] N objs (accepted=N, suppressed=...)` with high N | Detector sees ground/sky as obstacles | `detector.confidence_threshold` | Increase from 0.3 to 0.5 |
+| Ghost static cells | `promoted=N` growing unbounded | Depth estimator returns depth for non-obstacle pixels | `occupancy_grid.min_promotion_depth_confidence` | Increase from 0.8 to 0.85-0.9 |
+| EMERGENCY_LAND triggered | `FAULT_BATTERY_CRITICAL` or `FAULT_POSE_STALE` | Battery drains or VIO goes stale | `fault_manager.*_percent`, VIO pipeline | Check if sim is running too slowly |
+| ML model not loaded | `model not loaded` or `Failed to load model` | ONNX file missing or incompatible | `depth_estimator.model_path` | Run `bash models/download_depth_anything_v2.sh` |
+| Occupancy grid bloated at start | `hd_map=N` with high N on first Grid line | HD-map static obstacles use too many cells | `static_obstacles[].radius` | Reduce obstacle radii or `occupancy_grid.inflation_radius_m` |
+
+**Diagnostic commands:**
+
+```bash
+# Check grid saturation in a scenario log
+grep '\[Grid\]' drone_logs/scenarios_gazebo/<scenario>/<run>/mission_planner.log | tail -10
+
+# Check path planner status
+grep -E 'No path|Path OK|extraction FAILED' drone_logs/scenarios_gazebo/<scenario>/<run>/mission_planner.log | tail -20
+
+# Check promoted cell growth over time
+grep '\[Grid\]' <log> | grep -oP 'promoted=\d+' | sort -t= -k2 -n | uniq
+
+# Check what depth backend was active
+grep -i 'depth estimator' drone_logs/scenarios_gazebo/<scenario>/<run>/perception.log
+```
+
+---
+
+## Known Flaky Scenarios
+
+Scenarios that may intermittently fail due to timing sensitivity, physics jitter, or non-deterministic behavior. If a scenario listed here fails once, re-run it before investigating.
+
+| Scenario | Flakiness | Root cause | Mitigation |
+| --- | --- | --- | --- |
+| 02 Obstacle Avoidance | ~10% failure rate on return leg | False cell promotion blocks return path. color_contour detects ground texture during low-altitude passes, radar confirms range, cells get promoted. The final waypoint (home) is often surrounded by these ghost cells. | Increase `promotion_hits` or enable `require_radar_for_promotion`. See Fix #51 for the ML depth variant of this issue. |
+| 18 Perception Avoidance | Occasional SLAM pose stale | Gazebo rendering hiccup causes VIO to lose tracking for >500ms. Transient — next frame recovers. | Re-run. If persistent, check GPU load (`nvidia-smi`) — Gazebo rendering competes with OpenCV DNN inference on the GPU. |
+| 26 Gazebo Full VIO | Tight timeout (50s) | VIO initialization on Gazebo stereo data takes variable time (5-15s). If Gazebo is slow to render the first frames, the mission may not complete in 50s. | Increase `timeout_s` to 70s if consistently failing. |
+| 28 ML Depth | Grid saturation on slow machines | DA V2 inference takes ~1.7s/frame on CPU. On slower machines, fewer depth maps are produced, making promotion thresholds behave differently. | Increase `timeout_s` or reduce `input_size` to 256 (faster inference, lower accuracy). |
+
+> **Non-flaky scenarios:** Tier 1 scenarios (01-16, 19-20, 23-25) are deterministic — simulated backends produce identical results every run. If a Tier 1 scenario fails, it's a real bug.
+
+---
+
 ## Simulation Coverage Gaps
 
 The following code paths are **not exercised** by any scenario and rely solely on
@@ -1901,28 +2051,31 @@ unit tests for validation. This section is maintained to guide future scenario d
 
 ### Backends Never Tested in Scenarios
 
-| Backend  | Type     | Unit Tests | Why Not Covered                                        |
-|----------|----------|------------|--------------------------------------------------------|
-| `yolov8` | Detector | 24 tests   | Requires ONNX model + OpenCV; add to a Tier 2 scenario |
+All pluggable backends are now exercised by at least one scenario:
 
-> **Previously untested (now resolved):** `ukf` fusion engine is now exercised by scenario 17
-> (Radar Gazebo) which enables radar fusion with `GazeboRadarBackend`. See Issue #210 / #212.
+| Backend | Type | Scenario | Status |
+| --- | --- | --- | --- |
+| `yolov8` | Detector | 21 YOLOv8 Detection | Covered (requires ONNX model) |
+| `depth_anything_v2` | Depth estimator | 28 ML Depth | Covered (requires ONNX model) |
+| `ukf` | Fusion | 17, 18, 27, 28 | Covered |
+| `color_contour` | Detector | 02, 18, 27, 28 | Covered |
+| `bytetrack` | Tracker | All scenarios | Covered (sole tracker backend) |
+| `dstar_lite` | Path planner | All scenarios | Covered (sole planner backend) |
+| `potential_field_3d` | Obstacle avoider | All scenarios | Covered (sole avoider backend) |
+| `gazebo` (camera) | Camera HAL | All Tier 2 | Covered |
+| `gazebo` (IMU) | IMU HAL | 26 Full VIO | Covered |
+| `gazebo` (radar) | Radar HAL | 17, 18, 27, 28 | Covered |
+
+> **History:** `ukf` was untested until scenario 17 (Issue #210). `yolov8` was untested until scenario 21. `depth_anything_v2` was untested until scenario 28 (Issue #455). `SORT` tracker and `potential_field` 2D planner/avoider were removed — superseded by `bytetrack` and `dstar_lite`/`potential_field_3d` respectively.
 
 ### Backend Coverage Recommendations
 
-Per the "maximise stack coverage in simulation" principle, most scenarios should
-exercise the same backends that would run on real hardware:
+Per the "maximise stack coverage in simulation" principle, all 27 scenarios exercise the same core backends that run on real hardware:
 
-- **Tracker**: All 16 scenarios now use ByteTrack (default changed from SORT in
-  Issue #205). SORT was removed — ByteTrack strictly supersedes it with two-stage
-  association for better occlusion handling.
-- **Path planner**: All 16 scenarios now use D* Lite (default changed from
-  `potential_field` in Issue #207). PotentialFieldPlanner was removed — D* Lite
-  strictly supersedes it with 3D grid search and obstacle awareness.
-- **Obstacle avoider**: All 16 scenarios now use `potential_field_3d` (default
-  changed from `potential_field` in Issue #207). PotentialFieldAvoider (2D) was
-  removed — ObstacleAvoider3D strictly supersedes it with full 3D repulsion and
-  velocity prediction.
+- **Tracker**: All scenarios use ByteTrack (sole tracker since Issue #205).
+- **Path planner**: All scenarios use D* Lite (sole planner since Issue #207).
+- **Obstacle avoider**: All scenarios use ObstacleAvoider3D (sole avoider since Issue #207).
+- **Fusion**: Scenarios 17, 18, 27, 28 use UKF with radar. Remaining scenarios use camera-only fusion.
 
 ### Fault Types Never Triggered
 
@@ -1950,7 +2103,7 @@ exercise the same backends that would run on real hardware:
 
 ### Tier 2 Limitations
 
-Only **scenarios 02, 17, 18, 21, and 26** run on Gazebo SITL. The following fault
+**Scenarios 02, 17, 18, 21, 26, 27, and 28** run on Gazebo SITL (7 total). The following fault
 scenarios would benefit from Gazebo validation but are currently Tier 1 only:
 
 - Battery degradation (03) — PX4 has its own battery model; Tier 1 uses injected values
@@ -1967,10 +2120,9 @@ which parameters can be adjusted for manual testing:
 - **Thresholds**: Adjust `fault_manager.*_percent` values
 - **Fault timing**: Change `delay_s` in `fault_sequence.steps`
 - **Geofence polygon**: Modify vertices in `geofence.polygon`
-- **Backend selection**: Switch `path_planner.backend` between
-  `"potential_field"` and `"dstar_lite"`
-- **Obstacle avoider backend**: `"potential_field"` or
-  `"potential_field_3d"` (3D variant — used by scenarios 01, 02, 08, 09)
+- **Backend selection**: `path_planner.backend` is `dstar_lite` (sole planner)
+- **Obstacle avoider backend**: `potential_field_3d` (sole avoider)
+- **Depth estimator**: Enable with `perception.depth_estimator.enabled=true` and set `backend` to `simulated` or `depth_anything_v2`
 - **IPC transport**: Zenoh (sole backend, configured via `config/default.json`)
 
 ---

--- a/docs/architecture/SIMULATION_ARCHITECTURE.md
+++ b/docs/architecture/SIMULATION_ARCHITECTURE.md
@@ -207,7 +207,7 @@ flowchart TB
 
 ### When to Use Each Tier
 
-- **Tier 1**: Run on every commit in CI. Fast, deterministic, no external
+- **Tier 1**: Run on every commit in CI. Fast, reproducible, no external
   dependencies. Validates fault handling, FSM transitions, IPC flow, and
   config parsing. Use the `fault_injector` to simulate faults.
 
@@ -2031,7 +2031,7 @@ grep -i 'depth estimator' drone_logs/scenarios_gazebo/<scenario>/<run>/perceptio
 
 ## Known Flaky Scenarios
 
-Scenarios that may intermittently fail due to timing sensitivity, physics jitter, or non-deterministic behavior. If a scenario listed here fails once, re-run it before investigating.
+Scenarios that may intermittently fail due to timing sensitivity, physics jitter, or non-reproducible behavior. If a scenario listed here fails once, re-run it before investigating.
 
 | Scenario | Flakiness | Root cause | Mitigation |
 | --- | --- | --- | --- |
@@ -2040,7 +2040,7 @@ Scenarios that may intermittently fail due to timing sensitivity, physics jitter
 | 26 Gazebo Full VIO | Tight timeout (50s) | VIO initialization on Gazebo stereo data takes variable time (5-15s). If Gazebo is slow to render the first frames, the mission may not complete in 50s. | Increase `timeout_s` to 70s if consistently failing. |
 | 28 ML Depth | Grid saturation on slow machines | DA V2 inference takes ~1.7s/frame on CPU. On slower machines, fewer depth maps are produced, making promotion thresholds behave differently. | Increase `timeout_s` or reduce `input_size` to 256 (faster inference, lower accuracy). |
 
-> **Non-flaky scenarios:** Tier 1 scenarios (01-16, 19-20, 23-25) are deterministic — simulated backends produce identical results every run. If a Tier 1 scenario fails, it's a real bug.
+> **Non-flaky scenarios:** Tier 1 scenarios (01-16, 19-20, 23-25) are reproducible — simulated backends return fixed, predictable values and fault injection fires at exact delay offsets, so the FSM follows the same path every run. Thread scheduling and IPC latency vary by microseconds between runs, but the pass/fail outcome is consistent because thresholds have generous margins. If a Tier 1 scenario fails, it's a real bug — not a timing fluke.
 
 ---
 

--- a/docs/architecture/SIMULATION_ARCHITECTURE.md
+++ b/docs/architecture/SIMULATION_ARCHITECTURE.md
@@ -1725,7 +1725,7 @@ a zero-initialized struct would activate every override at its most dangerous va
 
 ## Test Scenarios
 
-Twenty-five pre-defined scenarios in `config/scenarios/`:
+Twenty-seven pre-defined scenarios in `config/scenarios/`:
 
 | # | Scenario | Tier | Gazebo | What it Tests |
 |---|---|---|---|---|

--- a/docs/guides/DESIGN_RATIONALE.md
+++ b/docs/guides/DESIGN_RATIONALE.md
@@ -359,3 +359,26 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 **When to revisit:** When migrating to TensorRT for Jetson Orin deployment (TensorRT supports full ONNX natively). Also revisit if OpenCV 5.x adds full Resize op support.
 
 **Date:** 2026-04-14
+
+---
+
+## DR-015: OpenCV INTERFACE Link in drone_hal CMake
+
+**Question:** Should we split OpenCV-dependent HAL backends into a separate `drone_hal_opencv` static library to prevent `${OpenCV_LIBS}` from leaking via INTERFACE link to all `drone_hal` consumers?
+
+**Background:** PR #456 review flagged that `target_link_libraries(drone_hal INTERFACE ${OpenCV_LIBS})` makes OpenCV a transitive dependency for every target that links `drone_hal` — including tests and processes that don't use OpenCV.
+
+**Arguments for splitting now:**
+- Cleaner dependency graph — only P2 and OpenCV-specific tests link OpenCV
+- Smaller link lines for non-perception targets
+- Matches the pattern suggested for Cosys-AirSim (see `common/hal/CMakeLists.txt` comment)
+
+**Arguments for deferring (our decision):**
+- Currently only two OpenCV HAL backends exist (YOLO detector, DA V2 depth). The link leak is benign — OpenCV is a shared library, so unused symbols aren't linked in
+- Splitting requires refactoring all consumers to explicitly link `drone_hal_opencv` — touches 5+ CMakeLists.txt files for zero functional benefit today
+- The Cosys-AirSim block already documents this same pattern with the same deferral rationale ("migrate to STATIC when real SDK code is added")
+- YOLO detector sources are already compiled per-target (not via INTERFACE), so the actual compile-time leak is minimal
+
+**When to revisit:** When a third OpenCV HAL backend is added, or when the Cosys-AirSim migration to STATIC happens — do both splits together.
+
+**Date:** 2026-04-14

--- a/docs/guides/DESIGN_RATIONALE.md
+++ b/docs/guides/DESIGN_RATIONALE.md
@@ -326,3 +326,36 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 **When to revisit:** When any real target enables `ENABLE_PLUGINS=ON` and targets a platform with separate libdl (cross-compilation, musl, older glibc).
 
 **Date:** 2026-04-13
+
+---
+
+## DR-014: ONNX Graph Surgery for Depth Anything V2 + OpenCV DNN Compatibility
+
+**Question:** How should we handle the incompatibility between the Depth Anything V2 ONNX export and OpenCV DNN's Resize layer?
+
+**Background:** DA V2's DINOv2 backbone uses bicubic interpolation and produces ONNX Resize nodes with 4 inputs (X, roi, scales, sizes) per the ONNX spec. OpenCV DNN (tested on 4.6.0 and 4.10.0) only supports Resize nodes with 1-2 inputs and bilinear/nearest interpolation. This is a fundamental limitation — not a version gap we can upgrade past easily.
+
+**Arguments for using ONNX Runtime instead of OpenCV DNN:**
+- ORT supports the full ONNX spec natively — no graph surgery needed
+- Better long-term compatibility as models evolve
+- GPU acceleration via CUDA/TensorRT providers
+
+**Arguments for keeping OpenCV DNN (our decision):**
+- OpenCV is already a project dependency (used for detection, image processing) — no new dependency
+- ONNX Runtime adds ~200MB to deployment image, plus CUDA runtime for GPU
+- For our target (Jetson Orin), TensorRT is the production inference path — ORT would be a temporary stopgap anyway
+- The graph surgery is deterministic and well-understood: replace dynamic-size Resize with precomputed fixed-scale Resize for a known input size (518x518)
+- CPU inference at ~1s/frame is acceptable for our 15fps depth budget (we subsample)
+
+**The fix:** Three-step ONNX post-processing in `models/download_depth_anything_v2.sh`:
+1. Export with `torch.onnx.export(dynamo=False, opset_version=14)` + monkey-patch `F.interpolate` to replace bicubic→bilinear
+2. Run `onnxsim` to simplify the graph (folds constants, removes Shape/Gather/Cast nodes)
+3. ONNX graph surgery: trace Resize input/output shapes via ORT, compute scale factors, replace 4-input Resize(X, roi, scales, sizes) with 3-input Resize(X, roi, scales) using constant scale tensors
+
+**Limitations:**
+- Scales are baked in for 518x518 input. Changing `input_size` in config requires re-running the export script.
+- Bilinear interpolation in the patch embedding (instead of bicubic) may slightly affect depth accuracy — not measured, but the model still produces valid relative depth maps.
+
+**When to revisit:** When migrating to TensorRT for Jetson Orin deployment (TensorRT supports full ONNX natively). Also revisit if OpenCV 5.x adds full Resize op support.
+
+**Date:** 2026-04-14

--- a/docs/guides/DESIGN_RATIONALE.md
+++ b/docs/guides/DESIGN_RATIONALE.md
@@ -333,7 +333,7 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 
 **Question:** How should we handle the incompatibility between the Depth Anything V2 ONNX export and OpenCV DNN's Resize layer?
 
-**Background:** DA V2's DINOv2 backbone uses bicubic interpolation and produces ONNX Resize nodes with 4 inputs (X, roi, scales, sizes) per the ONNX spec. OpenCV DNN (tested on 4.6.0 and 4.10.0) only supports Resize nodes with 1-2 inputs and bilinear/nearest interpolation. This is a fundamental limitation — not a version gap we can upgrade past easily.
+**Background:** DA V2's DINOv2 backbone uses bicubic interpolation and produces ONNX Resize nodes with 4 inputs (X, roi, scales, sizes) per the ONNX spec. OpenCV DNN (tested on 4.6.0 and 4.10.0) fails to load the 4-input `Resize(X, roi, scales, sizes)` form. Our workaround rewrites these to the 3-input `Resize(X, roi, scales)` form with precomputed constant scales, which OpenCV DNN accepts. It also does not support bicubic interpolation mode. This is a fundamental limitation — not a version gap we can upgrade past easily.
 
 **Arguments for using ONNX Runtime instead of OpenCV DNN:**
 - ORT supports the full ONNX spec natively — no graph surgery needed
@@ -344,8 +344,8 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 - OpenCV is already a project dependency (used for detection, image processing) — no new dependency
 - ONNX Runtime adds ~200MB to deployment image, plus CUDA runtime for GPU
 - For our target (Jetson Orin), TensorRT is the production inference path — ORT would be a temporary stopgap anyway
-- The graph surgery is deterministic and well-understood: replace dynamic-size Resize with precomputed fixed-scale Resize for a known input size (518x518)
-- CPU inference at ~1s/frame is acceptable for our 15fps depth budget (we subsample)
+- The graph surgery is deterministic and well-understood: replace 4-input Resize(X, roi, scales, sizes) with 3-input Resize(X, roi, scales) using precomputed constant scale tensors for a known input size (518x518)
+- CPU inference at ~1s/frame on i7 laptop (single-threaded) is acceptable — the depth thread runs independently and the fusion engine consumes whatever rate is available. On Jetson Orin with GPU, TensorRT will be the production path
 
 **The fix:** Three-step ONNX post-processing in `models/download_depth_anything_v2.sh`:
 1. Export with `torch.onnx.export(dynamo=False, opset_version=14)` + monkey-patch `F.interpolate` to replace bicubic→bilinear

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -5,6 +5,9 @@ Tracking all bug fixes applied to the Drone Companion Software Stack.
 > **⚠️ IMPORTANT:** The "Fix #X" numbers (e.g., "Fix #1", "Fix #46") in this document are **sequential identifiers for this file only** and do **NOT** correspond to GitHub issue numbers. For the actual GitHub issue, see the **(Issue #Y)** reference in each fix title or use the `Found by:` / `Related to:` fields.
 
 Sections:
+
+- [Writing a Bug Fix Entry](#writing-a-bug-fix-entry)
+- [ONNX and OpenCV DNN Troubleshooting](#onnx-and-opencv-dnn-troubleshooting)
 - [IPC / Transport](#ipc--transport)
 - [Perception (Process 2)](#perception-process-2)
 - [SLAM / VIO (Process 3)](#slam--vio-process-3)
@@ -14,6 +17,90 @@ Sections:
 - [Simulation (Gazebo SITL)](#simulation-gazebo-sitl)
 - [CI / Tooling](#ci--tooling)
 - [Open Bugs](#open-bugs)
+
+---
+
+## Writing a Bug Fix Entry
+
+Copy this template when adding a new fix. Every section is mandatory — a fix entry that someone else can't reproduce or learn from is just a changelog line.
+
+```markdown
+### Fix #XX — <Short title describing the symptom> (#<GitHub issue>)
+
+**Date:** YYYY-MM-DD
+**Severity:** Critical / Blocker / High / Medium / Low
+**Files:** `path/to/changed_file.cpp`, `path/to/another.h`
+
+**What:** One paragraph. What broke, what the user/test/CI observed, and what the
+expected behavior should have been. Be specific — "tests fail" is not enough;
+"6 model-dependent tests GTEST_SKIP with 'model not loaded'" is.
+
+**Error messages (searchable):**
+Paste the exact error strings. People search for these.
+- `error: (-215:Assertion failed) inputs.size() == 1 ...`
+- `FATAL: No path: g(start)=1000000000`
+
+**Reproduce:**
+Numbered steps someone can follow to trigger the bug from a clean checkout.
+1. `git checkout <commit-before-fix>`
+2. `bash deploy/build.sh`
+3. `./build/bin/<test>` — observe: <exact symptom>
+
+**Why (Root Cause):**
+What actually went wrong in the code/data/environment. Not "it was broken" — explain
+the mechanism. If there are multiple layered causes, number them.
+
+**How (Fix):**
+What you changed and why each change was necessary. Separate the investigation
+narrative from the actual changeset:
+
+*Investigation:*
+What you tried, what failed, what you learned along the way.
+
+*Changeset:*
+- `file_a.cpp` — <what changed and why>
+- `file_b.json` — <what changed and why>
+
+**Diagnostic commands:**
+Copy-pasteable commands someone can use to diagnose the same class of issue.
+```bash
+# Example: check ONNX Resize node input counts
+python3 -c "import onnx; ..."
+```
+
+**Tools used:**
+- **Tool name** — What it did, why it was the right tool for this step.
+
+**Limitations / Known issues:**
+Anything that's still not perfect after the fix.
+
+**Found by:** How the bug was discovered (test name, CI run, Gazebo scenario, manual testing).
+
+**Regression test:** What test(s) now guard against this bug recurring.
+```
+
+### Key principles
+
+1. **Searchable error messages.** People Google error strings. Include them verbatim.
+2. **Reproducible steps.** If someone can't trigger the bug, they can't verify the fix.
+3. **Separate investigation from changeset.** The investigation teaches debugging skills; the changeset is what to review. Different audiences need different sections.
+4. **Diagnostic commands.** Copy-pasteable. Not "use GDB" — show the actual GDB commands.
+5. **Tools with purpose.** Not just "used onnxsim" — explain *what it did* and *why it was the right choice* for that step.
+6. **Limitations.** Be honest about what's still imperfect. The next person will find out anyway.
+
+---
+
+## ONNX and OpenCV DNN Troubleshooting
+
+Common issues when deploying ONNX models with OpenCV DNN in this project. If you're adding a new ML model backend, run through this checklist before filing a bug.
+
+- [ ] **Opset version:** `python3 -c "import onnx; print(onnx.load('model.onnx').opset_import)"` — use opset ≤14 for OpenCV DNN 4.6–4.10
+- [ ] **Self-contained model:** No `.onnx.data` external weight files. If present, inline with: `m = onnx.load('model.onnx', load_external_data=True); onnx.save(m, 'model_inline.onnx')`
+- [ ] **Resize node inputs:** `python3 -c "import onnx; m=onnx.load('model.onnx'); [print(n.name, len(n.input)) for n in m.graph.node if n.op_type=='Resize']"` — OpenCV DNN requires ≤2 inputs (3 with empty roi). Run `onnxsim` first; if still >2, use graph surgery (see Fix #51 and `models/download_depth_anything_v2.sh`)
+- [ ] **Interpolation modes:** Only `nearest` and `bilinear` supported. If model uses `bicubic`/`cubic`, monkey-patch during export (see Fix #51)
+- [ ] **OpenCV DNN load test:** `python3 -c "import cv2; cv2.dnn.readNetFromONNX('model.onnx'); print('OK')"` — if Python cv2 is unavailable, build and run: `cv::dnn::readNetFromONNX("model.onnx")` in a test binary
+- [ ] **Inference test:** Create a random input blob, run `net.forward()`, verify output shape matches expected. ONNX Runtime (`onnxruntime`) is a good reference: `sess.run(None, {'input': np.random.randn(1,3,H,W).astype(np.float32)})`
+- [ ] **Unsupported ops:** Check OpenCV DNN's supported op list. Common failures: `Tile`, `NonZero`, `ScatterND`, `GatherElements`. Run `onnxsim` to see if they can be folded away.
 
 ---
 
@@ -538,6 +625,124 @@ else
 **Impact:** Radar tracks reduced further (best: 8 for 4 obstacles). Avoider max correction dropped from 1.51 → 0.33 m/s (planner handles avoidance). No collision risks across all test runs.
 
 **Found by:** Gazebo scenario testing — comparing single-circle vs double-circle survey coverage and obstacle proximity metrics.
+
+---
+
+### Fix #51 — Depth Anything V2 ONNX Model Incompatible with OpenCV DNN (#455)
+
+**Date:** 2026-04-14
+**Severity:** Blocker (ML depth backend completely non-functional)
+**Files:** `models/download_depth_anything_v2.sh`, `common/hal/src/depth_anything_v2.cpp`, `config/scenarios/28_ml_depth_estimation.json`
+
+**What:** The Depth Anything V2 ViT-S ONNX model could not be loaded by OpenCV DNN. Three separate compatibility issues surfaced sequentially during model export and loading, each blocking the next step. Additionally, the first successful Gazebo run (scenario 28) failed 19/20 — the drone could not find a path to the final waypoint because the ML depth backend caused occupancy grid saturation with 331 promoted static cells.
+
+**Error messages (searchable):**
+
+- `OpenCV(4.10.0) resize_layer.cpp:58: error: (-215:Assertion failed) inputs.size() == 1 || inputs.size() == 2 in function 'getMemoryShapes'`
+- `interpolation == "nearest" || interpolation == "opencv_linear" || interpolation == "bilinear"`
+- `Node [Resize@ai.onnx]:(onnx_node!/backbone/embeddings/Resize) parse error`
+- `D*Lite No path: start=(16,5,2) goal=(3,2,2) g(start)=1000000000 queue=0 occupied=52`
+- `[Grid] 7 objs (accepted=7, suppressed=5, excluded_cells=0), 67 dynamic, 331 static (promoted=331, hd_map=0, max=800, predictions=0)`
+
+**Reproduce:**
+
+1. `git checkout 1ec8668` (commit with DA V2 backend before model fix)
+2. `pip install torch transformers onnx` and export the model naively:
+   ```bash
+   python3 -c "
+   from transformers import AutoModelForDepthEstimation; import torch
+   m = AutoModelForDepthEstimation.from_pretrained('depth-anything/Depth-Anything-V2-Small-hf')
+   torch.onnx.export(m, {'pixel_values': torch.randn(1,3,518,518)}, 'model.onnx', opset_version=14, dynamo=False)
+   "
+   ```
+3. `bash deploy/build.sh && ./build/bin/test_depth_anything_v2` — observe: 6 model-dependent tests fail with `model not loaded`
+4. For the grid saturation bug: run scenario 28 with `promotion_hits=8` and `timeout_s=180` — observe: drone reaches WP 4/5 then cannot find a path to WP 5
+
+**Why (Root Causes):**
+
+1. **No pre-exported ONNX available.** HuggingFace hosts DA V2 as PyTorch safetensors only — no ONNX artifact exists. The download script assumed a direct download but needed a full torch-to-ONNX export pipeline.
+
+2. **Bicubic Resize unsupported by OpenCV DNN.** DA V2's DINOv2 backbone uses `F.interpolate(mode='bicubic')` for patch embedding resize. PyTorch faithfully exports this as an ONNX Resize node with `mode=cubic`. OpenCV DNN (4.6.0-4.10.0) only supports `nearest` and `bilinear` Resize modes — it rejects `cubic` at model parse time.
+
+3. **4-input ONNX Resize node format.** Even after fixing the interpolation mode, OpenCV DNN fails at the `inputs.size()` assertion. The ONNX standard Resize op has 4 inputs: `(X, roi, scales, sizes)`. PyTorch's TorchScript exporter faithfully produces this 4-input format. OpenCV DNN's `ResizeLayer::getMemoryShapes()` only handles 1-input (deprecated opset-10 format) or 2-input (X + scales). This is a fundamental limitation in OpenCV's ONNX import layer, not a version-specific bug.
+
+4. **ML depth causes occupancy grid saturation in Gazebo.** Unlike the simulated depth estimator (which returns constant values), DA V2 produces real depth values for everything in the scene — ground texture, distant geometry, sky gradients. Combined with radar, this promoted far more cells to static status (331 vs ~50 for simulated), eventually blocking all paths to the final waypoint.
+
+**How (Fix):**
+
+*Investigation (what we tried and what failed):*
+
+| Attempt | Approach | Result | Lesson |
+|---------|----------|--------|--------|
+| 1 | `hf_hub_download(filename='onnx/model.onnx')` | 404 — file doesn't exist on HuggingFace | HF only has safetensors for this model |
+| 2 | `torch.onnx.export(dynamo=True)` at opset 18 | Segfault in OpenCV DNN | Opset 18 too new; external `.onnx.data` weights also problematic |
+| 3 | `torch.onnx.export(dynamo=False)` at opset 14 | `mode=cubic` rejected | DINOv2 uses bicubic interpolation |
+| 4 | Monkey-patch `F.interpolate` bicubic→bilinear during export | `inputs.size() == 1 \|\| inputs.size() == 2` assertion | Resize node format incompatible |
+| 5 | `onnxsim` to simplify Resize nodes | Still 4-input Resize (sizes are dynamic via Concat) | Simplifier can't fold dynamic shapes |
+| 6 | ONNX graph surgery: replace 4-input Resize with 3-input using precomputed scales | Model loads and runs in OpenCV DNN | Final solution |
+| 7 | First Gazebo run with default promotion thresholds | 19/20 — drone stuck on WP 5, 331 static cells | ML depth too aggressive for default thresholds |
+
+*Changeset:*
+
+- `models/download_depth_anything_v2.sh` — Replaced naive HF download with 4-step pipeline: (1) torch export with bilinear monkey-patch, (2) onnxsim simplification, (3) ONNX graph surgery to convert 4-input Resize to 3-input with precomputed fixed scales, (4) validation via ONNX Runtime
+- `config/scenarios/28_ml_depth_estimation.json` — Tuned `promotion_hits` 8→12 and `min_promotion_depth_confidence` 0.8→0.85 to prevent grid saturation from ML depth noise; increased `timeout_s` 180→240 and `cruise_speed_mps` 1.5→2.0 for the slower ML inference cadence
+
+**Diagnostic commands:**
+
+```bash
+# Check ONNX opset version
+python3 -c "import onnx; print(onnx.load('model.onnx').opset_import)"
+
+# List all Resize nodes and their input counts
+python3 -c "
+import onnx; m = onnx.load('model.onnx')
+for n in m.graph.node:
+    if n.op_type == 'Resize':
+        print(f'{n.name}: {len(n.input)} inputs, names={list(n.input)}')
+"
+
+# Check interpolation modes on Resize nodes
+python3 -c "
+import onnx; m = onnx.load('model.onnx')
+for n in m.graph.node:
+    if n.op_type == 'Resize':
+        for a in n.attribute:
+            if a.name == 'mode': print(f'{n.name}: mode={a.s.decode()}')
+"
+
+# Test if OpenCV DNN can load the model
+python3 -c "import cv2; cv2.dnn.readNetFromONNX('model.onnx'); print('OK')"
+
+# Verify model output shape with ONNX Runtime (reference engine)
+python3 -c "
+import onnxruntime as ort, numpy as np
+s = ort.InferenceSession('model.onnx')
+out = s.run(None, {'pixel_values': np.random.randn(1,3,518,518).astype(np.float32)})
+print(f'Output shape: {out[0].shape}, range: [{out[0].min():.3f}, {out[0].max():.3f}]')
+"
+
+# Check occupancy grid saturation in Gazebo logs
+grep '\[Grid\]' drone_logs/scenarios_gazebo/*/mission_planner.log | tail -5
+grep 'No path' drone_logs/scenarios_gazebo/*/mission_planner.log | tail -5
+```
+
+**Tools used:**
+
+- **PyTorch + HuggingFace Transformers** — Model loading (`AutoModelForDepthEstimation.from_pretrained`) and ONNX export via `torch.onnx.export`. Used legacy TorchScript exporter (`dynamo=False`) at opset 14 because Dynamo (default in PyTorch 2.11) produced opset 18 with external weights and unsupported ops.
+- **onnx-simplifier (`onnxsim`)** — Graph-level constant folding. Reduced node count from 1593 to 806 (removed all 56 Shape nodes, 50 Gather nodes, 76 Unsqueeze nodes, 7 Cast nodes). Could not fix the Resize input count because the size inputs are dynamically computed via Concat nodes, not constants.
+- **ONNX Runtime (`onnxruntime`)** — Reference execution engine used in three ways: (a) verified model produces correct output shape `[1, 518, 518]` before and after surgery, (b) traced intermediate tensor shapes at each Resize node by temporarily adding extra model outputs and running inference, (c) validated output equivalence between original and surgically modified models.
+- **ONNX Python library (`onnx`)** — Direct graph manipulation for the surgery: iterated `model.graph.node`, replaced Resize nodes, added `numpy_helper.from_array()` initializer tensors for precomputed scales and empty roi, ran `onnx.checker.check_model()` for structural validation.
+- **Gazebo scenario log analysis** — Parsed `mission_planner.log` to diagnose grid saturation: `[Grid] 331 static (promoted=331)` and repeated `D*Lite No path: g(start)=1000000000` confirmed the planner was blocked by excessive static cell promotion, not an avoider bug.
+
+**Limitations / Known issues:**
+
+- The fixed scale factors are baked in for 518x518 input. Changing `input_size` in config requires re-running the export script.
+- Bilinear interpolation in the patch embedding (instead of bicubic) may slightly affect depth accuracy — not measured quantitatively, but validated qualitatively in Gazebo (drone navigates correctly around all 4 obstacles).
+- Documented in DR-014 (DESIGN_RATIONALE.md).
+
+**Found by:** Implementation and Gazebo testing during Issue #455 — each failure surfaced sequentially during the export→load→run pipeline. The investigation table above shows the exact sequence.
+
+**Regression test:** 15 unit tests (9 always-run + 6 model-dependent with GTEST_SKIP). Scenario 28 passes 20/20 in Gazebo SITL.
 
 ---
 

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -25,7 +25,7 @@ Sections:
 Copy this template when adding a new fix. Every section is mandatory — a fix entry that someone else can't reproduce or learn from is just a changelog line.
 
 ```markdown
-### Fix #XX — <Short title describing the symptom> (#<GitHub issue>)
+### Fix #XX — <Short title describing the symptom> (Issue #<GitHub issue>)
 
 **Date:** YYYY-MM-DD
 **Severity:** Critical / Blocker / High / Medium / Low
@@ -628,7 +628,7 @@ else
 
 ---
 
-### Fix #51 — Depth Anything V2 ONNX Model Incompatible with OpenCV DNN (#455)
+### Fix #51 — Depth Anything V2 ONNX Model Incompatible with OpenCV DNN (Issue #455)
 
 **Date:** 2026-04-14
 **Severity:** Blocker (ML depth backend completely non-functional)

--- a/models/download_depth_anything_v2.sh
+++ b/models/download_depth_anything_v2.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# models/download_depth_anything_v2.sh
+# Exports Depth Anything V2 ViT-Small to ONNX (~95MB) compatible with OpenCV DNN.
+#
+# The ViT-S variant balances accuracy and speed for drone applications:
+#   - Input: 518x518 RGB
+#   - Output: relative inverse depth map (converted to metric in C++ backend)
+#   - CPU inference via OpenCV DNN: ~60-80ms per frame
+#
+# Why export instead of download?
+#   HuggingFace hosts PyTorch weights (safetensors) only — no pre-exported ONNX.
+#   The PyTorch->ONNX export produces Resize nodes with 4 inputs (ONNX standard),
+#   but OpenCV DNN <=4.10 only supports 1-2 input Resize. We fix this with
+#   ONNX graph surgery: replace dynamic-size Resize with fixed-scale Resize.
+#
+# Requires: pip install torch transformers onnx onnxruntime onnxsim
+#
+# Usage:
+#   cd <project_root>
+#   bash models/download_depth_anything_v2.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODEL_PATH="${SCRIPT_DIR}/depth_anything_v2_vits.onnx"
+
+if [[ -f "$MODEL_PATH" ]]; then
+    echo "Model already exists: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
+    exit 0
+fi
+
+echo "Exporting Depth Anything V2 ViT-Small to ONNX (OpenCV DNN compatible)..."
+
+python3 -c "
+import torch
+import numpy as np
+import os, shutil
+
+# --- Step 1: Export PyTorch model to ONNX ---
+print('Step 1/4: Loading model from HuggingFace...')
+from transformers import AutoModelForDepthEstimation
+model = AutoModelForDepthEstimation.from_pretrained(
+    'depth-anything/Depth-Anything-V2-Small-hf'
+)
+model.eval()
+
+print('Step 2/4: Exporting to ONNX (opset 14, bilinear resize)...')
+# Monkey-patch bicubic -> bilinear (OpenCV DNN doesn't support bicubic Resize)
+import torch.nn.functional as F
+_orig_interpolate = F.interpolate
+def _bilinear_interpolate(*args, **kwargs):
+    if kwargs.get('mode') == 'bicubic':
+        kwargs['mode'] = 'bilinear'
+        kwargs.pop('align_corners', None)
+    return _orig_interpolate(*args, **kwargs)
+F.interpolate = _bilinear_interpolate
+
+dummy_input = torch.randn(1, 3, 518, 518)
+raw_path = '/tmp/da_v2_raw.onnx'
+torch.onnx.export(
+    model, {'pixel_values': dummy_input},
+    raw_path,
+    opset_version=14,
+    input_names=['pixel_values'],
+    output_names=['predicted_depth'],
+    dynamic_axes=None,
+    dynamo=False,
+)
+F.interpolate = _orig_interpolate  # Restore
+
+# --- Step 2: Simplify with onnxsim ---
+print('Step 3/4: Simplifying ONNX graph...')
+import subprocess
+sim_path = '/tmp/da_v2_simplified.onnx'
+subprocess.run(['onnxsim', raw_path, sim_path], check=True, capture_output=True)
+
+# --- Step 3: Fix Resize nodes for OpenCV DNN compatibility ---
+print('Step 4/4: Fixing Resize nodes for OpenCV DNN...')
+import onnx
+from onnx import helper, numpy_helper, TensorProto
+import onnxruntime as ort
+
+model_onnx = onnx.load(sim_path)
+graph = model_onnx.graph
+
+# Find all Resize nodes
+resize_nodes = [n for n in graph.node if n.op_type == 'Resize']
+
+# Get input/output shapes by running inference with extra outputs
+extra_outputs = []
+existing_names = {o.name for o in graph.output}
+value_info_map = {vi.name: vi for vi in graph.value_info}
+
+for node in resize_nodes:
+    for tname in [node.input[0], node.output[0]]:
+        if tname and tname not in existing_names:
+            vi = value_info_map.get(tname,
+                helper.make_tensor_value_info(tname, TensorProto.FLOAT, None))
+            extra_outputs.append(vi)
+            existing_names.add(tname)
+
+for eo in extra_outputs:
+    graph.output.append(eo)
+onnx.save(model_onnx, '/tmp/da_v2_debug.onnx')
+
+sess = ort.InferenceSession('/tmp/da_v2_debug.onnx')
+dummy_np = np.random.randn(1, 3, 518, 518).astype(np.float32)
+results = sess.run(None, {'pixel_values': dummy_np})
+shape_map = {name: r.shape for name, r in zip(
+    [o.name for o in sess.get_outputs()], results)}
+
+for eo in extra_outputs:
+    graph.output.remove(eo)
+
+# Replace 4-input Resize(X, roi, scales, sizes) with 3-input Resize(X, roi, scales)
+new_nodes = []
+new_inits = []
+for node in graph.node:
+    if node.op_type != 'Resize' or len(node.input) < 3:
+        new_nodes.append(node)
+        continue
+
+    in_shape = shape_map.get(node.input[0])
+    out_shape = shape_map.get(node.output[0])
+    if in_shape is None or out_shape is None:
+        new_nodes.append(node)
+        continue
+
+    scales = np.array(out_shape, dtype=np.float32) / np.array(in_shape, dtype=np.float32)
+    scales_name = f'{node.name}_fixed_scales'
+    roi_name = f'{node.name}_empty_roi'
+    new_inits.append(numpy_helper.from_array(scales, name=scales_name))
+    new_inits.append(numpy_helper.from_array(np.array([], dtype=np.float32), name=roi_name))
+
+    new_resize = helper.make_node('Resize',
+        inputs=[node.input[0], roi_name, scales_name],
+        outputs=node.output, name=node.name)
+    for attr in node.attribute:
+        new_resize.attribute.append(attr)
+    new_nodes.append(new_resize)
+
+del graph.node[:]
+graph.node.extend(new_nodes)
+for init in new_inits:
+    graph.initializer.append(init)
+
+onnx.checker.check_model(model_onnx)
+onnx.save(model_onnx, '${MODEL_PATH}')
+
+# Verify
+sess2 = ort.InferenceSession('${MODEL_PATH}')
+out = sess2.run(None, {'pixel_values': dummy_np})
+size_mb = os.path.getsize('${MODEL_PATH}') / 1e6
+print(f'Model saved to ${MODEL_PATH} ({size_mb:.1f} MB)')
+print(f'Output shape: {out[0].shape} — ready for OpenCV DNN')
+
+# Cleanup
+for f in [raw_path, sim_path, '/tmp/da_v2_debug.onnx']:
+    if os.path.exists(f):
+        os.remove(f)
+"
+
+echo "Done. Set config: perception.depth_estimator.backend=depth_anything_v2"

--- a/models/download_depth_anything_v2.sh
+++ b/models/download_depth_anything_v2.sh
@@ -5,7 +5,7 @@
 # The ViT-S variant balances accuracy and speed for drone applications:
 #   - Input: 518x518 RGB
 #   - Output: relative inverse depth map (converted to metric in C++ backend)
-#   - CPU inference via OpenCV DNN: ~60-80ms per frame
+#   - CPU inference via OpenCV DNN: ~1s per frame (i7 laptop, single-threaded)
 #
 # Why export instead of download?
 #   HuggingFace hosts PyTorch weights (safetensors) only — no pre-exported ONNX.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -230,13 +230,14 @@ add_drone_test(test_depth_estimator  test_depth_estimator.cpp
 endif()
 
 # ── Depth Anything V2 backend tests (Issue #455) ───────────
-add_drone_test(test_depth_anything_v2 test_depth_anything_v2.cpp)
-target_compile_definitions(test_depth_anything_v2 PRIVATE
-    DA_V2_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/depth_anything_v2_vits.onnx"
-)
+# Requires OpenCV: the DA V2 .cpp is only compiled into drone_hal when OPENCV_FOUND.
 if(OPENCV_FOUND)
+    add_drone_test(test_depth_anything_v2 test_depth_anything_v2.cpp)
+    target_compile_definitions(test_depth_anything_v2 PRIVATE
+        DA_V2_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/depth_anything_v2_vits.onnx"
+        HAS_OPENCV=1
+    )
     target_link_libraries(test_depth_anything_v2 PRIVATE ${OpenCV_LIBS})
-    target_compile_definitions(test_depth_anything_v2 PRIVATE HAS_OPENCV=1)
 endif()
 
 # ── Cosys-AirSim HAL backend tests (Issue #434) ────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,16 @@ add_drone_test(test_depth_estimator  test_depth_estimator.cpp
 )
 endif()
 
+# ── Depth Anything V2 backend tests (Issue #455) ───────────
+add_drone_test(test_depth_anything_v2 test_depth_anything_v2.cpp)
+target_compile_definitions(test_depth_anything_v2 PRIVATE
+    DA_V2_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/depth_anything_v2_vits.onnx"
+)
+if(OPENCV_FOUND)
+    target_link_libraries(test_depth_anything_v2 PRIVATE ${OpenCV_LIBS})
+    target_compile_definitions(test_depth_anything_v2 PRIVATE HAS_OPENCV=1)
+endif()
+
 # ── Cosys-AirSim HAL backend tests (Issue #434) ────────────
 add_drone_test(test_cosys_hal_backends test_cosys_hal_backends.cpp)
 

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -220,8 +220,10 @@ TEST_F(DAv2ModelTest, DepthValuesPositiveAndBounded) {
         max_d = std::max(max_d, d);
     }
 
-    // Non-uniform input must produce depth variation (not collapsed to single value)
+    // Non-uniform input must produce meaningful depth variation — the linear mapping
+    // should spread values across [0.1, max_depth], not collapse to a narrow range.
     EXPECT_LT(min_d, max_d) << "Depth map should have variation on non-uniform input";
+    EXPECT_GT(max_d - min_d, 1.0f) << "Depth range should span at least 1m on gradient input";
 }
 
 TEST_F(DAv2ModelTest, RGBAFrameWorks) {

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -122,13 +122,14 @@ TEST(DepthAnythingV2Test, ConfigConstruction) {
     }
 
     drone::Config cfg;
-    cfg.load(path);
+    bool          loaded = cfg.load(path);
+    std::remove(path.c_str());
+    ASSERT_TRUE(loaded) << "Failed to load test config from " << path;
+
     DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
 
     EXPECT_EQ(estimator.name(), "DepthAnythingV2Estimator");
     EXPECT_FALSE(estimator.is_loaded());  // model doesn't exist
-
-    std::remove(path.c_str());
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -1,0 +1,235 @@
+// tests/test_depth_anything_v2.cpp
+// Unit tests for DepthAnythingV2Estimator: Depth Anything V2 via OpenCV DNN.
+// Tests run with and without the ONNX model file.
+// Issue #455.
+#include "hal/depth_anything_v2.h"
+#include "hal/idepth_estimator.h"
+#include "util/config.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace drone::hal;
+
+// ═══════════════════════════════════════════════════════════
+// Model path resolution
+// ═══════════════════════════════════════════════════════════
+
+#ifdef DA_V2_MODEL_PATH
+static const char* g_model_path = DA_V2_MODEL_PATH;
+#else
+static const char* g_model_path = "models/depth_anything_v2_vits.onnx";
+#endif
+
+static bool model_exists() {
+    std::ifstream f(g_model_path);
+    return f.good();
+}
+
+// ═══════════════════════════════════════════════════════════
+// Tests that always run (no model file needed)
+// ═══════════════════════════════════════════════════════════
+
+TEST(DepthAnythingV2Test, NameReturnsExpected) {
+    // Construct with non-existent model — name() still works
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+    EXPECT_EQ(estimator.name(), "DepthAnythingV2Estimator");
+}
+
+TEST(DepthAnythingV2Test, ModelNotFoundNotLoaded) {
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+    EXPECT_FALSE(estimator.is_loaded());
+}
+
+TEST(DepthAnythingV2Test, ModelNotFoundEstimateReturnsError) {
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+
+    constexpr uint32_t   w = 64, h = 48, c = 3;
+    std::vector<uint8_t> frame(w * h * c, 128);
+
+    auto result = estimator.estimate(frame.data(), w, h, c);
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST(DepthAnythingV2Test, PathTraversalRejected) {
+    DepthAnythingV2Estimator estimator("../../etc/passwd");
+    EXPECT_FALSE(estimator.is_loaded());
+}
+
+TEST(DepthAnythingV2Test, PathTraversalMiddleRejected) {
+    DepthAnythingV2Estimator estimator("models/../../../secret.onnx");
+    EXPECT_FALSE(estimator.is_loaded());
+}
+
+TEST(DepthAnythingV2Test, NullFrameReturnsError) {
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+    auto                     result = estimator.estimate(nullptr, 640, 480, 3);
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST(DepthAnythingV2Test, ZeroDimensionsReturnError) {
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+    std::vector<uint8_t>     frame(100, 128);
+
+    auto r1 = estimator.estimate(frame.data(), 0, 480, 3);
+    EXPECT_FALSE(r1.is_ok());
+
+    auto r2 = estimator.estimate(frame.data(), 640, 0, 3);
+    EXPECT_FALSE(r2.is_ok());
+}
+
+TEST(DepthAnythingV2Test, InsufficientChannelsReturnsError) {
+    DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
+    std::vector<uint8_t>     frame(100, 128);
+
+    auto r1 = estimator.estimate(frame.data(), 10, 10, 0);
+    EXPECT_FALSE(r1.is_ok());
+
+    auto r2 = estimator.estimate(frame.data(), 10, 10, 1);
+    EXPECT_FALSE(r2.is_ok());
+
+    auto r3 = estimator.estimate(frame.data(), 10, 10, 2);
+    EXPECT_FALSE(r3.is_ok());
+}
+
+TEST(DepthAnythingV2Test, ConfigConstruction) {
+    // Write a temp config file
+    std::string path = "/tmp/test_da_v2_" + std::to_string(getpid()) + ".json";
+    {
+        std::ofstream ofs(path);
+        ofs << R"({
+            "perception": {
+                "depth_estimator": {
+                    "backend": "depth_anything_v2",
+                    "model_path": "nonexistent.onnx",
+                    "input_size": 256,
+                    "max_depth_m": 30.0
+                }
+            }
+        })";
+    }
+
+    drone::Config cfg;
+    cfg.load(path);
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+
+    EXPECT_EQ(estimator.name(), "DepthAnythingV2Estimator");
+    EXPECT_FALSE(estimator.is_loaded());  // model doesn't exist
+
+    std::remove(path.c_str());
+}
+
+// ═══════════════════════════════════════════════════════════
+// Tests that require the ONNX model file (skip if not present)
+// ═══════════════════════════════════════════════════════════
+
+class DAv2ModelTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!model_exists()) {
+            GTEST_SKIP() << "DA V2 model not found at " << g_model_path;
+        }
+    }
+};
+
+TEST_F(DAv2ModelTest, ModelLoadsSuccessfully) {
+    DepthAnythingV2Estimator estimator(g_model_path);
+    EXPECT_TRUE(estimator.is_loaded());
+}
+
+TEST_F(DAv2ModelTest, ValidFrameProducesDepthMap) {
+    DepthAnythingV2Estimator estimator(g_model_path, 518, 20.0f);
+
+    // Create a synthetic RGB frame (gradient pattern)
+    constexpr uint32_t   w = 640, h = 480, c = 3;
+    std::vector<uint8_t> frame(w * h * c);
+    for (uint32_t y = 0; y < h; ++y) {
+        for (uint32_t x = 0; x < w; ++x) {
+            size_t idx     = (y * w + x) * c;
+            frame[idx + 0] = static_cast<uint8_t>(x % 256);  // R: horizontal gradient
+            frame[idx + 1] = static_cast<uint8_t>(y % 256);  // G: vertical gradient
+            frame[idx + 2] = 128;                            // B: constant
+        }
+    }
+
+    auto result = estimator.estimate(frame.data(), w, h, c);
+    ASSERT_TRUE(result.is_ok()) << result.error();
+
+    const auto& map = result.value();
+    EXPECT_GT(map.width, 0u);
+    EXPECT_GT(map.height, 0u);
+    EXPECT_EQ(map.data.size(), static_cast<size_t>(map.width) * map.height);
+    EXPECT_FLOAT_EQ(map.scale, 1.0f);
+    EXPECT_FLOAT_EQ(map.confidence, 0.7f);
+}
+
+TEST_F(DAv2ModelTest, SourceDimensionsSetCorrectly) {
+    DepthAnythingV2Estimator estimator(g_model_path, 518, 20.0f);
+
+    constexpr uint32_t   w = 1920, h = 1080, c = 3;
+    std::vector<uint8_t> frame(w * h * c, 128);
+
+    auto result = estimator.estimate(frame.data(), w, h, c);
+    ASSERT_TRUE(result.is_ok()) << result.error();
+
+    const auto& map = result.value();
+    // source_width/source_height must be the INPUT frame dimensions
+    // (for fusion bbox mapping), not the model output dimensions
+    EXPECT_EQ(map.source_width, w);
+    EXPECT_EQ(map.source_height, h);
+}
+
+TEST_F(DAv2ModelTest, DepthValuesPositiveAndBounded) {
+    DepthAnythingV2Estimator estimator(g_model_path, 518, 20.0f);
+
+    constexpr uint32_t   w = 320, h = 240, c = 3;
+    std::vector<uint8_t> frame(w * h * c, 100);
+
+    auto result = estimator.estimate(frame.data(), w, h, c);
+    ASSERT_TRUE(result.is_ok()) << result.error();
+
+    const auto& map = result.value();
+    for (float d : map.data) {
+        EXPECT_GE(d, 0.1f) << "Depth must be >= 0.1m";
+        EXPECT_LE(d, 20.0f) << "Depth must be <= max_depth_m (20.0)";
+    }
+}
+
+TEST_F(DAv2ModelTest, RGBAFrameWorks) {
+    DepthAnythingV2Estimator estimator(g_model_path, 518, 20.0f);
+
+    constexpr uint32_t   w = 320, h = 240, c = 4;
+    std::vector<uint8_t> frame(w * h * c, 128);
+
+    auto result = estimator.estimate(frame.data(), w, h, c);
+    ASSERT_TRUE(result.is_ok()) << result.error();
+    EXPECT_GT(result.value().data.size(), 0u);
+}
+
+TEST_F(DAv2ModelTest, MaxDepthConfigAffectsOutput) {
+    // Same frame, different max_depth — output range should differ
+    constexpr uint32_t   w = 320, h = 240, c = 3;
+    std::vector<uint8_t> frame(w * h * c, 128);
+
+    DepthAnythingV2Estimator est_20(g_model_path, 518, 20.0f);
+    DepthAnythingV2Estimator est_50(g_model_path, 518, 50.0f);
+
+    auto r20 = est_20.estimate(frame.data(), w, h, c);
+    auto r50 = est_50.estimate(frame.data(), w, h, c);
+    ASSERT_TRUE(r20.is_ok());
+    ASSERT_TRUE(r50.is_ok());
+
+    // Max depth in map with max_depth=20 should be <= 20
+    float max_20 = *std::max_element(r20.value().data.begin(), r20.value().data.end());
+    float max_50 = *std::max_element(r50.value().data.begin(), r50.value().data.end());
+
+    EXPECT_LE(max_20, 20.0f);
+    EXPECT_LE(max_50, 50.0f);
+}

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -85,18 +85,23 @@ TEST(DepthAnythingV2Test, ZeroDimensionsReturnError) {
     EXPECT_FALSE(r2.is_ok());
 }
 
-TEST(DepthAnythingV2Test, InsufficientChannelsReturnsError) {
+TEST(DepthAnythingV2Test, InvalidChannelsReturnsError) {
     DepthAnythingV2Estimator estimator("nonexistent_model.onnx");
     std::vector<uint8_t>     frame(100, 128);
 
-    auto r1 = estimator.estimate(frame.data(), 10, 10, 0);
+    // Too few channels
+    auto r0 = estimator.estimate(frame.data(), 10, 10, 0);
+    EXPECT_FALSE(r0.is_ok());
+
+    auto r1 = estimator.estimate(frame.data(), 10, 10, 1);
     EXPECT_FALSE(r1.is_ok());
 
-    auto r2 = estimator.estimate(frame.data(), 10, 10, 1);
+    auto r2 = estimator.estimate(frame.data(), 10, 10, 2);
     EXPECT_FALSE(r2.is_ok());
 
-    auto r3 = estimator.estimate(frame.data(), 10, 10, 2);
-    EXPECT_FALSE(r3.is_ok());
+    // Too many channels (only 3=RGB and 4=RGBA supported)
+    auto r5 = estimator.estimate(frame.data(), 10, 10, 5);
+    EXPECT_FALSE(r5.is_ok());
 }
 
 TEST(DepthAnythingV2Test, ConfigConstruction) {
@@ -189,17 +194,33 @@ TEST_F(DAv2ModelTest, SourceDimensionsSetCorrectly) {
 TEST_F(DAv2ModelTest, DepthValuesPositiveAndBounded) {
     DepthAnythingV2Estimator estimator(g_model_path, 518, 20.0f);
 
+    // Use a gradient frame (not uniform) to ensure depth variation in output
     constexpr uint32_t   w = 320, h = 240, c = 3;
-    std::vector<uint8_t> frame(w * h * c, 100);
+    std::vector<uint8_t> frame(w * h * c);
+    for (uint32_t y = 0; y < h; ++y) {
+        for (uint32_t x = 0; x < w; ++x) {
+            size_t idx     = (y * w + x) * c;
+            frame[idx + 0] = static_cast<uint8_t>(x % 256);
+            frame[idx + 1] = static_cast<uint8_t>(y % 256);
+            frame[idx + 2] = 128;
+        }
+    }
 
     auto result = estimator.estimate(frame.data(), w, h, c);
     ASSERT_TRUE(result.is_ok()) << result.error();
 
-    const auto& map = result.value();
+    const auto& map   = result.value();
+    float       min_d = map.data[0];
+    float       max_d = map.data[0];
     for (float d : map.data) {
         EXPECT_GE(d, 0.1f) << "Depth must be >= 0.1m";
         EXPECT_LE(d, 20.0f) << "Depth must be <= max_depth_m (20.0)";
+        min_d = std::min(min_d, d);
+        max_d = std::max(max_d, d);
     }
+
+    // Non-uniform input must produce depth variation (not collapsed to single value)
+    EXPECT_LT(min_d, max_d) << "Depth map should have variation on non-uniform input";
 }
 
 TEST_F(DAv2ModelTest, RGBAFrameWorks) {


### PR DESCRIPTION
## Summary

- Adds `DepthAnythingV2Estimator` HAL backend: monocular metric depth via DA V2 ViT-S ONNX on OpenCV DNN (CPU inference ~1.7s/frame at 518x518)
- Converts relative inverse depth to metric depth for UKF fusion Tier 3.5 integration
- New Gazebo scenario 28: validates full ML depth pipeline (color_contour + DA V2 + radar + UKF fusion + D* Lite)
- Export script with ONNX graph surgery to fix Resize node incompatibility with OpenCV DNN (documented in DR-014)
- 15 unit tests (9 always-run, 6 model-dependent with GTEST_SKIP)

## Files

| File | Change |
|------|--------|
| `common/hal/include/hal/depth_anything_v2.h` | New: DA V2 estimator header |
| `common/hal/src/depth_anything_v2.cpp` | New: DA V2 implementation (OpenCV DNN inference) |
| `common/hal/include/hal/hal_factory.h` | Register `depth_anything_v2` backend in `create_depth_estimator()` |
| `common/hal/CMakeLists.txt` | Add conditional OpenCV source + link |
| `tests/test_depth_anything_v2.cpp` | New: 15 tests |
| `tests/CMakeLists.txt` | Add test target with `HAS_OPENCV` + `DA_V2_MODEL_PATH` |
| `config/scenarios/28_ml_depth_estimation.json` | New: Gazebo scenario |
| `models/download_depth_anything_v2.sh` | New: model export script |
| `docs/guides/DESIGN_RATIONALE.md` | DR-014: ONNX graph surgery rationale |

## Key design decisions

- **HAS_OPENCV stays per-target** (not INTERFACE on drone_hal) to avoid leaking to all consumers
- **ONNX graph surgery**: Replaces 4-input Resize nodes with 3-input (precomputed scales) for OpenCV DNN compatibility
- **Promotion thresholds tuned for ML depth**: 12 hits + 0.85 confidence (vs 8/0.8 for simulated) to prevent grid saturation

## Test plan

- [x] 15/15 unit tests pass (9 always-run + 6 model-dependent)
- [x] Build clean with zero warnings
- [x] clang-format-18 clean
- [x] Test count: 1545
- [x] Scenario 28 passes 20/20 checks in Gazebo SITL

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)