### PR TITLE
fix(#462): radar LiDAR proxy + AirSim SDK build fixes + test cleanup

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -38,6 +38,30 @@ Display: PR title, state, base branch, files changed count, CI status.
 
 If the PR is merged or closed, warn the user and ask whether to proceed.
 
+### Step 1.5: Checkout PR Branch in Worktree [SEQUENTIAL]
+
+Review agents need to read the actual PR branch files, not the current working directory (which may be on `main` or a different branch). Create a temporary git worktree for the PR branch:
+
+```bash
+# Fetch the PR branch
+git fetch origin <headRefName>
+
+# Create a worktree INSIDE the project directory (not /tmp)
+# Agents have restricted file access — paths outside the project tree are denied.
+PR_WORKTREE="<project_root>/.pr-review-<pr_number>"
+git worktree remove "$PR_WORKTREE" --force 2>/dev/null || true
+git worktree add "$PR_WORKTREE" "origin/<headRefName>" --detach
+
+# Verify the worktree has the PR files
+ls "$PR_WORKTREE"
+```
+
+Store the `PR_WORKTREE` path — all agent prompts will reference it.
+
+**IMPORTANT:** The worktree MUST be inside the project directory (e.g., `.pr-review-472/`), not under `/tmp/`. Review agents have sandboxed file access restricted to the project tree — they cannot read files under `/tmp/` or other external paths. The `.pr-review-*` prefix keeps it hidden and gitignored.
+
+**Why worktree instead of passing the diff?** Passing the full diff inflates agent prompts by thousands of tokens, exhausting context on large PRs. A worktree gives agents direct file access via `Read` with no Bash requirement — they just read from `$PR_WORKTREE/path/to/file` instead of the working directory path. This is cheaper, more accurate (agents can navigate includes and cross-reference), and works for any PR size.
+
 ### Step 2: Analyze Diff for Review Routing
 
 Examine the diff to determine which Pass 1 agents to launch:
@@ -79,20 +103,33 @@ Spawn Pass 1 agents in **parallel** using `subagent_type` to reference each cust
 Agent(
   description: "Review PR #<N> — memory safety",
   subagent_type: "review-memory-safety",   // loads .claude/agents/review-memory-safety.md
-  prompt: "Review this PR diff for memory safety issues.\n\n<PR diff or summary>\n\nReport findings with severity (P1/P2/P3) and file:line references. Cap output to 200 words if clean."
+  prompt: "Review PR #<N> for memory safety issues.
+
+IMPORTANT: The PR branch files are checked out at: <PR_WORKTREE>
+Read files from that path (e.g., <PR_WORKTREE>/common/hal/include/hal/foo.h), NOT from the main
+working directory. The working directory may be on a different branch.
+
+Key files changed in this PR:
+<list of changed files from Step 1>
+
+<Brief summary of what the PR does — 2-3 sentences from PR body>
+
+Report findings with severity (P1/P2/P3) and file:line references. Cap output to 200 words if clean."
 )
 Agent(
   description: "Review PR #<N> — security",
   subagent_type: "review-security",
-  prompt: "..."
+  prompt: "... (same PR_WORKTREE instructions) ..."
 )
 Agent(
   description: "Review PR #<N> — unit tests",
   subagent_type: "test-unit",
-  prompt: "..."
+  prompt: "... (same PR_WORKTREE instructions) ..."
 )
 // Add conditional agents (review-concurrency, review-fault-recovery, test-scenario) if triggered
 ```
+
+**Critical:** Every agent prompt MUST include the `PR_WORKTREE` path and explicit instructions to read files from there. Agents that read from the working directory will review stale code from whatever branch is currently checked out.
 
 Wait for all Pass 1 agents to complete. Collect findings.
 
@@ -100,36 +137,59 @@ Wait for all Pass 1 agents to complete. Collect findings.
 
 Skip if `--pass1-only` was specified.
 
-Spawn Pass 2 agents in **parallel** using `subagent_type`. Provide Pass 1 findings as context in the prompt:
+Spawn Pass 2 agents in **parallel** using `subagent_type`. Provide Pass 1 findings as context AND the `PR_WORKTREE` path:
 
 ```
 Agent(
   description: "Review PR #<N> — test quality",
   subagent_type: "review-test-quality",    // loads .claude/agents/review-test-quality.md
-  prompt: "Review test quality.\n\nPass 1 findings:\n<merged results>\n\nPR diff:\n<diff>\n\nCap output to 200 words if clean."
+  prompt: "Review test quality for PR #<N>.
+
+IMPORTANT: The PR branch files are checked out at: <PR_WORKTREE>
+Read files from that path, NOT from the main working directory.
+
+Key files changed: <list>
+
+Pass 1 findings (for context):
+<merged Pass 1 results — summarized to ~200 words max>
+
+Cap output to 200 words if clean."
 )
 Agent(
   description: "Review PR #<N> — API contracts",
   subagent_type: "review-api-contract",
-  prompt: "..."
+  prompt: "... (same PR_WORKTREE instructions + Pass 1 context) ..."
 )
 Agent(
   description: "Review PR #<N> — code quality",
   subagent_type: "review-code-quality",
-  prompt: "..."
+  prompt: "... (same PR_WORKTREE instructions + Pass 1 context) ..."
 )
 Agent(
   description: "Review PR #<N> — performance",
   subagent_type: "review-performance",
-  prompt: "..."
+  prompt: "... (same PR_WORKTREE instructions + Pass 1 context) ..."
 )
 ```
 
+**Critical:** Same as Pass 1 — every agent prompt must include the `PR_WORKTREE` path.
+
 Wait for all Pass 2 agents to complete. Collect findings.
+
+### Step 4.5: Check Copilot/Bot Review Comments
+
+Before synthesizing, check for existing review comments from Copilot or other bots:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<pr_number>/comments --jq '.[] | select(.user.type == "Bot") | {user: .user.login, body: .body, path: .path, line: .line}' | head -50
+gh api repos/{owner}/{repo}/pulls/<pr_number>/reviews --jq '.[] | select(.user.type == "Bot") | {user: .user.login, state: .state, body: .body}'
+```
+
+Copilot comments overlap ~60% with our agents. Focus on the unique edge cases they catch that our agents might miss. Include any non-duplicate Copilot findings in the synthesis with `[Copilot]` attribution.
 
 ### Step 5: Synthesize Findings
 
-Merge findings from both passes. As tech-lead, synthesize:
+Merge findings from both passes AND Copilot/bot comments. As tech-lead, synthesize:
 
 1. **Deduplicate** — multiple agents may flag the same issue
 2. **Prioritize** — rank by severity (P1 > P2 > P3)
@@ -181,5 +241,19 @@ If posting, format the comment with:
 - Severity-tagged findings with file:line references
 - Collapsible sections for P3 issues (use `<details>` tags)
 - Agent attribution for each finding
+
+### Step 7: Cleanup
+
+Remove the PR branch worktree created in Step 1.5:
+
+```bash
+git worktree remove "$PR_WORKTREE" --force 2>/dev/null || true
+```
+
+Do this after posting (or after the user chooses "skip"). Don't leave stale worktrees.
+
+**IMPORTANT:** The worktree MUST always be inside the project workspace directory (e.g., `<project_root>/.pr-review-<N>`). Never use `/tmp/`, `~/.claude/`, or any path outside the project root. Agents are sandboxed to the project directory and cannot read external paths.
+
+---
 
 If the user provided arguments, use them as context: $ARGUMENTS

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ graphify-out/graph.json
 # claude script
 export_claude_context.sh
 
+# PR review worktrees (created by /review-pr skill, cleaned up after review)
+.pr-review-*
+
 # Agent artifacts (transient reports from deploy-issue/deploy-wave pipelines)
 AGENT_REPORT.md
 

--- a/common/hal/include/hal/cosys_camera.h
+++ b/common/hal/include/hal/cosys_camera.h
@@ -94,10 +94,10 @@ public:
             return false;
         }
 
-        width_    = width;
-        height_   = height;
-        fps_      = fps;
-        sequence_ = 0;
+        width_  = width;
+        height_ = height;
+        fps_    = fps;
+        sequence_.store(0, std::memory_order_relaxed);
 
         open_.store(true, std::memory_order_release);
 
@@ -162,7 +162,8 @@ private:
     CapturedFrame build_frame(const FrameData& data, bool new_frame) {
         CapturedFrame frame;
         frame.timestamp_ns = data.timestamp_ns;
-        frame.sequence     = new_frame ? sequence_++ : sequence_;
+        frame.sequence     = new_frame ? sequence_.fetch_add(1, std::memory_order_relaxed)
+                                       : sequence_.load(std::memory_order_relaxed);
         frame.width        = data.width;
         frame.height       = data.height;
         frame.channels     = data.channels;
@@ -185,17 +186,16 @@ private:
 
         constexpr uint32_t kRGBChannels = 3;
 
+        // Hoist request vector outside the loop — same request every frame
+        std::vector<ImageCaptureBase::ImageRequest> requests = {
+            ImageCaptureBase::ImageRequest(camera_name_, ImageCaptureBase::ImageType::Scene,
+                                           /* pixels_as_float */ false,
+                                           /* compress */ false)};
+
         while (open_.load(std::memory_order_acquire)) {
             try {
                 // Use with_client() to prevent TOCTOU race on disconnect
                 bool got_frame = client_->with_client([&](auto& rpc) {
-                    // Request uncompressed RGB Scene image from AirSim
-                    std::vector<ImageCaptureBase::ImageRequest> requests = {
-                        ImageCaptureBase::ImageRequest(camera_name_,
-                                                       ImageCaptureBase::ImageType::Scene,
-                                                       /* pixels_as_float */ false,
-                                                       /* compress */ false)};
-
                     auto responses = rpc.simGetImages(requests, vehicle_name_);
 
                     if (responses.empty() || responses[0].image_data_uint8.empty()) {
@@ -227,13 +227,13 @@ private:
                     fd.pixels.assign(resp.image_data_uint8.begin(),
                                      resp.image_data_uint8.begin() +
                                          static_cast<ptrdiff_t>(expected));
-                    fd.width        = w;
-                    fd.height       = h;
-                    fd.channels     = kRGBChannels;
-                    fd.timestamp_ns = static_cast<uint64_t>(
-                        std::chrono::duration_cast<std::chrono::nanoseconds>(
-                            std::chrono::steady_clock::now().time_since_epoch())
-                            .count());
+                    fd.width         = w;
+                    fd.height        = h;
+                    fd.channels      = kRGBChannels;
+                    const auto ts_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                           std::chrono::steady_clock::now().time_since_epoch())
+                                           .count();
+                    fd.timestamp_ns = static_cast<uint64_t>(std::max(decltype(ts_ns){0}, ts_ns));
 
                     frame_buffer_.write(std::move(fd));
                 });
@@ -264,10 +264,11 @@ private:
     std::mutex        state_mtx_;    ///< Guards open/close transitions only
     std::atomic<bool> open_{false};  ///< Atomic for lock-free checks in hot path
 
-    uint32_t width_{0};
-    uint32_t height_{0};
-    int      fps_{0};
-    uint64_t sequence_{0};
+    uint32_t              width_{0};
+    uint32_t              height_{0};
+    int                   fps_{0};
+    std::atomic<uint64_t> sequence_{
+        0};  ///< Frame sequence (atomic: written by capture(), read after open())
 
     // ── Lock-free frame handoff (hot path) ─────────────────
     // Producer (retrieval thread) writes via frame_buffer_.write()

--- a/common/hal/include/hal/cosys_depth.h
+++ b/common/hal/include/hal/cosys_depth.h
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <vector>
@@ -89,22 +90,23 @@ public:
                 "CosysDepthBackend: invalid channel count (0)");
         }
 
-        // Use with_client() to prevent TOCTOU race on disconnect
-        using namespace msr::airlib;
-        std::vector<ImageCaptureBase::ImageResponse> responses;
-        bool got_data = client_->with_client([&](auto& rpc) {
-            std::vector<ImageCaptureBase::ImageRequest> requests = {ImageCaptureBase::ImageRequest(
-                camera_name_, ImageCaptureBase::ImageType::DepthPerspective,
-                /* pixels_as_float */ true, /* compress */ false)};
-            responses = rpc.simGetImages(requests, vehicle_name_);
-        });
-
-        if (!got_data) {
-            return drone::util::Result<DepthMap, std::string>::err(
-                "CosysDepthBackend: RPC client not connected");
-        }
-
         try {
+            // Use with_client() to prevent TOCTOU race on disconnect.
+            // Must be inside try/catch — simGetImages() can throw on RPC failure.
+            using namespace msr::airlib;
+            std::vector<ImageCaptureBase::ImageResponse> responses;
+            bool got_data = client_->with_client([&](auto& rpc) {
+                std::vector<ImageCaptureBase::ImageRequest> requests = {
+                    ImageCaptureBase::ImageRequest(
+                        camera_name_, ImageCaptureBase::ImageType::DepthPerspective,
+                        /* pixels_as_float */ true, /* compress */ false)};
+                responses = rpc.simGetImages(requests, vehicle_name_);
+            });
+
+            if (!got_data) {
+                return drone::util::Result<DepthMap, std::string>::err(
+                    "CosysDepthBackend: RPC client not connected");
+            }
             if (responses.empty()) {
                 return drone::util::Result<DepthMap, std::string>::err(
                     "CosysDepthBackend: simGetImages returned empty response");
@@ -137,16 +139,24 @@ public:
             std::copy(resp.image_data_float.begin(),
                       resp.image_data_float.begin() + static_cast<ptrdiff_t>(total_pixels),
                       depth_map.data.begin());
+
+            // Sanitise depth values: NaN/Inf from rendering artifacts → 0 (invalid)
+            for (auto& d : depth_map.data) {
+                if (!std::isfinite(d) || d < 0.0f) {
+                    d = 0.0f;
+                }
+            }
+
             depth_map.scale = 1.0f;  // AirSim returns metric depth in metres
 
             // Ground truth from simulator — high confidence but not perfect
             // due to rendering artifacts and floating-point precision
             depth_map.confidence = 0.95f;
 
-            depth_map.timestamp_ns =
-                static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
-                                          std::chrono::steady_clock::now().time_since_epoch())
-                                          .count());
+            const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                    std::chrono::steady_clock::now().time_since_epoch())
+                                    .count();
+            depth_map.timestamp_ns = static_cast<uint64_t>(std::max(decltype(now_ns){0}, now_ns));
 
             // Record source frame dimensions for bbox-to-depth coordinate mapping
             depth_map.source_width  = width;

--- a/common/hal/include/hal/cosys_imu.h
+++ b/common/hal/include/hal/cosys_imu.h
@@ -96,6 +96,7 @@ public:
     /// @param rate_hz  Polling rate; actual data rate depends on AirSim sensor config.
     /// @return true on successful startup
     bool init(int rate_hz) override {
+        std::lock_guard<std::mutex> lock(reading_mutex_);
         if (active_.load(std::memory_order_acquire)) {
             DRONE_LOG_WARN("[CosysIMU] Already initialised on imu='{}'", imu_name_);
             return false;
@@ -106,7 +107,11 @@ public:
             return false;
         }
 
-        rate_hz_ = rate_hz;
+        // Clamp rate_hz to [1, 1000] — non-positive creates hot-loop
+        rate_hz_ = std::clamp(rate_hz, 1, 1000);
+        if (rate_hz != rate_hz_) {
+            DRONE_LOG_WARN("[CosysIMU] rate_hz clamped from {} to {}", rate_hz, rate_hz_);
+        }
         active_.store(true, std::memory_order_release);
 
         // Start polling thread at the requested rate

--- a/common/hal/include/hal/cosys_radar.h
+++ b/common/hal/include/hal/cosys_radar.h
@@ -29,6 +29,7 @@
 #include <cmath>
 #include <memory>
 #include <mutex>
+#include <numbers>
 #include <string>
 #include <thread>
 
@@ -39,12 +40,13 @@ STRICT_MODE_ON
 
 namespace drone::hal {
 
-/// CosysRadarBackend — retrieves radar detections from Cosys-AirSim
-/// via the getRadarData() RPC endpoint.
+/// CosysRadarBackend — emulates radar using LiDAR point cloud data
+/// from Cosys-AirSim via the getLidarData() RPC endpoint.
 ///
 /// The polling thread runs at a fixed 20 Hz (kPollInterval = 50 ms)
-/// and converts AirSim's native radar data to our RadarDetectionList
-/// wire format. Ground returns with elevation < -30 degrees are filtered.
+/// and converts LiDAR point cloud (flat x,y,z triples) to our
+/// RadarDetectionList wire format. Ground returns with steep downward
+/// elevation (> +30° in NED) are filtered.
 ///
 /// AirSim uses NED body frame which maps directly to our FRD convention:
 /// X=forward, Y=right, Z=down — no coordinate negation needed.
@@ -81,6 +83,7 @@ public:
     CosysRadarBackend& operator=(CosysRadarBackend&&)      = delete;
 
     bool init() override {
+        std::lock_guard<std::mutex> lock(mutex_);
         if (active_.load(std::memory_order_acquire)) {
             DRONE_LOG_WARN("[CosysRadar] Already initialised");
             return false;
@@ -137,10 +140,11 @@ private:
     /// Radar polling loop — runs at 20 Hz, converts AirSim radar data
     /// to our RadarDetectionList format with ground filtering.
     void poll_loop() {
-        constexpr auto  kPollInterval = std::chrono::milliseconds(50);  // 20 Hz
-        constexpr float kPiF          = 3.14159265358979f;
-        // Ground filter: skip returns looking more than 30 degrees below horizontal.
-        constexpr float kGroundElevationThreshold = -30.0f * kPiF / 180.0f;
+        constexpr auto kPollInterval = std::chrono::milliseconds(50);  // 20 Hz
+        // Ground filter: skip returns with steep downward elevation in NED frame.
+        // In NED (Z=down), ground points below the drone have positive elevation
+        // from asin(z/range). Threshold +30° filters steep ground returns.
+        constexpr float kGroundElevationThreshold = 30.0f * std::numbers::pi_v<float> / 180.0f;
         // Simplified radar equation: SNR = ref_snr - path_loss * log10(range)
         constexpr float kReferenceSNRdB    = 30.0f;  // SNR at 1m range
         constexpr float kSNRPathLossFactor = 20.0f;  // Free-space path loss exponent
@@ -161,9 +165,10 @@ private:
                 }
 
                 drone::ipc::RadarDetectionList list{};
-                const auto now    = std::chrono::steady_clock::now().time_since_epoch();
-                list.timestamp_ns = static_cast<uint64_t>(
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+                const auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                        std::chrono::steady_clock::now().time_since_epoch())
+                                        .count();
+                list.timestamp_ns = static_cast<uint64_t>(std::max(decltype(now_ns){0}, now_ns));
 
                 // Convert each AirSim radar point to our RadarDetection format.
                 // AirSim RadarData contains point_cloud (x,y,z triples) and
@@ -173,19 +178,23 @@ private:
 
                     // AirSim radar point_cloud entries are (x, y, z) in NED body frame.
                     // Convert Cartesian to spherical: range, azimuth, elevation.
-                    const float x     = point.x;
-                    const float y     = point.y;
-                    const float z     = point.z;
+                    const float x = point.x;
+                    const float y = point.y;
+                    const float z = point.z;
+
+                    // Guard against NaN/Inf in radar point cloud data
+                    if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) continue;
                     const float range = std::sqrt(x * x + y * y + z * z);
 
-                    // Skip zero-range or out-of-range returns
+                    // Skip zero-range or out-of-range returns (before trig ops)
                     if (range < 0.1f || range > max_range_m_) continue;
 
                     const float azimuth   = std::atan2(y, x);
                     const float elevation = std::asin(std::clamp(z / range, -1.0f, 1.0f));
 
-                    // Ground filter: skip returns with steep downward elevation
-                    if (elevation < kGroundElevationThreshold) continue;
+                    // Ground filter: in NED (Z=down), ground below has positive
+                    // elevation. Skip returns with steep downward angle.
+                    if (elevation > kGroundElevationThreshold) continue;
 
                     drone::ipc::RadarDetection det{};
                     det.timestamp_ns        = list.timestamp_ns;
@@ -231,7 +240,7 @@ private:
     std::shared_ptr<CosysRpcClient> client_;
 
     // ── Config ────────────────────────────────────────────────
-    std::string radar_name_;    ///< AirSim radar sensor name
+    std::string radar_name_;    ///< AirSim LiDAR sensor name (used as radar proxy)
     std::string vehicle_name_;  ///< AirSim vehicle name
     float       max_range_m_;   ///< Maximum detection range
 
@@ -244,7 +253,7 @@ private:
     drone::ipc::RadarDetectionList cached_detections_{};
 
     // ── Polling thread ────────────────────────────────────────
-    std::thread poll_thread_;  ///< Polls getRadarData() at 20 Hz
+    std::thread poll_thread_;  ///< Polls getLidarData() at 20 Hz (LiDAR as radar proxy)
 };
 
 }  // namespace drone::hal

--- a/common/hal/include/hal/icamera.h
+++ b/common/hal/include/hal/icamera.h
@@ -32,7 +32,8 @@ public:
     /// Close the camera and release resources.
     virtual void close() = 0;
 
-    /// Capture one frame. Blocks until a frame is ready (or timeout).
+    /// Capture one frame. May block (V4L2) or return immediately with the latest
+    /// available frame (SimulatedCamera, CosysCamera). Check CapturedFrame::valid.
     /// The returned CapturedFrame::data pointer is valid until the next call to capture().
     [[nodiscard]] virtual CapturedFrame capture() = 0;
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,9 @@
 FROM nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04 AS builder
 
 ARG MODEL_PRESET=edge
+# Override at build time: --build-arg ALLOW_INSECURE_ZENOH=ON (dev/testing only).
+# Default OFF for production — requires TLS certificates for Zenoh transport.
+ARG ALLOW_INSECURE_ZENOH=OFF
 ARG DEBIAN_FRONTEND=noninteractive
 
 LABEL stage="builder"
@@ -98,7 +101,7 @@ COPY . /app/
 RUN mkdir -p build && cd build && \
     cmake .. \
         -DCMAKE_BUILD_TYPE=Release \
-        -DALLOW_INSECURE_ZENOH=ON \
+        -DALLOW_INSECURE_ZENOH=${ALLOW_INSECURE_ZENOH} \
         -DMODEL_PRESET="${MODEL_PRESET}" \
         -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra" && \
     make -j$(nproc)

--- a/docker/docker-compose.cosys.yml
+++ b/docker/docker-compose.cosys.yml
@@ -63,8 +63,8 @@ services:
       - ../config/cosys_settings.json:/home/airsim/Documents/AirSim/settings.json:ro
       - airsim-data:/home/airsim/data
     ports:
-      - "41451:41451"    # AirSim RPC API
-      - "14540:14540"    # PX4 SITL MAVLink
+      - "127.0.0.1:41451:41451"    # AirSim RPC API (localhost only)
+      - "127.0.0.1:14540:14540"    # PX4 SITL MAVLink (localhost only)
     healthcheck:
       # AirSim uses msgpack RPC (not HTTP) — check TCP port reachability
       test: ["CMD-SHELL", "timeout 3 bash -c '</dev/tcp/localhost/41451' || exit 1"]

--- a/tests/test_triple_buffer.cpp
+++ b/tests/test_triple_buffer.cpp
@@ -176,7 +176,7 @@ TEST(TripleBufferTest, HighContentionStress) {
         }
         // Write continuously until stop is signalled
         uint64_t i = 0;
-        while (!stop.load(std::memory_order_relaxed)) {
+        while (!stop.load(std::memory_order_acquire)) {
             buf.write(++i);
             // Yield occasionally to let consumer run on single-core CI
             if ((i & 0xFF) == 0) std::this_thread::yield();
@@ -189,7 +189,7 @@ TEST(TripleBufferTest, HighContentionStress) {
             std::this_thread::yield();
         }
         uint64_t prev = 0;
-        while (!stop.load(std::memory_order_relaxed)) {
+        while (!stop.load(std::memory_order_acquire)) {
             auto v = buf.read();
             if (v.has_value()) {
                 // Monotonically increasing — no corruption


### PR DESCRIPTION
## Summary

Follow-up fixes for #462 after integrating with the actual AirSim SDK on the desktop.

**SDK API fix:**
- Radar backend uses `getLidarData()` as proxy — base Cosys-AirSim has no native radar (radar is in ASVSim extension only)

**Build fixes:**
- FindAirSim.cmake: guard empty CMAKE_C_COMPILER, forward CMAKE_POLICY_VERSION_MINIMUM, add Eigen include path
- Submodule initialized at tag 5.5-v3.3

**Test cleanup:**
- Moved 8 network-dependent tests to `#if 0` (integration tests for #465)
- AirSim `confirmConnection()` blocks indefinitely without a server — these tests hang in `ctest`
- Unit tests (config keys, construction, endpoint) remain active

Build: 1545/1545 tests pass, zero warnings.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)