### PR TITLE
feat(#452): ICamera::capture() returns owned frame data

### DIFF
--- a/common/hal/include/hal/cosys_camera.h
+++ b/common/hal/include/hal/cosys_camera.h
@@ -126,8 +126,7 @@ public:
 
     /// Read the latest frame from the TripleBuffer (lock-free).
     /// SINGLE-CONSUMER: this method must only be called from one thread.
-    /// The returned CapturedFrame::data points into last_frame_.pixels and is
-    /// valid until the next capture() call (matches ICamera contract).
+    /// The returned CapturedFrame owns its pixel data (valid for frame lifetime).
     CapturedFrame capture() override {
         CapturedFrame frame;
         if (!open_.load(std::memory_order_acquire)) return frame;
@@ -155,8 +154,8 @@ public:
     }
 
 private:
-    /// Build a CapturedFrame from FrameData. The returned frame points into
-    /// last_frame_.pixels which is stable until the next capture() call.
+    /// Build a CapturedFrame from FrameData. The returned frame owns a copy of
+    /// the pixel data, so it remains valid for its entire lifetime.
     /// @param new_frame  If true, increment sequence (new data). If false, reuse
     ///                   last sequence (duplicate frame, no new data from producer).
     CapturedFrame build_frame(const FrameData& data, bool new_frame) {
@@ -168,7 +167,7 @@ private:
         frame.height       = data.height;
         frame.channels     = data.channels;
         frame.stride       = data.width * data.channels;
-        frame.data         = data.pixels.data();
+        frame.data         = data.pixels;  // copy from cached FrameData
         frame.valid        = true;
         return frame;
     }

--- a/common/hal/include/hal/gazebo_camera.h
+++ b/common/hal/include/hal/gazebo_camera.h
@@ -126,8 +126,11 @@ public:
         frame.height       = last_height_;
         frame.channels     = last_channels_;
         frame.stride       = last_width_ * last_channels_;
-        frame.data         = front_buffer_.data();
-        frame.valid        = true;
+        // Copy only the valid pixel region (front_buffer_ may be larger than the frame)
+        const auto pixel_bytes = static_cast<size_t>(last_width_) * last_height_ * last_channels_;
+        frame.data.assign(front_buffer_.begin(),
+                          front_buffer_.begin() + static_cast<ptrdiff_t>(pixel_bytes));
+        frame.valid = true;
 
         return frame;
     }

--- a/common/hal/include/hal/icamera.h
+++ b/common/hal/include/hal/icamera.h
@@ -16,7 +16,7 @@ struct CapturedFrame {
     uint32_t             height{0};
     uint32_t             channels{0};  // 1=GRAY, 3=RGB
     uint32_t             stride{0};
-    std::vector<uint8_t> data;  // owned pixel data — valid for the lifetime of this frame
+    std::vector<uint8_t> data;  // owned pixel data; size == height * stride when valid
     bool                 valid{false};
 };
 

--- a/common/hal/include/hal/icamera.h
+++ b/common/hal/include/hal/icamera.h
@@ -4,19 +4,20 @@
 #pragma once
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace drone::hal {
 
 /// Result of a single frame capture.
 struct CapturedFrame {
-    uint64_t       timestamp_ns{0};
-    uint64_t       sequence{0};
-    uint32_t       width{0};
-    uint32_t       height{0};
-    uint32_t       channels{0};  // 1=GRAY, 3=RGB
-    uint32_t       stride{0};
-    const uint8_t* data{nullptr};  // pointer to internal buffer — valid until next capture()
-    bool           valid{false};
+    uint64_t             timestamp_ns{0};
+    uint64_t             sequence{0};
+    uint32_t             width{0};
+    uint32_t             height{0};
+    uint32_t             channels{0};  // 1=GRAY, 3=RGB
+    uint32_t             stride{0};
+    std::vector<uint8_t> data;  // owned pixel data — valid for the lifetime of this frame
+    bool                 valid{false};
 };
 
 /// Abstract camera interface.
@@ -34,7 +35,7 @@ public:
 
     /// Capture one frame. May block (V4L2) or return immediately with the latest
     /// available frame (SimulatedCamera, CosysCamera). Check CapturedFrame::valid.
-    /// The returned CapturedFrame::data pointer is valid until the next call to capture().
+    /// The returned CapturedFrame owns its pixel data — valid for the lifetime of the frame.
     [[nodiscard]] virtual CapturedFrame capture() = 0;
 
     /// Check whether the camera is currently open.

--- a/common/hal/include/hal/simulated_camera.h
+++ b/common/hal/include/hal/simulated_camera.h
@@ -59,7 +59,7 @@ public:
         f.height   = height_;
         f.channels = channels_;
         f.stride   = stride_;
-        f.data     = buffer_.data();
+        f.data     = buffer_;  // copy — simulated backend reuses buffer_ as working canvas
         f.valid    = true;
 
         return f;

--- a/process1_video_capture/src/main.cpp
+++ b/process1_video_capture/src/main.cpp
@@ -67,12 +67,12 @@ static void mission_cam_thread(drone::hal::ICamera&                            c
         // Copy pixel data into IPC frame
         size_t copy_size = std::min(static_cast<size_t>(frame.height) * frame.stride,
                                     sizeof(ipc_frame.pixel_data));
-        if (frame.data) {
-            std::copy(frame.data, frame.data + copy_size, ipc_frame.pixel_data);
+        if (!frame.data.empty()) {
+            std::copy(frame.data.data(), frame.data.data() + copy_size, ipc_frame.pixel_data);
         } else {
             ++null_data_count;
             ++drop_count;
-            diag.add_error("Camera", "Frame marked valid but data is nullptr (null #" +
+            diag.add_error("Camera", "Frame marked valid but data is empty (null #" +
                                          std::to_string(null_data_count) + ")");
             if (null_data_count == 1 || null_data_count % 100 == 0) {
                 diag.log_summary("MissionCam");
@@ -166,12 +166,12 @@ static void stereo_cam_thread(drone::hal::ICamera& left_cam, drone::hal::ICamera
             std::min(static_cast<size_t>(right_frame.height) * right_frame.stride,
                      sizeof(ipc_frame.right_data));
 
-        // Treat null data pointers as a dropped pair — don't publish corrupted
+        // Treat empty data as a dropped pair — don't publish corrupted
         // frames into SLAM.
-        const bool left_has_data  = (left_frame.data != nullptr);
-        const bool right_has_data = (right_frame.data != nullptr);
-        if (!left_has_data) diag.add_error("CameraLeft", "Valid frame but null data pointer");
-        if (!right_has_data) diag.add_error("CameraRight", "Valid frame but null data pointer");
+        const bool left_has_data  = !left_frame.data.empty();
+        const bool right_has_data = !right_frame.data.empty();
+        if (!left_has_data) diag.add_error("CameraLeft", "Valid frame but empty data");
+        if (!right_has_data) diag.add_error("CameraRight", "Valid frame but empty data");
 
         if (!left_has_data || !right_has_data) {
             ++drop_count;
@@ -182,8 +182,10 @@ static void stereo_cam_thread(drone::hal::ICamera& left_cam, drone::hal::ICamera
             continue;
         }
 
-        std::copy(left_frame.data, left_frame.data + copy_size_left, ipc_frame.left_data);
-        std::copy(right_frame.data, right_frame.data + copy_size_right, ipc_frame.right_data);
+        std::copy(left_frame.data.data(), left_frame.data.data() + copy_size_left,
+                  ipc_frame.left_data);
+        std::copy(right_frame.data.data(), right_frame.data.data() + copy_size_right,
+                  ipc_frame.right_data);
 
         publisher.publish(ipc_frame);
 

--- a/process1_video_capture/src/main.cpp
+++ b/process1_video_capture/src/main.cpp
@@ -64,15 +64,15 @@ static void mission_cam_thread(drone::hal::ICamera&                            c
         ipc_frame.channels        = frame.channels;
         ipc_frame.stride          = frame.stride;
 
-        // Copy pixel data into IPC frame
-        size_t copy_size = std::min(static_cast<size_t>(frame.height) * frame.stride,
-                                    sizeof(ipc_frame.pixel_data));
+        // Copy pixel data into IPC frame — clamp to both IPC buffer and actual data size
+        size_t copy_size = std::min({static_cast<size_t>(frame.height) * frame.stride,
+                                     sizeof(ipc_frame.pixel_data), frame.data.size()});
         if (!frame.data.empty()) {
             std::copy(frame.data.data(), frame.data.data() + copy_size, ipc_frame.pixel_data);
         } else {
             ++null_data_count;
             ++drop_count;
-            diag.add_error("Camera", "Frame marked valid but data is empty (null #" +
+            diag.add_error("Camera", "Frame marked valid but data is empty (empty #" +
                                          std::to_string(null_data_count) + ")");
             if (null_data_count == 1 || null_data_count % 100 == 0) {
                 diag.log_summary("MissionCam");
@@ -159,12 +159,13 @@ static void stereo_cam_thread(drone::hal::ICamera& left_cam, drone::hal::ICamera
         ipc_frame.width           = left_frame.width;
         ipc_frame.height          = left_frame.height;
 
-        // Copy left and right data using height * stride for correct padding
-        size_t copy_size_left = std::min(static_cast<size_t>(left_frame.height) * left_frame.stride,
-                                         sizeof(ipc_frame.left_data));
+        // Copy left and right data — clamp to IPC buffer and actual data size
+        size_t copy_size_left =
+            std::min({static_cast<size_t>(left_frame.height) * left_frame.stride,
+                      sizeof(ipc_frame.left_data), left_frame.data.size()});
         size_t copy_size_right =
-            std::min(static_cast<size_t>(right_frame.height) * right_frame.stride,
-                     sizeof(ipc_frame.right_data));
+            std::min({static_cast<size_t>(right_frame.height) * right_frame.stride,
+                      sizeof(ipc_frame.right_data), right_frame.data.size()});
 
         // Treat empty data as a dropped pair — don't publish corrupted
         // frames into SLAM.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -117,6 +117,9 @@ add_drone_test(test_system_monitor  test_system_monitor.cpp)
 # ── HAL tests ────────────────────────────────────────────────
 add_drone_test(test_hal             test_hal.cpp)
 
+# ── HAL Camera Lifetime tests (Issue #452) ───────────────────
+add_drone_test(test_hal_camera_lifetime test_hal_camera_lifetime.cpp)
+
 # ── MavlinkFCLink tests ─────────────────────────────────────
 add_drone_test(test_mavlink_fc_link test_mavlink_fc_link.cpp)
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -52,7 +52,7 @@
 | `perception` | Kalman tracker, fusion engine (UKF+camera+radar), color contour, YOLOv8 | ~189 |
 | `mission` | Mission FSM, FaultManager, D* Lite, ObstacleAvoider3D, geofence, event bus | ~287 |
 | `comms` | MavlinkSim and GCSLink | ~13 |
-| `hal` | Simulated, Gazebo, MAVLink, and plugin HAL backends | ~129 |
+| `hal` | Simulated, Gazebo, MAVLink, and plugin HAL backends | ~136 |
 | `payload` | GimbalController servo simulation | ~34 |
 | `monitor` | P7 system monitor (CPU/memory/thermal, ISysInfo, process context) | ~64 |
 | `util` | Config, Result, latency tracker, JSON log, correlation, replay dispatch | ~251 |
@@ -128,7 +128,8 @@ bash deploy/build.sh --test-filter watchdog
 | [IPC — Serializer](#ipc--serializer) | 1 | 21 | ISerializer<T> interface, RawSerializer round-trip, wire-format compat, null safety |
 | [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
-| **Total** | **68 C++ + 5 shell** | **1546 + 42 + 250+** | |
+| [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
+| **Total** | **70 C++ + 5 shell** | **1553 + 42 + 250+** | |
 
 ---
 
@@ -261,6 +262,21 @@ network configuration.
 | `HALFactoryTest` | 5 | Factory creates correct backend from `config.hal_backend` string |
 
 **Key files under test:** `hal/hal_factory.h`, `hal/icamera.h`, `hal/iimu_source.h`, `hal/ifc_link.h`, `hal/igcs_link.h`, `hal/igimbal.h`
+
+---
+
+### test_hal_camera_lifetime.cpp — 7 tests
+
+**What it tests:** CapturedFrame owned data lifetime safety (Issue #452).
+Verifies that frame data survives beyond subsequent capture() calls, matches
+expected dimensions, and remains valid after camera close.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `CameraLifetimeTest` | 6 | Frame data survives next capture, size matches w*h*c, invalid frame empty, multiple frames independent, grayscale size, data survives close |
+| `CapturedFrameDefault` | 1 | Default-constructed CapturedFrame has empty data |
+
+**Key files under test:** `hal/icamera.h`, `hal/simulated_camera.h`
 
 ---
 

--- a/tests/test_hal.cpp
+++ b/tests/test_hal.cpp
@@ -157,7 +157,7 @@ TEST_F(SimulatedCameraTest, CaptureReturnsValidFrame) {
     EXPECT_EQ(frame.height, 240u);
     EXPECT_GT(frame.timestamp_ns, 0u);
     EXPECT_EQ(frame.sequence, 0u);
-    EXPECT_NE(frame.data, nullptr);
+    EXPECT_FALSE(frame.data.empty());
 }
 
 TEST_F(SimulatedCameraTest, SequenceIncrementsEachCapture) {

--- a/tests/test_hal_camera_lifetime.cpp
+++ b/tests/test_hal_camera_lifetime.cpp
@@ -118,18 +118,14 @@ TEST_F(CameraLifetimeTest, FrameDataSurvivesAfterClose) {
     ASSERT_TRUE(frame.valid);
     ASSERT_FALSE(frame.data.empty());
 
-    const size_t data_size = frame.data.size();
+    // Save snapshot before close for content integrity check
+    const std::vector<uint8_t> snapshot(frame.data.begin(), frame.data.end());
 
     // Close the camera — frame data must remain valid (owned by frame)
     cam_.close();
 
-    EXPECT_EQ(frame.data.size(), data_size);
-    // Verify we can still read the data without crashing
-    uint8_t sum = 0;
-    for (uint8_t byte : frame.data) {
-        sum ^= byte;
-    }
-    (void)sum;  // just verifying access doesn't crash
+    EXPECT_EQ(frame.data.size(), snapshot.size());
+    EXPECT_EQ(frame.data, snapshot);
 }
 
 }  // namespace

--- a/tests/test_hal_camera_lifetime.cpp
+++ b/tests/test_hal_camera_lifetime.cpp
@@ -1,0 +1,135 @@
+// tests/test_hal_camera_lifetime.cpp
+// Lifetime safety tests for CapturedFrame owned data (Issue #452).
+// Verifies that CapturedFrame::data (now std::vector<uint8_t>) survives
+// beyond subsequent capture() calls — the key safety property that the
+// old raw-pointer design lacked.
+
+#include "hal/icamera.h"
+#include "hal/simulated_camera.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class CameraLifetimeTest : public ::testing::Test {
+protected:
+    drone::hal::SimulatedCamera cam_;
+};
+
+// ── Frame data survives beyond next capture() ──────────────────
+// This is the core safety test: with the old raw-pointer design,
+// frame1.data would become a dangling pointer after capture() #2.
+TEST_F(CameraLifetimeTest, FrameDataSurvivesBeyondNextCapture) {
+    cam_.open(64, 64, 10);
+
+    auto frame1 = cam_.capture();
+    ASSERT_TRUE(frame1.valid);
+    ASSERT_FALSE(frame1.data.empty());
+
+    // Save a copy of frame1's data for comparison
+    const std::vector<uint8_t> frame1_snapshot(frame1.data.begin(), frame1.data.end());
+
+    // Capture again — this must NOT invalidate frame1.data
+    auto frame2 = cam_.capture();
+    ASSERT_TRUE(frame2.valid);
+
+    // frame1.data must still be accessible and unchanged
+    ASSERT_EQ(frame1.data.size(), frame1_snapshot.size());
+    EXPECT_EQ(frame1.data, frame1_snapshot);
+}
+
+// ── Frame data size matches width * height * channels ──────────
+TEST_F(CameraLifetimeTest, FrameDataSizeMatchesDimensions) {
+    constexpr uint32_t kWidth  = 128;
+    constexpr uint32_t kHeight = 96;
+    constexpr int      kFps    = 10;
+
+    cam_.open(kWidth, kHeight, kFps);
+    auto frame = cam_.capture();
+    ASSERT_TRUE(frame.valid);
+
+    const size_t expected_size = static_cast<size_t>(frame.width) * frame.height * frame.channels;
+    EXPECT_EQ(frame.data.size(), expected_size);
+}
+
+// ── Invalid frame has empty data ───────────────────────────────
+TEST_F(CameraLifetimeTest, InvalidFrameHasEmptyData) {
+    // Camera not opened — capture returns invalid frame
+    auto frame = cam_.capture();
+    EXPECT_FALSE(frame.valid);
+    EXPECT_TRUE(frame.data.empty());
+}
+
+// ── Multiple frames are independent ────────────────────────────
+// Each frame must own its own data independently.
+TEST_F(CameraLifetimeTest, MultipleFramesAreIndependent) {
+    cam_.open(32, 32, 10);
+
+    auto frame1 = cam_.capture();
+    auto frame2 = cam_.capture();
+    auto frame3 = cam_.capture();
+
+    ASSERT_TRUE(frame1.valid);
+    ASSERT_TRUE(frame2.valid);
+    ASSERT_TRUE(frame3.valid);
+
+    // All frames must have data of the correct size
+    const size_t expected = static_cast<size_t>(frame1.width) * frame1.height * frame1.channels;
+    EXPECT_EQ(frame1.data.size(), expected);
+    EXPECT_EQ(frame2.data.size(), expected);
+    EXPECT_EQ(frame3.data.size(), expected);
+
+    // Data pointers must be distinct (each frame owns its own allocation)
+    EXPECT_NE(frame1.data.data(), frame2.data.data());
+    EXPECT_NE(frame2.data.data(), frame3.data.data());
+    EXPECT_NE(frame1.data.data(), frame3.data.data());
+}
+
+// ── Grayscale frame data size ──────────────────────────────────
+TEST_F(CameraLifetimeTest, GrayscaleFrameDataSize) {
+    // SimulatedCamera uses 1 channel for small resolutions (stereo mode)
+    cam_.open(640, 480, 10);
+    auto frame = cam_.capture();
+    ASSERT_TRUE(frame.valid);
+    EXPECT_EQ(frame.channels, 1u);
+
+    const size_t expected_size = static_cast<size_t>(frame.width) * frame.height * frame.channels;
+    EXPECT_EQ(frame.data.size(), expected_size);
+}
+
+// ── Default CapturedFrame has empty data ───────────────────────
+TEST(CapturedFrameDefault, DefaultConstructedHasEmptyData) {
+    drone::hal::CapturedFrame frame;
+    EXPECT_TRUE(frame.data.empty());
+    EXPECT_FALSE(frame.valid);
+    EXPECT_EQ(frame.width, 0u);
+    EXPECT_EQ(frame.height, 0u);
+}
+
+// ── Frame data survives after camera close ─────────────────────
+TEST_F(CameraLifetimeTest, FrameDataSurvivesAfterClose) {
+    cam_.open(64, 64, 10);
+    auto frame = cam_.capture();
+    ASSERT_TRUE(frame.valid);
+    ASSERT_FALSE(frame.data.empty());
+
+    const size_t data_size = frame.data.size();
+
+    // Close the camera — frame data must remain valid (owned by frame)
+    cam_.close();
+
+    EXPECT_EQ(frame.data.size(), data_size);
+    // Verify we can still read the data without crashing
+    uint8_t sum = 0;
+    for (uint8_t byte : frame.data) {
+        sum ^= byte;
+    }
+    (void)sum;  // just verifying access doesn't crash
+}
+
+}  // namespace

--- a/tests/test_plugin_mock.cpp
+++ b/tests/test_plugin_mock.cpp
@@ -30,7 +30,7 @@ public:
         frame.stride       = 640 * 3;
         frame.timestamp_ns = 12345;
         frame.sequence     = seq_++;
-        frame.data         = dummy_data_.data();
+        frame.data         = dummy_data_;  // copy — each frame owns its data
         frame.valid        = opened_;
         return frame;
     }

--- a/tests/test_plugin_mock.cpp
+++ b/tests/test_plugin_mock.cpp
@@ -15,6 +15,10 @@ namespace {
 
 class MockPluginCamera final : public drone::hal::ICamera {
 public:
+    static constexpr uint32_t kWidth    = 640;
+    static constexpr uint32_t kHeight   = 480;
+    static constexpr uint32_t kChannels = 3;
+
     [[nodiscard]] bool open(uint32_t /*width*/, uint32_t /*height*/, int /*fps*/) override {
         opened_ = true;
         return true;
@@ -24,14 +28,16 @@ public:
 
     [[nodiscard]] drone::hal::CapturedFrame capture() override {
         drone::hal::CapturedFrame frame;
-        frame.width        = 640;
-        frame.height       = 480;
-        frame.channels     = 3;
-        frame.stride       = 640 * 3;
+        frame.width        = kWidth;
+        frame.height       = kHeight;
+        frame.channels     = kChannels;
+        frame.stride       = kWidth * kChannels;
         frame.timestamp_ns = 12345;
         frame.sequence     = seq_++;
-        frame.data         = dummy_data_;  // copy — each frame owns its data
         frame.valid        = opened_;
+        if (frame.valid) {
+            frame.data = dummy_data_;  // copy — each valid frame owns its data
+        }
         return frame;
     }
 
@@ -42,7 +48,7 @@ public:
 private:
     bool                 opened_ = false;
     uint64_t             seq_    = 0;
-    std::vector<uint8_t> dummy_data_{std::vector<uint8_t>(640 * 480 * 3, 128)};
+    std::vector<uint8_t> dummy_data_{std::vector<uint8_t>(kWidth * kHeight * kChannels, 128)};
 };
 
 }  // namespace


### PR DESCRIPTION
## Summary

Replaces the raw `const uint8_t*` pointer in `CapturedFrame::data` with an owned `std::vector<uint8_t>`, eliminating a temporal coupling where frame data was only valid until the next `capture()` call. This is a safety-critical lifetime guarantee — the returned frame now owns its pixel data for its entire lifetime, with no possibility of dangling pointers.

**Design decision:** Chose `std::vector<uint8_t>` over the issue's suggested `shared_ptr` frame pool because CLAUDE.md discourages `shared_ptr` in safety-critical code. Owned vector is simpler, sufficient (all callers immediately copy into fixed-size IPC arrays), and works with RAII.

## Changes

| File | Change |
|------|--------|
| `common/hal/include/hal/icamera.h` | `const uint8_t* data` → `std::vector<uint8_t> data`, updated docstrings |
| `common/hal/include/hal/simulated_camera.h` | Copy `buffer_` into `frame.data` (was pointer) |
| `common/hal/include/hal/gazebo_camera.h` | `.assign()` front buffer into `frame.data` |
| `common/hal/include/hal/cosys_camera.h` | Copy `pixels` into `frame.data`, updated docstrings |
| `process1_video_capture/src/main.cpp` | `frame.data` → `frame.data.data()`, null → `.empty()` checks |
| `tests/test_plugin_mock.cpp` | Copy `dummy_data_` into `frame.data` |
| `tests/test_hal.cpp` | `EXPECT_NE(frame.data, nullptr)` → `EXPECT_FALSE(frame.data.empty())` |
| `tests/test_hal_camera_lifetime.cpp` | **NEW** — 7 lifetime safety tests |
| `tests/CMakeLists.txt` | Register new test file |
| `tests/TESTS.md` | Updated test counts (1546 → 1553) |

## Test plan

- [x] Build passes with zero warnings (`-Werror -Wall -Wextra`)
- [x] clang-format-18 clean
- [x] All 1553 tests pass
- [x] 7 new lifetime safety tests verify owned semantics:
  - Frame data survives beyond next `capture()` call
  - Frame data size matches `width * height * channels`
  - Invalid frame has empty data
  - Multiple frames are independent allocations
  - Grayscale frame data size correct
  - Default-constructed frame has empty data
  - Frame data survives after camera close

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>