### PR TITLE
feat(#460): vendor AirSim C++ SDK as git submodule + CMake FindAirSim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "third_party/cosys-airsim"]
+	path = third_party/cosys-airsim
+	url = https://github.com/Cosys-Lab/Cosys-AirSim.git
+	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,14 +187,10 @@ else()
 endif()
 
 # ── Optional: Cosys-AirSim simulation backend ─────────────
-find_package(AirSim QUIET)
-if(AirSim_FOUND)
-    set(COSYS_AIRSIM_FOUND TRUE)
-    message(STATUS "  Cosys-AirSim : ${AirSim_VERSION} — Cosys-AirSim HAL backends available")
-else()
-    set(COSYS_AIRSIM_FOUND FALSE)
-    message(STATUS "  Cosys-AirSim : NOT FOUND — Cosys-AirSim HAL backends disabled")
-endif()
+# Uses ExternalProject_Add for flag isolation (AirSim's CommonSetup.cmake
+# mutates global CXX_FLAGS which would break our -Werror policy).
+# See cmake/FindAirSim.cmake for details.
+include(cmake/FindAirSim.cmake)
 
 # ── ML model presets ───────────────────────────────────────
 include(cmake/ModelPresets.cmake)

--- a/cmake/FindAirSim.cmake
+++ b/cmake/FindAirSim.cmake
@@ -41,18 +41,25 @@ set(RPCLIB_DOWNLOAD_URL "https://github.com/WouterJansen/rpclib/archive/refs/tag
     CACHE STRING "URL for rpclib tarball (override for mirrors/air-gapped builds)")
 set(RPCLIB_DOWNLOAD_DEST "${AIRSIM_SUBMODULE_DIR}/external/rpclib/v2.3.1.tar.gz")
 
+# NOTE: rpclib is extracted into the submodule tree (external/rpclib/) because
+# AirSim's own CMakeLists expects it at that exact path. This makes the submodule
+# appear "dirty" (untracked files). Add external/rpclib/ to .gitignore if this
+# bothers your workflow. Moving it to CMAKE_BINARY_DIR would require patching
+# AirSim's build system, which defeats the purpose of vendoring.
 if(NOT EXISTS "${RPCLIB_DIR}/CMakeLists.txt")
     message(STATUS "  Cosys-AirSim : Downloading rpclib v2.3.1...")
 
     # Create target directory
     file(MAKE_DIRECTORY "${AIRSIM_SUBMODULE_DIR}/external/rpclib")
 
-    # Download the tarball
+    # Download the tarball (SHA256 pinned for supply-chain integrity)
     file(DOWNLOAD
         "${RPCLIB_DOWNLOAD_URL}"
         "${RPCLIB_DOWNLOAD_DEST}"
         STATUS _rpclib_download_status
         TIMEOUT 60
+        EXPECTED_HASH SHA256=16a1f5f112e2a7f6706f660f8ab3f0937049aef5750d580311e34b0e8846d248
+        TLS_VERIFY ON
     )
     list(GET _rpclib_download_status 0 _rpclib_download_code)
 
@@ -99,11 +106,29 @@ set(AIRSIM_OUTPUT_LIB_DIR "${AIRSIM_BINARY_DIR}/output/lib")
 
 find_package(Threads REQUIRED)
 
+# Handle multi-config generators (Ninja Multi-Config, VS) where
+# CMAKE_BUILD_TYPE is empty — default to Release for the external build.
+set(_AIRSIM_EFFECTIVE_TYPE "${CMAKE_BUILD_TYPE}")
+if(NOT _AIRSIM_EFFECTIVE_TYPE)
+    set(_AIRSIM_EFFECTIVE_TYPE "Release")
+endif()
+
+# Forward compiler and toolchain settings so cross-compilation and
+# non-default compilers work consistently with the external build.
+set(_AIRSIM_COMPILER_ARGS
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+)
+if(CMAKE_TOOLCHAIN_FILE)
+    list(APPEND _AIRSIM_COMPILER_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
+endif()
+
 ExternalProject_Add(airsim_external
     SOURCE_DIR        "${AIRSIM_SUBMODULE_DIR}/cmake"
     BINARY_DIR        "${AIRSIM_BINARY_DIR}"
     CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_BUILD_TYPE=${_AIRSIM_EFFECTIVE_TYPE}
+        ${_AIRSIM_COMPILER_ARGS}
         -DCMAKE_CXX_STANDARD=17
         -DCMAKE_CXX_STANDARD_REQUIRED=ON
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON

--- a/cmake/FindAirSim.cmake
+++ b/cmake/FindAirSim.cmake
@@ -18,7 +18,9 @@
 include(ExternalProject)
 
 set(AIRSIM_SUBMODULE_DIR "${CMAKE_SOURCE_DIR}/third_party/cosys-airsim")
-set(AIRSIM_VERSION "5.5-v3.3")
+# NOTE: Update this when bumping the submodule to a new tag.
+# Dependabot PRs that update the submodule should also update this version.
+set(AIRSIM_VERSION "5.5-v3.3" CACHE STRING "Cosys-AirSim SDK version (must match submodule tag)")
 
 # ── Check if submodule is populated ──────────────────────────
 # AirSim.sln is a reliable sentinel file that exists in the repo root.
@@ -33,7 +35,10 @@ endif()
 # AirSim's setup.sh normally downloads rpclib. We handle it in CMake so the
 # submodule works without running setup.sh first.
 set(RPCLIB_DIR "${AIRSIM_SUBMODULE_DIR}/external/rpclib/rpclib-2.3.1")
-set(RPCLIB_DOWNLOAD_URL "https://github.com/WouterJansen/rpclib/archive/refs/tags/v2.3.1.tar.gz")
+# Override for air-gapped builds or internal mirrors:
+#   cmake .. -DRPCLIB_DOWNLOAD_URL=https://internal-mirror.example.com/rpclib-2.3.1.tar.gz
+set(RPCLIB_DOWNLOAD_URL "https://github.com/WouterJansen/rpclib/archive/refs/tags/v2.3.1.tar.gz"
+    CACHE STRING "URL for rpclib tarball (override for mirrors/air-gapped builds)")
 set(RPCLIB_DOWNLOAD_DEST "${AIRSIM_SUBMODULE_DIR}/external/rpclib/v2.3.1.tar.gz")
 
 if(NOT EXISTS "${RPCLIB_DIR}/CMakeLists.txt")

--- a/cmake/FindAirSim.cmake
+++ b/cmake/FindAirSim.cmake
@@ -1,0 +1,151 @@
+# ============================================================================
+# FindAirSim.cmake — Locate and build vendored Cosys-AirSim C++ SDK
+# ============================================================================
+# Uses ExternalProject_Add to build AirLib + rpclib + MavLinkCom from the
+# vendored git submodule at third_party/cosys-airsim/. ExternalProject builds
+# in a separate CMake invocation, which isolates AirSim's aggressive global
+# flag mutations (CommonSetup.cmake adds -Wno-unused, etc.) from our build.
+#
+# Outputs:
+#   COSYS_AIRSIM_FOUND  — TRUE if SDK was found and build targets created
+#   AIRSIM_VERSION      — Version string (tag of vendored submodule)
+#   AirSim::AirLib      — Imported static library
+#   AirSim::rpc         — Imported static library (rpclib)
+#   AirSim::MavLinkCom  — Imported static library
+#   AirSim::All          — Interface target combining all three + Threads
+# ============================================================================
+
+include(ExternalProject)
+
+set(AIRSIM_SUBMODULE_DIR "${CMAKE_SOURCE_DIR}/third_party/cosys-airsim")
+set(AIRSIM_VERSION "5.5-v3.3")
+
+# ── Check if submodule is populated ──────────────────────────
+# AirSim.sln is a reliable sentinel file that exists in the repo root.
+if(NOT EXISTS "${AIRSIM_SUBMODULE_DIR}/AirSim.sln")
+    set(COSYS_AIRSIM_FOUND FALSE)
+    message(STATUS "  Cosys-AirSim : NOT FOUND — submodule not initialized")
+    message(STATUS "    Hint: git submodule update --init third_party/cosys-airsim")
+    return()
+endif()
+
+# ── Ensure rpclib source is available ────────────────────────
+# AirSim's setup.sh normally downloads rpclib. We handle it in CMake so the
+# submodule works without running setup.sh first.
+set(RPCLIB_DIR "${AIRSIM_SUBMODULE_DIR}/external/rpclib/rpclib-2.3.1")
+set(RPCLIB_DOWNLOAD_URL "https://github.com/WouterJansen/rpclib/archive/refs/tags/v2.3.1.tar.gz")
+set(RPCLIB_DOWNLOAD_DEST "${AIRSIM_SUBMODULE_DIR}/external/rpclib/v2.3.1.tar.gz")
+
+if(NOT EXISTS "${RPCLIB_DIR}/CMakeLists.txt")
+    message(STATUS "  Cosys-AirSim : Downloading rpclib v2.3.1...")
+
+    # Create target directory
+    file(MAKE_DIRECTORY "${AIRSIM_SUBMODULE_DIR}/external/rpclib")
+
+    # Download the tarball
+    file(DOWNLOAD
+        "${RPCLIB_DOWNLOAD_URL}"
+        "${RPCLIB_DOWNLOAD_DEST}"
+        STATUS _rpclib_download_status
+        TIMEOUT 60
+    )
+    list(GET _rpclib_download_status 0 _rpclib_download_code)
+
+    if(NOT _rpclib_download_code EQUAL 0)
+        list(GET _rpclib_download_status 1 _rpclib_download_msg)
+        set(COSYS_AIRSIM_FOUND FALSE)
+        message(STATUS "  Cosys-AirSim : NOT FOUND — rpclib download failed: ${_rpclib_download_msg}")
+        message(STATUS "    Hint: manually download rpclib v2.3.1 to ${RPCLIB_DIR}/")
+        return()
+    endif()
+
+    # Extract — produces rpclib-2.3.1/ directory
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xzf "${RPCLIB_DOWNLOAD_DEST}"
+        WORKING_DIRECTORY "${AIRSIM_SUBMODULE_DIR}/external/rpclib"
+        RESULT_VARIABLE _rpclib_extract_result
+    )
+
+    if(NOT _rpclib_extract_result EQUAL 0)
+        set(COSYS_AIRSIM_FOUND FALSE)
+        message(STATUS "  Cosys-AirSim : NOT FOUND — rpclib extraction failed")
+        return()
+    endif()
+
+    # Verify extraction produced the expected directory
+    if(NOT EXISTS "${RPCLIB_DIR}/CMakeLists.txt")
+        set(COSYS_AIRSIM_FOUND FALSE)
+        message(STATUS "  Cosys-AirSim : NOT FOUND — rpclib extracted but CMakeLists.txt not found")
+        return()
+    endif()
+
+    message(STATUS "  Cosys-AirSim : rpclib v2.3.1 downloaded and extracted")
+endif()
+
+# ── Build via ExternalProject_Add ────────────────────────────
+# AirSim's CMake entry point is in the cmake/ subdirectory. It builds:
+#   - AirLib (the main client library)
+#   - rpc (rpclib, for RPC transport)
+#   - MavLinkCom (MAVLink communication)
+# Output libraries go to <BINARY_DIR>/output/lib/
+
+set(AIRSIM_BINARY_DIR "${CMAKE_BINARY_DIR}/airsim-build")
+set(AIRSIM_OUTPUT_LIB_DIR "${AIRSIM_BINARY_DIR}/output/lib")
+
+find_package(Threads REQUIRED)
+
+ExternalProject_Add(airsim_external
+    SOURCE_DIR        "${AIRSIM_SUBMODULE_DIR}/cmake"
+    BINARY_DIR        "${AIRSIM_BINARY_DIR}"
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+    BUILD_BYPRODUCTS
+        "${AIRSIM_OUTPUT_LIB_DIR}/libAirLib.a"
+        "${AIRSIM_OUTPUT_LIB_DIR}/librpc.a"
+        "${AIRSIM_OUTPUT_LIB_DIR}/libMavLinkCom.a"
+    INSTALL_COMMAND   ""
+    LOG_CONFIGURE     TRUE
+    LOG_BUILD         TRUE
+)
+
+# ── Create imported targets ──────────────────────────────────
+# These targets depend on airsim_external so they are built before use.
+
+# AirSim::AirLib
+add_library(AirSim::AirLib STATIC IMPORTED GLOBAL)
+set_target_properties(AirSim::AirLib PROPERTIES
+    IMPORTED_LOCATION "${AIRSIM_OUTPUT_LIB_DIR}/libAirLib.a"
+    INTERFACE_INCLUDE_DIRECTORIES
+        "${AIRSIM_SUBMODULE_DIR}/AirLib/include"
+)
+add_dependencies(AirSim::AirLib airsim_external)
+
+# AirSim::rpc
+add_library(AirSim::rpc STATIC IMPORTED GLOBAL)
+set_target_properties(AirSim::rpc PROPERTIES
+    IMPORTED_LOCATION "${AIRSIM_OUTPUT_LIB_DIR}/librpc.a"
+    INTERFACE_INCLUDE_DIRECTORIES
+        "${RPCLIB_DIR}/include"
+)
+add_dependencies(AirSim::rpc airsim_external)
+
+# AirSim::MavLinkCom
+add_library(AirSim::MavLinkCom STATIC IMPORTED GLOBAL)
+set_target_properties(AirSim::MavLinkCom PROPERTIES
+    IMPORTED_LOCATION "${AIRSIM_OUTPUT_LIB_DIR}/libMavLinkCom.a"
+    INTERFACE_INCLUDE_DIRECTORIES
+        "${AIRSIM_SUBMODULE_DIR}/MavLinkCom/include"
+)
+add_dependencies(AirSim::MavLinkCom airsim_external)
+
+# AirSim::All — convenience interface target combining everything
+add_library(AirSim::All INTERFACE IMPORTED GLOBAL)
+set_target_properties(AirSim::All PROPERTIES
+    INTERFACE_LINK_LIBRARIES "AirSim::AirLib;AirSim::MavLinkCom;AirSim::rpc;Threads::Threads"
+)
+
+set(COSYS_AIRSIM_FOUND TRUE)
+message(STATUS "  Cosys-AirSim : ${AIRSIM_VERSION} — Cosys-AirSim HAL backends available (ExternalProject)")

--- a/common/hal/CMakeLists.txt
+++ b/common/hal/CMakeLists.txt
@@ -31,9 +31,9 @@ if(GAZEBO_FOUND)
 endif()
 
 # ── Optional: Cosys-AirSim backend ────────────────────────
-# NOTE: Currently uses INTERFACE target_sources because the .cpp stubs are
-# empty (ifdef guards only). When real AirSim SDK code is added, migrate to
-# a STATIC library (drone_hal_cosys) to avoid compiling in every consumer.
+# Links against the vendored AirSim SDK (built via ExternalProject in
+# cmake/FindAirSim.cmake). The AirSim::All target bundles AirLib + rpclib +
+# MavLinkCom + Threads.
 if(COSYS_AIRSIM_FOUND)
     target_compile_definitions(drone_hal INTERFACE HAVE_COSYS_AIRSIM)
     target_sources(drone_hal INTERFACE
@@ -42,6 +42,7 @@ if(COSYS_AIRSIM_FOUND)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cosys_imu.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/cosys_depth.cpp
     )
+    target_link_libraries(drone_hal INTERFACE AirSim::All)
 endif()
 
 # ── Optional: Depth Anything V2 (OpenCV DNN) ──────────────

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -76,8 +76,11 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
 // ── Depth estimation ────────────────────────────────────────
 [[nodiscard]] drone::util::Result<DepthMap, std::string> DepthAnythingV2Estimator::estimate(
-    const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
-    uint32_t stride) {
+    [[maybe_unused]] const uint8_t* frame_data,
+    [[maybe_unused]] uint32_t width,
+    [[maybe_unused]] uint32_t height,
+    [[maybe_unused]] uint32_t channels,
+    [[maybe_unused]] uint32_t stride) {
     if (frame_data == nullptr || width == 0 || height == 0) {
         return drone::util::Result<DepthMap, std::string>::err(
             "DepthAnythingV2: invalid frame (null data or zero dimensions)");
@@ -222,11 +225,6 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     return drone::util::Result<DepthMap, std::string>::ok(std::move(map));
 
 #else
-    (void)frame_data;
-    (void)width;
-    (void)height;
-    (void)channels;
-    (void)stride;
     return drone::util::Result<DepthMap, std::string>::err(
         "DepthAnythingV2: OpenCV not available (compiled without HAS_OPENCV)");
 #endif

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -76,10 +76,8 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
 // ── Depth estimation ────────────────────────────────────────
 [[nodiscard]] drone::util::Result<DepthMap, std::string> DepthAnythingV2Estimator::estimate(
-    [[maybe_unused]] const uint8_t* frame_data,
-    [[maybe_unused]] uint32_t width,
-    [[maybe_unused]] uint32_t height,
-    [[maybe_unused]] uint32_t channels,
+    [[maybe_unused]] const uint8_t* frame_data, [[maybe_unused]] uint32_t width,
+    [[maybe_unused]] uint32_t height, [[maybe_unused]] uint32_t channels,
     [[maybe_unused]] uint32_t stride) {
     if (frame_data == nullptr || width == 0 || height == 0) {
         return drone::util::Result<DepthMap, std::string>::err(
@@ -101,7 +99,7 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     // ── Step 1: Wrap raw pixel data as cv::Mat ──────────────
     int     cv_type = (channels == 4) ? CV_8UC4 : CV_8UC3;
     size_t  step    = (stride > 0) ? static_cast<size_t>(stride)
-                                    : static_cast<size_t>(cv::Mat::AUTO_STEP);
+                                   : static_cast<size_t>(cv::Mat::AUTO_STEP);
     cv::Mat frame(static_cast<int>(height), static_cast<int>(width), cv_type,
                   const_cast<uint8_t*>(frame_data), step);
 

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -97,7 +97,8 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
     // ── Step 1: Wrap raw pixel data as cv::Mat ──────────────
     int     cv_type = (channels == 4) ? CV_8UC4 : CV_8UC3;
-    size_t  step    = (stride > 0) ? static_cast<size_t>(stride) : cv::Mat::AUTO_STEP;
+    size_t  step    = (stride > 0) ? static_cast<size_t>(stride)
+                                    : static_cast<size_t>(cv::Mat::AUTO_STEP);
     cv::Mat frame(static_cast<int>(height), static_cast<int>(width), cv_type,
                   const_cast<uint8_t*>(frame_data), step);
 
@@ -221,6 +222,11 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     return drone::util::Result<DepthMap, std::string>::ok(std::move(map));
 
 #else
+    (void)frame_data;
+    (void)width;
+    (void)height;
+    (void)channels;
+    (void)stride;
     return drone::util::Result<DepthMap, std::string>::err(
         "DepthAnythingV2: OpenCV not available (compiled without HAS_OPENCV)");
 #endif

--- a/deploy/install_dependencies.sh
+++ b/deploy/install_dependencies.sh
@@ -277,15 +277,11 @@ if $INSTALL_OPENCV; then
     MODELS_DIR="${PROJECT_DIR}/models"
     mkdir -p "$MODELS_DIR"
 
-    # YOLOv8n — direct download (no Python deps needed)
-    if [[ ! -f "${MODELS_DIR}/yolov8n.onnx" ]]; then
-        info "Downloading YOLOv8n ONNX model (12.8 MB)..."
-        wget -q --show-progress -O "${MODELS_DIR}/yolov8n.onnx" \
-            "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.onnx" \
-            || warn "Failed to download YOLOv8n model. You can download it later manually."
-        if [[ -f "${MODELS_DIR}/yolov8n.onnx" ]]; then
-            success "YOLOv8n model saved to models/yolov8n.onnx"
-        fi
+    # YOLOv8n — delegate to standalone script (has multi-URL fallback + Python export)
+    if [[ ! -f "${MODELS_DIR}/yolov8n.onnx" ]] || [[ ! -s "${MODELS_DIR}/yolov8n.onnx" ]]; then
+        info "Downloading YOLOv8n ONNX model..."
+        bash "${PROJECT_DIR}/models/download_yolov8n.sh" || \
+            warn "YOLOv8n download failed. Run manually: bash models/download_yolov8n.sh"
     else
         info "YOLOv8n model already exists at models/yolov8n.onnx"
     fi
@@ -493,15 +489,15 @@ if $INSTALL_ZENOH; then
 
             if ls libzenohc_*.deb 1>/dev/null 2>&1 && ls libzenohc-dev_*.deb 1>/dev/null 2>&1; then
                 sudo dpkg -i libzenohc_*.deb libzenohc-dev_*.deb || sudo apt-get -f install -y
-            sudo ldconfig
-            if pkg-config --exists zenohc 2>/dev/null; then
-                VER="$(pkg-config --modversion zenohc)"
-                success "zenohc ${VER} installed successfully"
-                INSTALLED+=("Zenoh zenohc ${VER}")
-            else
-                warn "zenohc installed but pkg-config doesn't see it."
-                INSTALLED+=("Zenoh zenohc ${ZENOH_VERSION} (no pkg-config)")
-            fi
+                sudo ldconfig
+                if pkg-config --exists zenohc 2>/dev/null; then
+                    VER="$(pkg-config --modversion zenohc)"
+                    success "zenohc ${VER} installed successfully"
+                    INSTALLED+=("Zenoh zenohc ${VER}")
+                else
+                    warn "zenohc installed but pkg-config doesn't see it."
+                    INSTALLED+=("Zenoh zenohc ${ZENOH_VERSION} (no pkg-config)")
+                fi
             else
                 warn "Extracted zip but .deb files not found. Contents:"
                 ls -la "$ZENOH_TMP"

--- a/deploy/install_dependencies.sh
+++ b/deploy/install_dependencies.sh
@@ -296,6 +296,11 @@ if $INSTALL_OPENCV; then
         info "Depth Anything V2 model requires Python export (ONNX graph surgery for OpenCV DNN)."
         if ask_yes_no "Install Python deps and export DA V2 model (~95 MB)?" "y"; then
             # Use a venv to avoid polluting system Python or conflicting with Conda
+            # Ensure python3-venv is installed (not present on fresh Ubuntu by default)
+            if ! python3 -m venv --help &>/dev/null; then
+                info "Installing python3-venv package..."
+                sudo apt-get install -y --no-install-recommends python3-venv python3-pip
+            fi
             VENV_DIR="${PROJECT_DIR}/.venv"
             if [[ ! -d "$VENV_DIR" ]]; then
                 info "Creating Python virtual environment at .venv/..."
@@ -428,9 +433,19 @@ echo "  zero-copy, peer-to-peer networking, and multi-machine support."
 echo "  The stack requires Zenoh to build and run."
 echo ""
 
-INSTALL_ZENOH=false
-if ask_yes_no "Install Zenoh (zenohc + zenoh-cpp)?" "y"; then
-    INSTALL_ZENOH=true
+# Zenoh is REQUIRED (not optional) — always install unless already present.
+# In --core-only mode, ask_yes_no returns "no" for optional deps, but Zenoh
+# is not optional — the build fails without it.
+INSTALL_ZENOH=true
+if [[ "$MODE" == "interactive" ]]; then
+    if ! ask_yes_no "Install Zenoh (zenohc + zenoh-cpp)?" "y"; then
+        warn "Zenoh is required — the stack will not build without it."
+        if ! ask_yes_no "Skip anyway?" "n"; then
+            INSTALL_ZENOH=true
+        else
+            INSTALL_ZENOH=false
+        fi
+    fi
 fi
 
 if $INSTALL_ZENOH; then

--- a/deploy/install_dependencies.sh
+++ b/deploy/install_dependencies.sh
@@ -8,11 +8,13 @@
 #   bash deploy/install_dependencies.sh --core-only  # Core dependencies only (no optional)
 #
 # What this installs:
-#   CORE (always):  build-essential, cmake, spdlog, Eigen3, nlohmann-json, GTest
+#   CORE (always):  build-essential, cmake, spdlog, fmt, Eigen3, nlohmann-json, GTest
+#   REQUIRED:
+#     Zenoh (zenohc)    — Zenoh IPC backend (sole IPC, always required)
 #   OPTIONAL:
 #     OpenCV 4.10       — YOLOv8-nano object detection via OpenCV DNN module
+#     ML models         — YOLOv8n ONNX (direct download) + DA V2 ONNX (Python export)
 #     MAVSDK 2.12       — MAVLink communication with PX4 flight controller
-#     Zenoh (zenohc)    — Zenoh IPC backend (alternative to POSIX SHM)
 #     Gazebo Harmonic   — 3D physics simulation (camera, IMU, odometry)
 #     PX4 SITL          — Software-in-the-loop flight controller
 #
@@ -151,15 +153,17 @@ sudo apt-get install -y --no-install-recommends \
     pkg-config \
     wget \
     curl \
+    unzip \
     lsb-release \
     gnupg \
     libspdlog-dev \
+    libfmt-dev \
     libeigen3-dev \
     nlohmann-json3-dev \
     libgtest-dev
 
 success "Core dependencies installed"
-INSTALLED+=("Core (spdlog, Eigen3, nlohmann-json, GTest)")
+INSTALLED+=("Core (spdlog, fmt, Eigen3, nlohmann-json, GTest)")
 
 # ══════════════════════════════════════════════════════════════
 #  STEP 2: OpenCV (Optional)
@@ -269,11 +273,13 @@ if $INSTALL_OPENCV; then
         fi
     fi
 
-    # Download YOLOv8n model
+    # Download ML models
     MODELS_DIR="${PROJECT_DIR}/models"
+    mkdir -p "$MODELS_DIR"
+
+    # YOLOv8n — direct download (no Python deps needed)
     if [[ ! -f "${MODELS_DIR}/yolov8n.onnx" ]]; then
         info "Downloading YOLOv8n ONNX model (12.8 MB)..."
-        mkdir -p "$MODELS_DIR"
         wget -q --show-progress -O "${MODELS_DIR}/yolov8n.onnx" \
             "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.onnx" \
             || warn "Failed to download YOLOv8n model. You can download it later manually."
@@ -282,6 +288,55 @@ if $INSTALL_OPENCV; then
         fi
     else
         info "YOLOv8n model already exists at models/yolov8n.onnx"
+    fi
+
+    # Depth Anything V2 ViT-S — requires Python export (graph surgery for OpenCV DNN)
+    # The raw HuggingFace ONNX has Resize nodes with 4 inputs; OpenCV DNN <=4.10
+    # only supports 1-2 inputs. The export script patches this automatically.
+    # NOTE: DA V2 also requires OpenCV 4.10+ at runtime — the apt version (4.5.4 on
+    # 22.04, 4.6.0 on 24.04) cannot parse the ReduceMean node. Build OpenCV from
+    # source (Section 4 Option A in INSTALL.md) if you need DA V2.
+    if [[ ! -f "${MODELS_DIR}/depth_anything_v2_vits.onnx" ]]; then
+        info "Depth Anything V2 model requires Python export (ONNX graph surgery for OpenCV DNN)."
+        if ask_yes_no "Install Python deps and export DA V2 model (~95 MB)?" "y"; then
+            # Use a venv to avoid polluting system Python or conflicting with Conda
+            VENV_DIR="${PROJECT_DIR}/.venv"
+            if [[ ! -d "$VENV_DIR" ]]; then
+                info "Creating Python virtual environment at .venv/..."
+                python3 -m venv "$VENV_DIR"
+            fi
+            # shellcheck disable=SC1091
+            source "${VENV_DIR}/bin/activate"
+
+            info "Installing Python dependencies for model export..."
+            pip install --quiet torch transformers onnx onnxruntime onnxsim 2>/dev/null || {
+                warn "pip install failed. Try manually:"
+                warn "  source .venv/bin/activate"
+                warn "  pip install torch transformers onnx onnxruntime onnxsim"
+                warn "  bash models/download_depth_anything_v2.sh"
+            }
+            if python3 -c "import transformers, onnx, onnxruntime" 2>/dev/null; then
+                info "Exporting Depth Anything V2 (this takes 1-2 minutes)..."
+                bash "${PROJECT_DIR}/models/download_depth_anything_v2.sh" && \
+                    success "Depth Anything V2 model exported to models/depth_anything_v2_vits.onnx" || \
+                    warn "DA V2 export failed. Run manually: bash models/download_depth_anything_v2.sh"
+            else
+                warn "Python deps not available. Skipping DA V2 model export."
+                warn "To install later:"
+                warn "  source .venv/bin/activate"
+                warn "  pip install torch transformers onnx onnxruntime onnxsim"
+                warn "  bash models/download_depth_anything_v2.sh"
+            fi
+
+            deactivate 2>/dev/null || true
+        else
+            info "Skipping DA V2 model. To export later:"
+            info "  python3 -m venv .venv && source .venv/bin/activate"
+            info "  pip install torch transformers onnx onnxruntime onnxsim"
+            info "  bash models/download_depth_anything_v2.sh"
+        fi
+    else
+        info "Depth Anything V2 model already exists at models/depth_anything_v2_vits.onnx"
     fi
 else
     info "Skipping OpenCV."
@@ -399,25 +454,45 @@ if $INSTALL_ZENOH; then
     if $INSTALL_ZENOH; then
         info "Installing Zenoh C bindings (zenohc)..."
 
-        # Method: install from Eclipse Zenoh apt repo / pre-built .deb
+        # Method: install from Eclipse Zenoh GitHub releases.
+        # Releases are distributed as a .zip containing two .deb files.
         # The zenohc packages provide libzenohc.so and the CMake config
         # files needed by find_package(zenohc).
         ZENOH_VERSION="1.7.2"
-        ARCH="$(dpkg --print-architecture)"
-        ZENOH_DEB_URL="https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOH_VERSION}"
+        ARCH="$(uname -m)"
+        # Map dpkg architecture to Rust target triple used in release assets
+        case "$ARCH" in
+            x86_64)  ZENOH_TARGET="x86_64-unknown-linux-gnu" ;;
+            aarch64) ZENOH_TARGET="aarch64-unknown-linux-gnu" ;;
+            armv7l)  ZENOH_TARGET="armv7-unknown-linux-gnueabihf" ;;
+            *)       fail "Unsupported architecture: $ARCH"; INSTALL_ZENOH=false ;;
+        esac
 
         ZENOH_TMP="/tmp/zenoh_install_$$"
         mkdir -p "$ZENOH_TMP"
         cd "$ZENOH_TMP"
 
-        info "Downloading zenohc ${ZENOH_VERSION} .deb packages..."
-        wget -q --show-progress "${ZENOH_DEB_URL}/libzenohc_${ZENOH_VERSION}-1_${ARCH}.deb" \
-            -O "libzenohc.deb" || true
-        wget -q --show-progress "${ZENOH_DEB_URL}/libzenohc-dev_${ZENOH_VERSION}-1_${ARCH}.deb" \
-            -O "libzenohc-dev.deb" || true
+        if $INSTALL_ZENOH; then
+            ZENOH_ZIP="libzenohc-${ZENOH_VERSION}-${ZENOH_TARGET}-debian.zip"
+            ZENOH_ZIP_URL="https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOH_VERSION}/${ZENOH_ZIP}"
 
-        if [[ -f libzenohc.deb && -f libzenohc-dev.deb ]]; then
-            sudo dpkg -i libzenohc.deb libzenohc-dev.deb || sudo apt-get -f install -y
+            info "Downloading zenohc ${ZENOH_VERSION} for ${ZENOH_TARGET}..."
+            wget -q --show-progress "${ZENOH_ZIP_URL}" -O "${ZENOH_ZIP}" || true
+
+            if [[ ! -f "${ZENOH_ZIP}" ]] || [[ ! -s "${ZENOH_ZIP}" ]]; then
+                fail "Download failed. Check the URL: ${ZENOH_ZIP_URL}"
+                warn "Browse releases at: https://github.com/eclipse-zenoh/zenoh-c/releases"
+                SKIPPED+=("Zenoh")
+                INSTALL_ZENOH=false
+            fi
+        fi
+
+        if $INSTALL_ZENOH; then
+            info "Extracting .deb packages..."
+            unzip -o "${ZENOH_ZIP}" -d .
+
+            if ls libzenohc_*.deb 1>/dev/null 2>&1 && ls libzenohc-dev_*.deb 1>/dev/null 2>&1; then
+                sudo dpkg -i libzenohc_*.deb libzenohc-dev_*.deb || sudo apt-get -f install -y
             sudo ldconfig
             if pkg-config --exists zenohc 2>/dev/null; then
                 VER="$(pkg-config --modversion zenohc)"
@@ -427,11 +502,13 @@ if $INSTALL_ZENOH; then
                 warn "zenohc installed but pkg-config doesn't see it."
                 INSTALLED+=("Zenoh zenohc ${ZENOH_VERSION} (no pkg-config)")
             fi
-        else
-            warn "Could not download zenohc .deb packages."
-            warn "Try manual install: https://github.com/eclipse-zenoh/zenoh-c/releases"
-            SKIPPED+=("Zenoh")
-            INSTALL_ZENOH=false
+            else
+                warn "Extracted zip but .deb files not found. Contents:"
+                ls -la "$ZENOH_TMP"
+                warn "Try manual install: https://github.com/eclipse-zenoh/zenoh-c/releases"
+                SKIPPED+=("Zenoh")
+                INSTALL_ZENOH=false
+            fi
         fi
 
         # Install zenoh-cpp (header-only C++17 bindings)

--- a/docs/guides/DESIGN_RATIONALE.md
+++ b/docs/guides/DESIGN_RATIONALE.md
@@ -382,3 +382,24 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 **When to revisit:** When a third OpenCV HAL backend is added, or when the Cosys-AirSim migration to STATIC happens — do both splits together.
 
 **Date:** 2026-04-14
+
+---
+
+## DR-016: rpclib Downloaded Into Submodule Working Tree
+
+**Question:** The `FindAirSim.cmake` module downloads rpclib into `third_party/cosys-airsim/external/rpclib/`, which dirties the submodule working tree. Should we download into `${CMAKE_BINARY_DIR}` instead?
+
+**For moving to CMAKE_BINARY_DIR:**
+- Clean submodule (`git status` shows no untracked files)
+- Standard CMake practice (FetchContent, ExternalProject all use binary dir)
+- Less confusing for developers who check submodule status
+
+**For keeping in submodule tree:**
+- AirSim's own `cmake/CMakeLists.txt` hardcodes `find_path(... PATHS ${AIRSIM_ROOT}/external/rpclib/rpclib-2.3.1)` — the build expects rpclib at that exact relative path
+- Moving it would require patching AirSim's CMakeLists, defeating the purpose of vendoring an unmodified upstream
+- The `external/rpclib/` directory is already in `.gitignore` (or should be) since AirSim's own `setup.sh` downloads it there too
+- Only happens once (cached after first configure)
+
+**Decision:** Keep rpclib in the submodule tree. The cost of a "dirty" submodule is low (add to `.gitignore`), while patching AirSim's build creates maintenance burden on every upstream update.
+
+**Revisit when:** AirSim's CMake is refactored to accept external rpclib paths, or we fork the repo and can control the build system.

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -13,6 +13,8 @@ This guide takes you from a **fresh clone to a working build** in under 10 minut
 - **Resources:** 4 GB RAM (minimum), 8+ GB disk space, 2 cores (minimum)
 - **User:** Can be any user; `sudo` access required for real-time scheduling (optional)
 
+> **Conda/Anaconda Warning:** If you have Conda installed, run `conda deactivate` before building. Conda ships its own `libfmt`, `libstdc++`, and `GTest` that conflict with system libraries and cause linker errors. See [INSTALL.md](INSTALL.md) for details.
+
 ### Check Your System
 
 ```bash
@@ -67,10 +69,27 @@ sudo apt-get update
 sudo apt-get install -y \
     build-essential \
     cmake \
+    git \
+    pkg-config \
+    wget \
+    unzip \
     libspdlog-dev \
+    libfmt-dev \
     libeigen3-dev \
     nlohmann-json3-dev \
     libgtest-dev
+```
+
+**Zenoh IPC (required):**
+```bash
+# Zenoh is the sole IPC backend — not available via apt
+# See docs/guides/INSTALL.md Section 3 for full instructions
+ZENOH_VERSION="1.7.2"
+wget "https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOH_VERSION}/libzenohc-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-debian.zip"
+unzip libzenohc-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-debian.zip
+sudo dpkg -i libzenohc_*.deb libzenohc-dev_*.deb && sudo ldconfig
+rm -f libzenohc-*.zip libzenohc_*.deb libzenohc-dev_*.deb
+# Also install zenoh-cpp headers — see INSTALL.md Section 3.2
 ```
 
 **Optional (recommended):**
@@ -79,13 +98,10 @@ sudo apt-get install -y \
 sudo apt-get install -y libopencv-dev
 
 # MAVSDK (for PX4 MAVLink communication)
-# Build from source — see docs/INSTALL.md
+# Build from source — see docs/guides/INSTALL.md Section 5
 
 # Gazebo (for SITL simulation)
-sudo apt-get install -y gz-harmonic
-
-# Zenoh (for network IPC — usually pre-installed)
-# Pre-built debs at: https://github.com/eclipse-zenoh/zenoh-c/releases
+sudo apt-get install -y gz-harmonic libgz-transport13-dev libgz-msgs10-dev
 ```
 
 > **Note:** If you choose `--core-only`, you can still build and test everything — optional backends are auto-detected and skipped gracefully.
@@ -326,12 +342,17 @@ ctest -N --test-dir build | grep "Total Tests:"
 ```
 companion_software_stack/
   ├── README.md                    ← Read next (architecture overview)
-  ├── docs/
-  │   ├── GETTING_STARTED.md       ← You are here
-  │   ├── DEVELOPMENT_WORKFLOW.md  ← Read if you want to contribute
-  │   ├── API.md                   ← IPC message types
-  │   ├── HARDWARE_SETUP.md        ← Real Jetson Orin setup
-  │   └── DEBUG.md                 ← Debugging tips
+  ├── common/
+  │   ├── hal/                     ← Hardware Abstraction Layer (interfaces + backends)
+  │   ├── ipc/                     ← Zenoh IPC (publisher/subscriber/MessageBus)
+  │   └── util/                    ← Config, Result<T,E>, logging, watchdog
+  ├── process1_video_capture/      ← P1: Camera frame acquisition
+  ├── process2_perception/         ← P2: Detection + tracking + sensor fusion
+  ├── process3_slam_vio_nav/       ← P3: Visual-inertial odometry + navigation
+  ├── process4_mission_planner/    ← P4: FSM + path planning + obstacle avoidance
+  ├── process5_comms/              ← P5: Flight controller & GCS communication
+  ├── process6_payload_manager/    ← P6: Gimbal & camera control
+  ├── process7_system_monitor/     ← P7: Health monitoring & process supervision
   ├── config/
   │   └── default.json             ← All tunables (camera res, detect threshold, etc.)
   ├── deploy/
@@ -342,49 +363,53 @@ companion_software_stack/
   ├── tests/
   │   ├── run_tests.sh             ← Run all tests (see TESTS.md for count)
   │   └── TESTS.md                 ← Test inventory
-  └── src/
-      ├── process1_video_capture/
-      ├── process2_perception/
-      ├── process3_slam_vio_nav/
-      ├── process4_mission_planner/
-      ├── process5_comms/
-      ├── process6_payload_manager/
-      └── process7_system_monitor/
+  └── docs/
+      ├── guides/
+      │   ├── GETTING_STARTED.md   ← You are here
+      │   ├── INSTALL.md           ← Detailed installation guide
+      │   └── DEVELOPMENT_WORKFLOW.md ← Read if you want to contribute
+      └── design/
+          └── API.md               ← IPC message types
 ```
 
 ---
 
-## Typical First Session (10 minutes)
+## Typical First Session
 
 ```bash
 # 1. Clone (1 min)
 git clone https://github.com/nmohamaya/companion_software_stack.git
 cd companion_software_stack
 
-# 2. Install deps (3 min, mostly waiting for apt)
+# 2. Install deps
+#    Core only: ~5 min (apt + Zenoh .deb)
+#    Full (+ OpenCV source + MAVSDK source + Gazebo + PX4): ~1-2 hours
 bash deploy/install_dependencies.sh --all
 
-# 3. Build (3 min)
+# 3. Build (3-5 min)
 bash deploy/build.sh
 
-# 4. Test (2 min)
+# 4. Test (1-2 min)
 bash tests/run_tests.sh
 
-# 5. Run Gazebo (1+ min of autonomous flight)
+# 5. Run simulated stack (no Gazebo needed)
+bash deploy/launch_all.sh
+
+# 6. Run with Gazebo SITL (requires Gazebo + MAVSDK + PX4)
 bash deploy/launch_gazebo.sh --gui
 ```
 
-**Total time:** ~10–12 minutes, mostly automated.
+**Total time:** ~10 minutes for core-only build+test, ~1-2 hours for full environment with all optional deps.
 
 ---
 
 ## Questions?
 
-- **How do I contribute?** → [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) (Steps 1–9)
+- **How do I contribute?** → [DEVELOPMENT_WORKFLOW.md](DEVELOPMENT_WORKFLOW.md) (Steps 1-9)
 - **What's the architecture?** → [README.md](../../README.md#architecture)
-- **How do I debug a crash?** → [Debugging workflow](../architecture/SIMULATION_ARCHITECTURE.md#debugging-workflow)
+- **Detailed installation/troubleshooting?** → [INSTALL.md](INSTALL.md)
 - **Real hardware setup?** → [README.md](../../README.md#launch-on-real-hardware)
-- **IPC message types?** → [docs/API.md](../design/API.md)
+- **IPC message types?** → [API.md](../design/API.md)
 
 ---
 

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -296,7 +296,8 @@ cmake \
 
 | Issue | Symptom | Fix |
 |---|---|---|
-| **Stale source build with CUDA** | CMake error: `Could NOT find CUDA: Found unsuitable version` | Old OpenCV at `/usr/local` was built against a different CUDA. Fix: `-DOpenCV_DIR=/usr/lib/x86_64-linux-gnu/cmake/opencv4` to force apt version, or remove stale build: `sudo rm -rf /usr/local/lib/cmake/opencv4 /usr/local/lib/libopencv*` |
+| **Stale source build with CUDA** | CMake error: `Could NOT find CUDA: Found unsuitable version` | Old OpenCV at `/usr/local` was built against a different CUDA. Remove stale build: `sudo rm -rf /usr/local/lib/cmake/opencv4 /usr/local/lib/libopencv*` and rebuild from source |
+| **CMake finds apt OpenCV instead of source build** | `OpenCV : 4.5.4` when 4.10.0 is installed at `/usr/local` | Remove the apt package: `sudo apt-get remove -y libopencv-dev && sudo ldconfig`. Having both causes version confusion. |
 | **pkg-config finds apt version instead of source build** | CMake picks up 4.6.0 when 4.10.0 is installed to `/usr/local` | Set `OpenCV_DIR=/usr/local/lib/cmake/opencv4` or uninstall `libopencv-dev` |
 | **Missing protobuf for DNN** | `cv::dnn::readNetFromONNX()` fails at build time | Add `-DWITH_PROTOBUF=ON -DBUILD_PROTOBUF=ON` to the OpenCV CMake flags |
 | **Anaconda/Conda conflicts** | Linker picks up Conda's older `libstdc++.so` | `conda deactivate` before building |

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -4,16 +4,23 @@ Step-by-step instructions for setting up the Drone Companion Software Stack on a
 
 | Dependency Level | Libraries | What It Enables |
 |---|---|---|
-| **Core (required)** | spdlog, Eigen3, nlohmann-json, GTest | Full stack with simulated backends; all tests pass |
+| **Core (required)** | spdlog, fmt, Eigen3, nlohmann-json, GTest, Zenoh | Full stack with simulated backends; all tests pass |
 | **Optional: OpenCV** | OpenCV 4.x with DNN module | `OpenCvYoloDetector` — YOLOv8-nano object detection via ONNX |
 | **Optional: MAVSDK** | MAVSDK 2.x | `MavlinkFCLink` — real MAVLink communication with PX4 flight controller |
 | **Optional: Gazebo** | Gazebo Harmonic (gz-sim 8), gz-transport 13, gz-msgs 10 | `GazeboCamera`, `GazeboIMU`, `GazeboVIOBackend` — SITL simulation with PX4 |
+| **Optional: Cosys-AirSim** | AirSim C++ SDK (vendored submodule) | `CosysCamera`, `CosysRadar`, `CosysIMU`, `CosysDepth` — photorealistic simulation |
+
+> **Conda/Anaconda Warning:** If you have Conda installed, **deactivate it before building:**
+> ```bash
+> conda deactivate
+> ```
+> Conda ships its own `libfmt`, `libstdc++`, and `libprotobuf` which conflict with system libraries. Symptoms: linker errors about `libfmt.so.9` conflicting with `libfmt.so.8`, or `GLIBCXX_3.4.30 not found`. The launch scripts handle this automatically, but **you must deactivate Conda for building and CMake configuration.**
 
 ---
 
 ## 1. Prerequisites
 
-**Tested on:** Ubuntu 24.04 LTS (x86_64) with GCC 13.3 and CMake 3.28.
+**Tested on:** Ubuntu 22.04 LTS and Ubuntu 24.04 LTS (x86_64) with GCC 11.4+ and CMake 3.22+.
 
 ```bash
 # Update package lists
@@ -26,8 +33,21 @@ sudo apt-get install -y \
     git \
     pkg-config \
     wget \
-    curl
+    curl \
+    unzip
 ```
+
+### Ubuntu 22.04 vs 24.04 Differences
+
+| Package | Ubuntu 22.04 | Ubuntu 24.04 | Notes |
+|---|---|---|---|
+| GCC | 11.4 | 13.3 | Both work; 22.04 has stricter enum/ternary warnings |
+| spdlog | 1.9.2 | 1.12.0 | 22.04 version links against `libfmt.so.8` separately |
+| fmt | 8.1.1 (separate) | 10.x (bundled with spdlog) | On 22.04, install `libfmt-dev` explicitly |
+| OpenCV | 4.5.4 (apt) | 4.6.0 (apt) | Both work for DNN; 4.10 from source recommended |
+| CMake | 3.22 | 3.28 | Both work |
+| clang-format-18 | Needs LLVM apt repo | Available in default repos | See Section 7 |
+| nlohmann-json | 3.10.5 | 3.11.3 | Both work |
 
 ---
 
@@ -38,48 +58,98 @@ These are needed for every build. The CI pipeline installs only these.
 ```bash
 sudo apt-get install -y --no-install-recommends \
     libspdlog-dev \
+    libfmt-dev \
     libeigen3-dev \
     nlohmann-json3-dev \
     libgtest-dev
 ```
 
-| Library | Version (Ubuntu 24.04) | Purpose |
-|---|---|---|
-| spdlog | 1.12.0 | Structured logging (all 7 processes) |
-| Eigen3 | 3.4.0 | Linear algebra — Kalman filter, pose math, path planning |
-| nlohmann-json | 3.11.3 | JSON config parsing (`Config` class) |
-| GTest | 1.14.0 | Unit testing framework |
+| Library | Purpose |
+|---|---|
+| spdlog | Structured logging (all 7 processes) |
+| fmt | String formatting (spdlog dependency, explicit on 22.04) |
+| Eigen3 | Linear algebra — Kalman filter, pose math, path planning |
+| nlohmann-json | JSON config parsing (`Config` class) |
+| GTest | Unit testing framework |
 
-### Minimal Build (No Optional Dependencies)
+---
+
+## 3. Zenoh IPC Backend (Required)
+
+Zenoh is the **sole IPC backend** for the companion stack. It provides high-performance publish/subscribe with zero-copy, peer-to-peer networking, and multi-machine support. The stack will not build without it.
+
+Zenoh is not available via apt — install from GitHub releases.
+
+### Step 3.1: Install zenohc (C library)
+
+```bash
+ZENOH_VERSION="1.7.2"
+
+# Download the release zip (contains .deb packages)
+wget "https://github.com/eclipse-zenoh/zenoh-c/releases/download/${ZENOH_VERSION}/libzenohc-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-debian.zip"
+
+# Extract and install
+unzip libzenohc-${ZENOH_VERSION}-x86_64-unknown-linux-gnu-debian.zip
+sudo dpkg -i libzenohc_*.deb libzenohc-dev_*.deb
+sudo ldconfig
+
+# Clean up
+rm -f libzenohc-*.zip libzenohc_*.deb libzenohc-dev_*.deb
+
+# Verify
+pkg-config --modversion zenohc
+# Should print: 1.7.2
+```
+
+**For aarch64 (Jetson Orin):** Replace `x86_64-unknown-linux-gnu` with `aarch64-unknown-linux-gnu` in the URL.
+
+### Step 3.2: Install zenoh-cpp (C++ headers)
+
+```bash
+cd /tmp
+git clone --depth 1 --branch 1.7.2 https://github.com/eclipse-zenoh/zenoh-cpp.git
+cd zenoh-cpp
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr/local -DZENOHCXX_ZENOHC=OFF
+sudo cmake --install build
+cd ~ && rm -rf /tmp/zenoh-cpp
+
+# Verify
+ls /usr/local/include/zenoh.hxx
+# Should exist
+```
+
+### Minimal Build (Core + Zenoh Only)
 
 ```bash
 cd companion_software_stack
 mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
 make -j$(nproc)
 ctest --output-on-failure -j$(nproc)
 ```
 
-You should see all tests pass and 7 binaries in `build/bin/`. The stack runs with simulated backends — no hardware, OpenCV, MAVSDK, or Gazebo needed.
+`ALLOW_INSECURE_ZENOH=ON` is required on dev machines without TLS certificates. You should see all tests pass and 7 binaries in `build/bin/`. The stack runs with simulated backends — no hardware, OpenCV, MAVSDK, or Gazebo needed.
 
 ---
 
-## 3. OpenCV 4.10 (Optional — YOLOv8 Detection)
+## 4. OpenCV 4.10 (Optional — YOLOv8 Detection)
 
 ### Why OpenCV?
 
 The `OpenCvYoloDetector` backend uses OpenCV's DNN module to run a YOLOv8-nano ONNX model for 80-class object detection. This gives real object detection (people, vehicles, animals, etc.) instead of the random bounding boxes from the simulated detector or the color-only detection from `ColorContourDetector`.
 
 **What it enables:**
-- `"backend": "yolov8"` in config → `OpenCvYoloDetector`
-- Loads `models/yolov8n.onnx` (12.8 MB), runs inference at ~7–13 FPS on CPU
+- `"backend": "yolov8"` in config -> `OpenCvYoloDetector`
+- Loads `models/yolov8n.onnx` (12.8 MB), runs inference at ~7-13 FPS on CPU
 - 80 COCO classes mapped to internal `ObjectClass` enum (PERSON, VEHICLE_CAR, etc.)
 
 **Without OpenCV:** The stack still builds and runs. The `ColorContourDetector` (pure C++ HSV segmentation) or `SimulatedDetector` are always available.
 
 ### Option A: Build from Source (Recommended)
 
-The Ubuntu 24.04 `libopencv-dev` package (4.6.0) works but is older. Building from source gets you 4.10.0 with optimized DNN support:
+The Ubuntu apt package works but is older (4.5.4 on 22.04, 4.6.0 on 24.04). Building from source gets you 4.10.0 with optimized DNN support:
 
 ```bash
 # Install build dependencies
@@ -98,7 +168,7 @@ cd /tmp
 git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv.git
 git clone --depth 1 --branch 4.10.0 https://github.com/opencv/opencv_contrib.git
 
-# Build with DNN module enabled
+# Build with DNN module enabled (no CUDA — avoids version pinning issues)
 mkdir -p opencv/build && cd opencv/build
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
@@ -112,6 +182,7 @@ cmake \
     -DWITH_PROTOBUF=ON \
     -DBUILD_PROTOBUF=ON \
     -DOPENCV_DNN_OPENCL=OFF \
+    -DWITH_CUDA=OFF \
     ..
 
 make -j$(nproc)
@@ -119,7 +190,7 @@ sudo make install
 sudo ldconfig
 ```
 
-**Build time:** ~10–20 minutes depending on CPU cores.
+**Build time:** ~10-20 minutes depending on CPU cores.
 
 ### Option B: Ubuntu Package (Simpler, Older Version)
 
@@ -127,52 +198,120 @@ sudo ldconfig
 sudo apt-get install -y libopencv-dev
 ```
 
-This installs OpenCV 4.6.0 on Ubuntu 24.04. It works but may lack some DNN optimizations present in 4.10.0.
+This installs OpenCV 4.5.4 (22.04) or 4.6.0 (24.04). It works but may lack some DNN optimizations present in 4.10.0.
 
 ### Verify OpenCV Installation
 
 ```bash
 pkg-config --modversion opencv4
-# Should print 4.10.0 (from source) or 4.6.0 (from apt)
+# Should print 4.10.0 (from source) or 4.5.4/4.6.0 (from apt)
 ```
 
 Then rebuild the stack — CMake will auto-detect OpenCV:
 
 ```bash
 cd companion_software_stack/build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
 # Look for: "OpenCV : 4.10.0 — YOLOv8 detector available"
 make -j$(nproc)
 ```
+
+### Downloading ML Models
+
+The stack uses two ONNX models for perception. Download scripts are provided in `models/`:
+
+**YOLOv8n (object detection, 12.8 MB):**
+```bash
+# Option A: Direct download (no Python deps needed)
+mkdir -p models
+wget -O models/yolov8n.onnx \
+    https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.onnx
+
+# Option B: Export via script (requires: pip install ultralytics)
+bash models/download_yolov8n.sh
+```
+
+**Depth Anything V2 ViT-S (monocular depth estimation, ~95 MB):**
+```bash
+# Must use the export script — raw HuggingFace ONNX is not compatible with
+# OpenCV DNN (Resize node format mismatch). The script applies graph surgery
+# to fix this.
+# Use a venv to keep system Python clean:
+python3 -m venv .venv
+source .venv/bin/activate
+pip install torch transformers onnx onnxruntime onnxsim
+bash models/download_depth_anything_v2.sh
+deactivate
+```
+
+> **Note:** Both models are optional. Without them, the corresponding test suites skip (13 tests) but everything else works. The YOLOv8 model can be exported via the `ultralytics` Python package; the DA V2 model **must** be exported via the script due to OpenCV DNN compatibility requirements.
+>
+> **DA V2 requires OpenCV 4.10+ at runtime.** The apt version (4.5.4 on 22.04, 4.6.0 on 24.04) cannot parse the `ReduceMean` ONNX node. If DA V2 model tests fail with "parse error: Required argument keepdims not found", build OpenCV 4.10 from source (Option A above).
+
+### Option C: Build from Source with CUDA (GPU-Accelerated DNN)
+
+If you have an NVIDIA GPU and want GPU-accelerated inference, add CUDA flags. **Requires CUDA 11.8+ and cuDNN 8.6+** (CUDA 11.5 is not compatible with OpenCV 4.10 CUDA modules).
+
+```bash
+# Same as Option A, but with CUDA enabled
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr/local \
+    -DOPENCV_EXTRA_MODULES_PATH=/tmp/opencv_contrib/modules \
+    -DBUILD_LIST=core,imgproc,dnn,imgcodecs,highgui,cudev \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_PERF_TESTS=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_opencv_python3=OFF \
+    -DWITH_PROTOBUF=ON \
+    -DBUILD_PROTOBUF=ON \
+    -DWITH_CUDA=ON \
+    -DWITH_CUDNN=ON \
+    -DOPENCV_DNN_CUDA=ON \
+    -DCUDA_ARCH_BIN=6.1 \
+    ..
+```
+
+**`CUDA_ARCH_BIN` values by GPU:**
+
+| GPU | Architecture | `CUDA_ARCH_BIN` |
+|---|---|---|
+| GTX 1080 Ti | Pascal | 6.1 |
+| RTX 2080 / T1000 | Turing | 7.5 |
+| RTX 3090 / A10G | Ampere | 8.6 |
+| Jetson Orin | Ampere | 8.7 |
+
+**If CUDA nvcc rejects your GCC version** (e.g., CUDA 11.x doesn't support GCC 13), point CUDA at an older host compiler:
+```bash
+-DCUDA_HOST_COMPILER=/usr/bin/g++-11
+```
+
+**Note:** `BUILD_LIST` must include `cudev` (from opencv_contrib) when CUDA is enabled.
+
+> **GPU rendering vs CUDA compute:** UE5 and Cosys-AirSim use the GPU directly for rendering via Vulkan — they do **not** require the CUDA toolkit. CUDA is only needed for GPU-accelerated ML inference (OpenCV DNN CUDA, TensorRT). If your CUDA toolkit is older than 11.8, build OpenCV without CUDA (`-DWITH_CUDA=OFF`) — CPU DNN inference still works.
 
 ### Known Issues — OpenCV
 
 | Issue | Symptom | Fix |
 |---|---|---|
+| **Stale source build with CUDA** | CMake error: `Could NOT find CUDA: Found unsuitable version` | Old OpenCV at `/usr/local` was built against a different CUDA. Fix: `-DOpenCV_DIR=/usr/lib/x86_64-linux-gnu/cmake/opencv4` to force apt version, or remove stale build: `sudo rm -rf /usr/local/lib/cmake/opencv4 /usr/local/lib/libopencv*` |
 | **pkg-config finds apt version instead of source build** | CMake picks up 4.6.0 when 4.10.0 is installed to `/usr/local` | Set `OpenCV_DIR=/usr/local/lib/cmake/opencv4` or uninstall `libopencv-dev` |
 | **Missing protobuf for DNN** | `cv::dnn::readNetFromONNX()` fails at build time | Add `-DWITH_PROTOBUF=ON -DBUILD_PROTOBUF=ON` to the OpenCV CMake flags |
-| **Anaconda/Conda conflicts** | Linker picks up Conda's older `libstdc++.so` | `export LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"` before building |
+| **Anaconda/Conda conflicts** | Linker picks up Conda's older `libstdc++.so` | `conda deactivate` before building |
 | **ONNX model not found** | Runtime error: "Failed to load model" | Download `yolov8n.onnx` from [Ultralytics](https://github.com/ultralytics/assets/releases) into `models/` |
-| **`swapRB` confusion** | Wrong colors in detection (model expects RGB) | Our code uses `swapRB=false` because input frames are already RGB from SHM |
-
-### Downloading the YOLOv8n Model
-
-```bash
-mkdir -p models
-wget -O models/yolov8n.onnx \
-    https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.onnx
-```
 
 ---
 
-## 4. MAVSDK 2.x (Optional — PX4 MAVLink Communication)
+## 5. MAVSDK 2.x (Optional — PX4 MAVLink Communication)
 
 ### Why MAVSDK?
 
 MAVSDK provides a high-level C++ API for MAVLink communication with the PX4 flight controller. It enables the `MavlinkFCLink` HAL backend, which sends/receives real commands (arm, takeoff, position setpoints, telemetry) over UDP to PX4 SITL or a physical flight controller over serial UART.
 
 **What it enables:**
-- `"backend": "mavlink"` in comms config → `MavlinkFCLink`
+- `"backend": "mavlink"` in comms config -> `MavlinkFCLink`
 - Real arming, takeoff, landing, position commands via MAVLink 2
 - Telemetry: battery, GPS, attitude, flight mode, armed state
 
@@ -205,7 +344,7 @@ sudo cmake --install build
 sudo ldconfig
 ```
 
-**Build time:** ~15–30 minutes (downloads MAVLink definitions during build).
+**Build time:** ~15-30 minutes (downloads MAVLink definitions during build).
 
 ### Verify MAVSDK Installation
 
@@ -215,7 +354,9 @@ ls /usr/local/lib/libmavsdk.so
 
 # Rebuild the stack
 cd companion_software_stack/build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
 # Look for: "MAVSDK : 2.12.12 — MavlinkFCLink backend available"
 make -j$(nproc)
 ```
@@ -232,7 +373,7 @@ make -j$(nproc)
 
 ---
 
-## 5. Gazebo Harmonic + PX4 SITL (Optional — Full Simulation)
+## 6. Gazebo Harmonic + PX4 SITL (Optional — Full Simulation)
 
 ### Why Gazebo?
 
@@ -246,7 +387,7 @@ Gazebo Harmonic (gz-sim 8) provides a physics-based 3D simulation environment. C
 
 **Without Gazebo:** The stack uses simulated backends (synthetic gradient images, circular trajectory pose, random IMU noise). Everything works, just not with physics or rendered visuals.
 
-### Step 5.1: Install Gazebo Harmonic
+### Step 6.1: Install Gazebo Harmonic
 
 Follow the [official installation guide](https://gazebosim.org/docs/harmonic/install_ubuntu):
 
@@ -267,7 +408,9 @@ sudo apt-get install -y \
     libgz-msgs10-dev
 ```
 
-### Step 5.2: Install PX4-Autopilot
+> **Note:** The CMake build system also supports Gazebo Ionic (gz-transport14 / gz-msgs11) and will auto-detect whichever version is installed.
+
+### Step 6.2: Install PX4-Autopilot
 
 ```bash
 cd ~
@@ -281,9 +424,9 @@ bash Tools/setup/ubuntu.sh
 make px4_sitl_default
 ```
 
-**Build time:** ~20–40 minutes on first build.
+**Build time:** ~20-40 minutes on first build.
 
-### Step 5.3: Set Up Simulation Assets
+### Step 6.3: Set Up Simulation Assets
 
 The companion stack includes custom Gazebo world and drone model files that need to be linked into PX4's resource directories:
 
@@ -302,11 +445,13 @@ ln -sf "$(pwd)/sim/models/x500_companion" \
     "${PX4_DIR}/Tools/simulation/gz/models/x500_companion"
 ```
 
-### Step 5.4: Rebuild Stack with Gazebo Support
+### Step 6.4: Rebuild Stack with Gazebo Support
 
 ```bash
 cd companion_software_stack/build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
 # Should show:
 #   MAVSDK       : 2.12.12 — MavlinkFCLink backend available
 #   OpenCV       : 4.10.0 — YOLOv8 detector available
@@ -314,7 +459,7 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j$(nproc)
 ```
 
-### Step 5.5: Run the Full SITL Stack
+### Step 6.5: Run the Full SITL Stack
 
 ```bash
 # Headless (no GUI)
@@ -337,49 +482,94 @@ The launch script:
 |---|---|---|
 | **Gazebo GUI won't start** | `gz sim -g` crashes or shows black screen | Often caused by Snap-installed Gazebo conflicting with apt. Remove Snap version: `sudo snap remove gz-harmonic` |
 | **Anaconda `libstdc++` conflict** | Runtime crash with `GLIBCXX_3.4.30 not found` | Deactivate Conda: `conda deactivate`, or set `LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"`. The launch script does this automatically. |
-| **PX4 can't find world/model** | "World file not found" or model doesn't spawn | Ensure the symlinks from Step 5.3 are correct. Check `GZ_SIM_RESOURCE_PATH` includes both `sim/models/` and PX4's model directory. |
-| **GUI detaches/lags** | GUI renders but doesn't show the drone | Give PX4 ~5–8 seconds to spawn the model before launching GUI. The launch script handles this with `sleep 3`. |
+| **PX4 can't find world/model** | "World file not found" or model doesn't spawn | Ensure the symlinks from Step 6.3 are correct. Check `GZ_SIM_RESOURCE_PATH` includes both `sim/models/` and PX4's model directory. |
+| **GUI detaches/lags** | GUI renders but doesn't show the drone | Give PX4 ~5-8 seconds to spawn the model before launching GUI. The launch script handles this with `sleep 3`. |
 | **"Address already in use" on port 14540** | Stale PX4 instance from a previous run | `pkill -f px4; sleep 2` before relaunching |
 | **Protobuf version mismatch** | Link errors about `google::protobuf` when building with both Gazebo and OpenCV | Build OpenCV with `-DBUILD_PROTOBUF=ON` to use its bundled protobuf, or ensure system protobuf version matches what Gazebo was built against |
 | **Camera follow doesn't work in GUI** | Drone flies but camera stays at origin | The launch script sends `gz service` commands after an 8-second delay. If PX4 takes longer to initialize, increase the sleep in the GUI follow section. |
 
 ---
 
-## 6. Complete Installation (All Dependencies)
+## 7. Developer Tooling
 
-For the full experience with all backends enabled:
+### clang-format-18
+
+Required for the format gate (CI enforces `clang-format-18 --Werror`).
+
+**Ubuntu 24.04:**
+```bash
+sudo apt-get install -y clang-format-18
+```
+
+**Ubuntu 22.04** (needs LLVM apt repository):
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+sudo apt-get install -y clang-format-18
+rm llvm.sh
+```
+
+### Verify
 
 ```bash
-# 1. Core (required)
-sudo apt-get update
-sudo apt-get install -y \
-    build-essential cmake git pkg-config wget curl \
-    libspdlog-dev libeigen3-dev nlohmann-json3-dev libgtest-dev
-
-# 2. OpenCV 4.10 from source (see Section 3 for full commands)
-#    ...or quick: sudo apt-get install -y libopencv-dev
-
-# 3. MAVSDK 2.x from source (see Section 4)
-#    No apt package available
-
-# 4. Gazebo Harmonic (see Section 5)
-sudo apt-get install -y gz-harmonic libgz-transport13-dev libgz-msgs10-dev
-
-# 5. PX4 SITL (see Section 5.2)
-cd ~ && git clone --recursive https://github.com/PX4/PX4-Autopilot.git
-cd PX4-Autopilot && bash Tools/setup/ubuntu.sh && make px4_sitl_default
-
-# 6. Build the companion stack
-cd companion_software_stack
-mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
-make -j$(nproc)
-ctest --output-on-failure -j$(nproc)
+clang-format-18 --version
+# Should print: clang-format version 18.x.x
 ```
 
 ---
 
-## 7. Build System Reference
+## 8. Complete Installation (All Dependencies)
+
+For the full experience with all backends enabled:
+
+```bash
+# 0. Deactivate Conda if active
+conda deactivate 2>/dev/null || true
+
+# 1. Core (required)
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential cmake git pkg-config wget curl unzip \
+    libspdlog-dev libfmt-dev libeigen3-dev nlohmann-json3-dev libgtest-dev
+
+# 2. Zenoh (required) — see Section 3 for full commands
+#    Download .zip from GitHub releases, extract, dpkg -i
+
+# 3. OpenCV 4.10 from source (see Section 4 for full commands)
+#    ...or quick: sudo apt-get install -y libopencv-dev
+
+# 4. MAVSDK 2.x from source (see Section 5)
+#    No apt package available
+
+# 5. Gazebo Harmonic (see Section 6)
+sudo apt-get install -y gz-harmonic libgz-transport13-dev libgz-msgs10-dev
+
+# 6. PX4 SITL (see Section 6.2)
+cd ~ && git clone --recursive https://github.com/PX4/PX4-Autopilot.git
+cd PX4-Autopilot && bash Tools/setup/ubuntu.sh && make px4_sitl_default
+
+# 7. Developer tooling (see Section 7)
+sudo apt-get install -y clang-format-18  # 24.04 only; see Section 7 for 22.04
+
+# 8. Build the companion stack
+cd companion_software_stack
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
+make -j$(nproc)
+ctest --output-on-failure -j$(nproc)
+```
+
+Or use the automated installer:
+```bash
+bash deploy/install_dependencies.sh --all
+```
+
+---
+
+## 9. Build System Reference
 
 ### CMake Configure Summary
 
@@ -390,9 +580,14 @@ After running `cmake`, look at the summary printed at the end:
   Drone Companion Stack v1.0.0
   C++ Standard : C++17
   Build Type   : Release
-  MAVSDK       : 1         (or empty = not found)
-  Gazebo       : TRUE      (or FALSE)
-  OpenCV       : TRUE      (or FALSE)
+  MAVSDK       : 2.12.12 (or 0 = not found)
+  Gazebo       : TRUE (or FALSE)
+  Cosys-AirSim : TRUE (or FALSE)
+  OpenCV       : TRUE (or FALSE)
+  Zenoh        : REQUIRED
+  Model Preset : edge (or orin / cloud / dev)
+  Plugins      : ON (or OFF)
+  systemd      : ON (or OFF)
 ════════════════════════════════════════════
 ```
 
@@ -400,21 +595,25 @@ After running `cmake`, look at the summary printed at the end:
 
 | Define | Set When | Effect |
 |---|---|---|
-| `HAS_OPENCV` | `find_package(OpenCV)` succeeds | Enables `OpenCvYoloDetector` class and YOLOv8 test suite |
+| `HAS_OPENCV` | `find_package(OpenCV)` succeeds | Enables `OpenCvYoloDetector` class, `DepthAnythingV2Estimator`, and ML test suites |
 | `HAVE_MAVSDK` | `find_package(MAVSDK)` succeeds | Enables `MavlinkFCLink` backend in HAL |
 | `HAVE_GAZEBO` | `find_package(gz-transport13)` + `find_package(gz-msgs10)` both succeed | Enables `GazeboCamera`, `GazeboIMU`, `GazeboVIOBackend` backends |
+| `HAVE_COSYS_AIRSIM` | Cosys-AirSim submodule present and built | Enables `CosysCamera`, `CosysRadar`, `CosysIMU`, `CosysDepth` backends |
+| `HAVE_DEPTH_ANYTHING_V2` | OpenCV found + DA V2 source compiled | Enables ML-based monocular depth estimation |
 
 ### Graceful Degradation
 
 The build system is designed so that missing optional dependencies never break the build:
 
-- If OpenCV is missing: `OpenCvYoloDetector` is compiled as a stub that logs a warning. The detector factory falls back to `ColorContourDetector` if `"yolov8"` is requested without OpenCV.
+- If OpenCV is missing: `OpenCvYoloDetector` and `DepthAnythingV2Estimator` compile as stubs that return errors at runtime. The detector factory falls back to `ColorContourDetector`.
 - If MAVSDK is missing: `MavlinkFCLink` is not compiled. The comms process uses `SimulatedFCLink`.
-- If Gazebo is missing: `GazeboCamera`, `GazeboIMU`, and `GazeboVIOBackend` are not compiled. Simulated backends are used instead.
+- If Gazebo is missing: Gazebo backends are not compiled. Simulated backends are used instead.
+- If Cosys-AirSim submodule is missing: AirSim backends compile as stubs (ifdef guards). Run `git submodule update --init third_party/cosys-airsim` to enable.
+- If Zenoh is missing: **Build fails.** Zenoh is the sole IPC backend and is always required.
 
 ---
 
-## 8. Troubleshooting
+## 10. Troubleshooting
 
 ### General
 
@@ -422,15 +621,30 @@ The build system is designed so that missing optional dependencies never break t
 # Clean rebuild (fixes most CMake cache issues)
 rm -rf build
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
+    -DALLOW_INSECURE_ZENOH=ON ..
 make -j$(nproc)
 ```
+
+### Conda/Anaconda Conflicts
+
+Conda is the **#1 source of build failures** on developer machines. It ships its own versions of `libfmt`, `libstdc++`, `libprotobuf`, and `GTest` that conflict with system libraries.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `libfmt.so.8 may conflict with libfmt.so.9` + linker errors | Conda's `libfmt.so.9` conflicts with system spdlog built against `libfmt.so.8` | `conda deactivate` before building |
+| `GLIBCXX_3.4.30 not found` | Conda's older `libstdc++.so.6` | `conda deactivate` or `LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH"` |
+| GTest found at `/home/*/anaconda3/lib/cmake/GTest/` | CMake finds Conda's GTest instead of system | `conda deactivate` or `-DGTest_DIR=/usr/lib/x86_64-linux-gnu/cmake/GTest` |
+| Protobuf version mismatch | Conda's protobuf conflicts with Gazebo's | `conda deactivate` |
+
+**Best practice:** Always `conda deactivate` before any build or CMake operation.
 
 ### Check What CMake Detected
 
 ```bash
 cd build
-grep -E "OPENCV_FOUND|MAVSDK_FOUND|GAZEBO_FOUND" CMakeCache.txt
+grep -E "OPENCV_FOUND|MAVSDK_FOUND|GAZEBO_FOUND|COSYS_AIRSIM_FOUND|zenohc" CMakeCache.txt
 ```
 
 ### Verify Shared Libraries
@@ -444,14 +658,29 @@ ldd build/bin/slam_vio_nav | grep "not found"
 
 If any show "not found", run `sudo ldconfig` or check `LD_LIBRARY_PATH`.
 
-### Clean SHM Segments After Crash
+### Do NOT Build spdlog/fmt from Source
 
-If a process crashes, stale shared memory segments may remain:
+The apt versions of `libspdlog-dev` and `libfmt-dev` work correctly with GCC 13 on Ubuntu 22.04. **Do not build spdlog or fmt from source** — a source-built spdlog installs cmake configs to `/usr/local` that conflict with the apt shared library, causing linker errors like:
+```
+undefined reference to `spdlog::details::log_msg::log_msg(...)'
+```
+If you accidentally installed source-built versions, remove them:
+```bash
+sudo rm -rf /usr/local/lib/cmake/spdlog /usr/local/lib/cmake/fmt \
+    /usr/local/lib/libspdlog* /usr/local/lib/libfmt* \
+    /usr/local/include/spdlog /usr/local/include/fmt
+sudo ldconfig
+```
+
+### ROS2 Coexistence
+
+If ROS2 is installed (e.g., Humble), its `CMAKE_PREFIX_PATH` and `LD_LIBRARY_PATH` entries may interfere. The companion stack does not depend on ROS2. If you see unexpected library resolution, try unsourcing ROS2:
 
 ```bash
-rm -f /dev/shm/drone_* /dev/shm/detected_* /dev/shm/slam_* \
-      /dev/shm/mission_* /dev/shm/trajectory_* /dev/shm/payload_* \
-      /dev/shm/fc_* /dev/shm/gcs_* /dev/shm/system_*
+# Before building:
+unset CMAKE_PREFIX_PATH
+unset AMENT_PREFIX_PATH
+# Or open a fresh terminal without sourcing /opt/ros/humble/setup.bash
 ```
 
 ### Run Tests
@@ -461,7 +690,4 @@ cd build
 ctest --output-on-failure -j$(nproc)
 ```
 
-Expected test counts:
-- **Core only (no optional deps):** ~221 tests
-- **With OpenCV:** ~262 tests (adds YOLOv8 + ColorContourDetector live tests)
-- All should pass with 0 failures.
+Expected: all tests pass. See [tests/TESTS.md](../../tests/TESTS.md) for the current baseline count (varies slightly based on which optional dependencies are detected).

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -661,7 +661,7 @@ If any show "not found", run `sudo ldconfig` or check `LD_LIBRARY_PATH`.
 
 ### Do NOT Build spdlog/fmt from Source
 
-The apt versions of `libspdlog-dev` and `libfmt-dev` work correctly with GCC 13 on Ubuntu 22.04. **Do not build spdlog or fmt from source** — a source-built spdlog installs cmake configs to `/usr/local` that conflict with the apt shared library, causing linker errors like:
+The apt versions of `libspdlog-dev` and `libfmt-dev` work correctly with GCC 11+ (including GCC 13 if installed from PPA) on Ubuntu 22.04 and with GCC 13 on Ubuntu 24.04. **Do not build spdlog or fmt from source** — a source-built spdlog installs cmake configs to `/usr/local` that conflict with the apt shared library, causing linker errors like:
 ```
 undefined reference to `spdlog::details::log_msg::log_msg(...)'
 ```

--- a/models/download_yolov8n.sh
+++ b/models/download_yolov8n.sh
@@ -37,7 +37,7 @@ URLS=(
 
 for url in "${URLS[@]}"; do
     echo "  Trying: $url"
-    if wget -q --show-progress -O "$MODEL_PATH" "$url" 2>/dev/null; then
+    if wget -q --show-progress -O "$MODEL_PATH" "$url"; then
         if [[ -s "$MODEL_PATH" ]]; then
             echo "Downloaded successfully: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
             exit 0

--- a/models/download_yolov8n.sh
+++ b/models/download_yolov8n.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # models/download_yolov8n.sh
-# Downloads and exports YOLOv8-nano to ONNX format for OpenCV DNN.
-# Requires: pip install ultralytics
+# Downloads YOLOv8-nano ONNX model for OpenCV DNN.
+#
+# Method 1 (preferred): Direct download from Ultralytics GitHub releases.
+# Method 2 (fallback):  Export via Python ultralytics package.
 #
 # Usage:
 #   cd <project_root>
@@ -11,14 +13,44 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MODEL_PATH="${SCRIPT_DIR}/yolov8n.onnx"
 
-if [[ -f "$MODEL_PATH" ]]; then
+# Check for existing valid model (not 0-byte)
+if [[ -f "$MODEL_PATH" ]] && [[ -s "$MODEL_PATH" ]]; then
     echo "Model already exists: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
     exit 0
 fi
 
-echo "Downloading and exporting YOLOv8n to ONNX..."
+# Remove 0-byte files from failed downloads
+if [[ -f "$MODEL_PATH" ]] && [[ ! -s "$MODEL_PATH" ]]; then
+    echo "Removing empty model file from previous failed download..."
+    rm -f "$MODEL_PATH"
+fi
 
-python3 -c "
+echo "Downloading YOLOv8n ONNX model..."
+
+# Method 1: Direct download (no Python deps needed)
+# Try multiple known URLs for the pre-exported ONNX model
+URLS=(
+    "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov8n.onnx"
+    "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8n.onnx"
+    "https://github.com/ultralytics/assets/releases/download/v8.1.0/yolov8n.onnx"
+)
+
+for url in "${URLS[@]}"; do
+    echo "  Trying: $url"
+    if wget -q --show-progress -O "$MODEL_PATH" "$url" 2>/dev/null; then
+        if [[ -s "$MODEL_PATH" ]]; then
+            echo "Downloaded successfully: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
+            exit 0
+        fi
+    fi
+    rm -f "$MODEL_PATH"
+done
+
+echo "Direct download failed. Trying Python export..."
+
+# Method 2: Export via ultralytics Python package
+if python3 -c "import ultralytics" 2>/dev/null; then
+    python3 -c "
 from ultralytics import YOLO
 import shutil, os
 
@@ -34,5 +66,15 @@ if os.path.exists(src):
 if os.path.exists('yolov8n.pt'):
     os.remove('yolov8n.pt')
 "
+    if [[ -s "$MODEL_PATH" ]]; then
+        echo "Done."
+        exit 0
+    fi
+fi
 
-echo "Done."
+echo "ERROR: Could not download or export YOLOv8n model."
+echo "Manual options:"
+echo "  1. pip3 install ultralytics && bash models/download_yolov8n.sh"
+echo "  2. Download yolov8n.onnx manually from https://github.com/ultralytics/assets/releases"
+echo "     and place it at: $MODEL_PATH"
+exit 1


### PR DESCRIPTION
## Summary

- Vendor Cosys-AirSim C++ SDK as optional git submodule at `third_party/cosys-airsim`
- `cmake/FindAirSim.cmake` uses `ExternalProject_Add` for build flag isolation (AirSim's `CommonSetup.cmake` mutates global `CXX_FLAGS`)
- Graceful fallback when submodule not initialized — CI unaffected
- Dependabot configured for weekly submodule update PRs
- Comprehensive update to install guides and scripts based on real Ubuntu 22.04 setup testing

## Changes

| File | What |
|------|------|
| `cmake/FindAirSim.cmake` | ExternalProject build, rpclib auto-download, 4 graceful fallback points, imported targets `AirSim::AirLib/rpc/MavLinkCom/All` |
| `.github/dependabot.yml` | Weekly gitsubmodule ecosystem checks |
| `.gitmodules` | Shallow submodule for `third_party/cosys-airsim` |
| `CMakeLists.txt` | Replace `find_package(AirSim QUIET)` with `include(cmake/FindAirSim.cmake)` |
| `common/hal/CMakeLists.txt` | Link `AirSim::All` in `COSYS_AIRSIM_FOUND` block |
| `docs/guides/INSTALL.md` | Full rewrite: added Zenoh, fmt, clang-format-18, 22.04/24.04 table, Conda warning, CUDA/OpenCV section, troubleshooting |
| `docs/guides/GETTING_STARTED.md` | Fixed file tree, Zenoh install, broken links, time estimates |
| `deploy/install_dependencies.sh` | Fixed Zenoh URL, added fmt/unzip, DA V2 venv export |
| `models/download_yolov8n.sh` | Direct download fallback, 0-byte file handling |
| `common/hal/src/depth_anything_v2.cpp` | Fix GCC 11 warnings (unused params, enum cast) |

## Test plan
- [x] Build without submodule: `COSYS_AIRSIM_FOUND=FALSE`, zero warnings
- [x] 1499/1499 tests pass
- [x] `install_dependencies.sh` Zenoh download path verified
- [x] `download_yolov8n.sh` fallback path verified
- [x] `download_depth_anything_v2.sh` export verified
- [ ] Build with submodule initialized (deferred — needs `git submodule update --init`)
- [ ] CI green

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)