### PR TITLE
feat(#498): SWVIO Phase 1 — IMU state propagation + state augmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ AGENT_REPORT.md
 
 # Local-only deep documentation (not committed — personal reference)
 docs/design/modularity_guide.md
+docs/adr/ADR-012-stereo-inertial-vio-algorithm-selection.md
+docs/design/swvio_implementation.md

--- a/config/default.json
+++ b/config/default.json
@@ -153,6 +153,17 @@
             "quality": {
                 "good_trace_max": 0.1,
                 "degraded_trace_max": 1.0
+            },
+            "swvio": {
+                "max_clones": 15,
+                "min_track_length": 3,
+                "max_gn_iterations": 5,
+                "convergence_threshold": 1e-6,
+                "chi2_threshold": 5.991,
+                "gravity": [0, 0, -9.81],
+                "noise_image_pixel": 1.0,
+                "init_frames": 10,
+                "enable_marginalization_prior": true
             }
         },
         "imu": {

--- a/docs/design/slam_vio_nav_design.md
+++ b/docs/design/slam_vio_nav_design.md
@@ -158,6 +158,7 @@ class IVIOBackend {
 | `SimulatedVIOBackend` | `"simulated"` | Circular trajectory with noise. Runs full pipeline (extract → match → preintegrate) but generates pose independently. |
 | `GazeboVIOBackend` | `"gazebo"` | Reads ground-truth odometry from gz-transport topic. Ignores stereo/IMU data. Requires `HAVE_GAZEBO` build flag. |
 | `GazeboFullVIOBackend` | `"gazebo_full_vio"` | Runs the **full VIO pipeline** (feature extraction → stereo matching → IMU pre-integration) on each frame, but obtains the final pose from Gazebo ground truth. Unlike `GazeboVIOBackend` (which skips the pipeline entirely), this exercises all estimation code paths while still producing a reliable pose for downstream consumers. Uses covariance-based health assessment (see below). Requires `HAVE_GAZEBO`. Used in scenario 26 for VIO validation. Source: `ivio_backend.h`. |
+| `SlidingWindowVIOBackend` | `"swvio"` | Custom sliding-window optimization VIO — the project's real sensor-fusion backend. Propagates IMU error state with covariance, maintains a sliding window of camera pose clones, and (when complete) will perform Gauss-Newton optimization over reprojection and IMU residuals. Being implemented in phases; see the [SWVIO Implementation Guide](swvio_implementation.md) for detailed design. |
 
 ### SimulatedVIOBackend Pipeline
 
@@ -487,11 +488,13 @@ non-airborne states (IDLE, PREFLIGHT), and VIO reaches NOMINAL well before TAKEO
 
 ## Known Limitations
 
-1. **No real VIO fusion:** The Simulated backend generates poses independently of visual/IMU data.
-   Full sensor fusion (optimiser backend) is planned for Phase 2B.
+1. **VIO fusion in progress:** The `SlidingWindowVIOBackend` ("swvio") implements real IMU
+   propagation with error-state covariance (Phase 1 complete). Optimization-based vision
+   updates are in development (Phase 2). The Simulated backend still generates poses
+   independently of sensor data.
 2. **No keyframe selection:** Keyframe config keys exist but no keyframe decision logic runs yet.
-3. **No loop closure:** No place recognition or loop closure optimisation.
+3. **No loop closure:** No place recognition or loop closure optimisation (planned Phase 4).
 4. **No relocalization:** Once tracking is LOST, there is no recovery path — the health
-   stays LOST until the process is restarted.
+   stays LOST until the process is restarted (planned Phase 3).
 5. **Fixed stereo calibration:** Calibration parameters are loaded at startup and cannot
    be updated at runtime.

--- a/process3_slam_vio_nav/CMakeLists.txt
+++ b/process3_slam_vio_nav/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_executable(slam_vio_nav
     src/main.cpp
     src/imu_preintegrator.cpp
+    src/swvio_backend.cpp
 )
 target_include_directories(slam_vio_nav PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/process3_slam_vio_nav/include/slam/ivio_backend.h
+++ b/process3_slam_vio_nav/include/slam/ivio_backend.h
@@ -19,6 +19,7 @@
 #include "slam/ifeature_extractor.h"
 #include "slam/imu_preintegrator.h"
 #include "slam/istereo_matcher.h"
+#include "slam/ivio_interface.h"
 #include "slam/types.h"
 #include "slam/vio_types.h"
 #include "util/diagnostic.h"
@@ -59,33 +60,8 @@ class CosysRpcClient;
 
 namespace drone::slam {
 
-// ─────────────────────────────────────────────────────────────
-// Interface
-// ─────────────────────────────────────────────────────────────
-
-class IVIOBackend {
-public:
-    virtual ~IVIOBackend() = default;
-
-    /// Process one stereo frame + buffered IMU data and produce a VIO output.
-    ///
-    /// @param frame        The stereo frame from the camera.
-    /// @param imu_samples  IMU readings accumulated since the last call.
-    /// @return Ok(VIOOutput) on success, Err(VIOError) on critical failure.
-    virtual VIOResult<VIOOutput> process_frame(const drone::ipc::StereoFrame& frame,
-                                               const std::vector<ImuSample>&  imu_samples) = 0;
-
-    /// Current pipeline health.
-    [[nodiscard]] virtual VIOHealth health() const = 0;
-
-    /// Human-readable name for logging.
-    [[nodiscard]] virtual std::string name() const = 0;
-
-    /// Set trajectory target for simulated navigation.
-    /// Only meaningful for simulated backends — real/Gazebo backends get pose
-    /// from actual sensors and ignore this. Default implementation is a no-op.
-    virtual void set_trajectory_target(float /*x*/, float /*y*/, float /*z*/, float /*yaw*/) {}
-};
+// IVIOBackend interface is defined in slam/ivio_interface.h (extracted to
+// break circular includes with swvio_backend.h).
 
 // ─────────────────────────────────────────────────────────────
 // Simulated VIO backend
@@ -857,12 +833,23 @@ private:
 
 #endif  // HAVE_COSYS_AIRSIM
 
+}  // namespace drone::slam
+
+// ── SWVIO backend (included here so the factory can instantiate it) ──
+// Must come after IVIOBackend is fully defined to avoid circular includes.
+// Included outside the namespace block because swvio_backend.h opens its own
+// drone::slam namespace — nesting would cause double-namespace errors.
+#include "slam/swvio_backend.h"
+
+namespace drone::slam {
+
 // ── Factory ────────────────────────────────────────────────
 
 /// Create a VIO backend by name.
 ///
 /// Supported backends:
 ///   "simulated"       — target-following dynamics (default; works without hardware)
+///   "swvio"           — sliding-window VIO with IMU propagation (Phase 1)
 ///   "gazebo"          — Gazebo ground-truth odometry via gz-transport (HAVE_GAZEBO only)
 ///   "gazebo_full_vio" — full pipeline on Gazebo frames + ground-truth pose (HAVE_GAZEBO only)
 ///   "cosys_airsim"    — Cosys-AirSim ground-truth kinematics via RPC (HAVE_COSYS_AIRSIM only)
@@ -925,8 +912,13 @@ inline std::unique_ptr<IVIOBackend> create_vio_backend(
     (void)cosys_client;
     (void)cosys_vehicle_name;
 #endif
+    if (backend == "swvio") {
+        SWVIOParams swvio_params;  // defaults
+        return std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, swvio_params, 5,
+                                                         good_trace_max, degraded_trace_max);
+    }
     throw std::runtime_error("[VIOBackend] Unknown backend: '" + backend +
-                             "' (available: simulated"
+                             "' (available: simulated, swvio"
 #ifdef HAVE_GAZEBO
                              ", gazebo, gazebo_full_vio"
 #endif

--- a/process3_slam_vio_nav/include/slam/ivio_backend.h
+++ b/process3_slam_vio_nav/include/slam/ivio_backend.h
@@ -913,9 +913,10 @@ inline std::unique_ptr<IVIOBackend> create_vio_backend(
     (void)cosys_vehicle_name;
 #endif
     if (backend == "swvio") {
-        SWVIOParams swvio_params;  // defaults
-        return std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, swvio_params, 5,
-                                                         good_trace_max, degraded_trace_max);
+        SWVIOParams swvio_params;
+        swvio_params.good_trace_max     = good_trace_max;
+        swvio_params.degraded_trace_max = degraded_trace_max;
+        return std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, swvio_params);
     }
     throw std::runtime_error("[VIOBackend] Unknown backend: '" + backend +
                              "' (available: simulated, swvio"

--- a/process3_slam_vio_nav/include/slam/ivio_interface.h
+++ b/process3_slam_vio_nav/include/slam/ivio_interface.h
@@ -26,8 +26,8 @@ public:
     /// @param frame        The stereo frame from the camera.
     /// @param imu_samples  IMU readings accumulated since the last call.
     /// @return Ok(VIOOutput) on success, Err(VIOError) on critical failure.
-    virtual VIOResult<VIOOutput> process_frame(const drone::ipc::StereoFrame& frame,
-                                               const std::vector<ImuSample>&  imu_samples) = 0;
+    [[nodiscard]] virtual VIOResult<VIOOutput> process_frame(
+        const drone::ipc::StereoFrame& frame, const std::vector<ImuSample>& imu_samples) = 0;
 
     /// Current pipeline health.
     [[nodiscard]] virtual VIOHealth health() const = 0;

--- a/process3_slam_vio_nav/include/slam/ivio_interface.h
+++ b/process3_slam_vio_nav/include/slam/ivio_interface.h
@@ -1,0 +1,44 @@
+// process3_slam_vio_nav/include/slam/ivio_interface.h
+// Pure interface for VIO backends — extracted to break circular includes
+// between ivio_backend.h (SimulatedVIOBackend + factory) and
+// swvio_backend.h (SlidingWindowVIOBackend).
+//
+// All VIO backends inherit from IVIOBackend. The factory function
+// create_vio_backend() lives in ivio_backend.h.
+#pragma once
+
+#include "ipc/ipc_types.h"
+#include "slam/types.h"
+#include "slam/vio_types.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace drone::slam {
+
+class IVIOBackend {
+public:
+    virtual ~IVIOBackend() = default;
+
+    /// Process one stereo frame + buffered IMU data and produce a VIO output.
+    ///
+    /// @param frame        The stereo frame from the camera.
+    /// @param imu_samples  IMU readings accumulated since the last call.
+    /// @return Ok(VIOOutput) on success, Err(VIOError) on critical failure.
+    virtual VIOResult<VIOOutput> process_frame(const drone::ipc::StereoFrame& frame,
+                                               const std::vector<ImuSample>&  imu_samples) = 0;
+
+    /// Current pipeline health.
+    [[nodiscard]] virtual VIOHealth health() const = 0;
+
+    /// Human-readable name for logging.
+    [[nodiscard]] virtual std::string name() const = 0;
+
+    /// Set trajectory target for simulated navigation.
+    /// Only meaningful for simulated backends — real/Gazebo backends get pose
+    /// from actual sensors and ignore this. Default implementation is a no-op.
+    virtual void set_trajectory_target(float /*x*/, float /*y*/, float /*z*/, float /*yaw*/) {}
+};
+
+}  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/slam_math.h
+++ b/process3_slam_vio_nav/include/slam/slam_math.h
@@ -1,0 +1,80 @@
+// process3_slam_vio_nav/include/slam/slam_math.h
+// Shared SO(3)/SE(3) math utilities for VIO backends.
+//
+// Provides:
+//   exp_map  : so(3) -> SO(3)  (Rodrigues' formula)
+//   log_map  : SO(3) -> so(3)  (inverse of exp_map)
+//   skew     : R^3   -> so(3)  (skew-symmetric matrix)
+//   left/right Jacobian of SO(3) (for covariance propagation)
+#pragma once
+
+#include <cmath>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace drone::slam {
+
+// ── Exp map: so(3) -> SO(3) (Rodrigues' formula) ────────────
+// Converts an axis-angle vector omega*dt into a unit quaternion.
+// For small angles, uses first-order approximation.
+inline Eigen::Quaterniond exp_map(const Eigen::Vector3d& omega_dt) {
+    const double theta = omega_dt.norm();
+    if (theta < 1e-10) {
+        // First-order approximation for small angles
+        return Eigen::Quaterniond(1.0, omega_dt.x() * 0.5, omega_dt.y() * 0.5, omega_dt.z() * 0.5)
+            .normalized();
+    }
+    Eigen::Vector3d axis = omega_dt / theta;
+    return Eigen::Quaterniond(Eigen::AngleAxisd(theta, axis));
+}
+
+// ── Log map: SO(3) -> so(3) ─────────────────────────────────
+// Inverse of exp_map: extracts the axis-angle vector from a quaternion.
+inline Eigen::Vector3d log_map(const Eigen::Quaterniond& q) {
+    // Ensure w >= 0 for numerical stability (q and -q represent the same rotation)
+    Eigen::Quaterniond q_pos = q.w() >= 0 ? q : Eigen::Quaterniond(-q.w(), -q.x(), -q.y(), -q.z());
+
+    const double sin_half = q_pos.vec().norm();
+    if (sin_half < 1e-10) {
+        // Small angle: theta ~ 2 * sin(theta/2) ~ 2 * ||q.vec()||
+        return 2.0 * q_pos.vec();
+    }
+    const double theta = 2.0 * std::atan2(sin_half, q_pos.w());
+    return theta / sin_half * q_pos.vec();
+}
+
+// ── Skew-symmetric matrix [v]x ──────────────────────────────
+// Returns the 3x3 skew-symmetric matrix such that skew(v)*u = v x u.
+inline Eigen::Matrix3d skew(const Eigen::Vector3d& v) {
+    Eigen::Matrix3d m;
+    m << 0, -v.z(), v.y(), v.z(), 0, -v.x(), -v.y(), v.x(), 0;
+    return m;
+}
+
+// ── Left Jacobian of SO(3) ─────────────────────────────────
+// J_l(phi) maps a perturbation in the tangent space to the group.
+// For small phi, J_l ~ I. Otherwise uses the closed-form expression:
+//   J_l = (sin(t)/t)*I + (1 - sin(t)/t)*a*a^T + ((1 - cos(t))/t)*[a]x
+// where t = ||phi||, a = phi/t.
+inline Eigen::Matrix3d left_jacobian_SO3(const Eigen::Vector3d& phi) {
+    const double theta = phi.norm();
+    if (theta < 1e-10) {
+        return Eigen::Matrix3d::Identity();
+    }
+    const Eigen::Vector3d a     = phi / theta;
+    const double          sin_t = std::sin(theta);
+    const double          cos_t = std::cos(theta);
+
+    // J_l = (sin(t)/t)*I + (1 - sin(t)/t)*a*a^T + ((1 - cos(t))/t)*[a]x
+    return (sin_t / theta) * Eigen::Matrix3d::Identity() +
+           (1.0 - sin_t / theta) * (a * a.transpose()) + ((1.0 - cos_t) / theta) * skew(a);
+}
+
+// ── Right Jacobian of SO(3) ────────────────────────────────
+// J_r(phi) = J_l(-phi).
+inline Eigen::Matrix3d right_jacobian_SO3(const Eigen::Vector3d& phi) {
+    return left_jacobian_SO3(-phi);
+}
+
+}  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/swvio_backend.h
+++ b/process3_slam_vio_nav/include/slam/swvio_backend.h
@@ -19,6 +19,7 @@
 #include "slam/types.h"
 #include "slam/vio_types.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -32,8 +33,10 @@ public:
     SlidingWindowVIOBackend(const StereoCalibration& calib, const ImuNoiseParams& imu_params,
                             const SWVIOParams& params);
 
-    SlidingWindowVIOBackend(const SlidingWindowVIOBackend&)            = delete;
-    SlidingWindowVIOBackend& operator=(const SlidingWindowVIOBackend&) = delete;
+    SlidingWindowVIOBackend(const SlidingWindowVIOBackend&)                = delete;
+    SlidingWindowVIOBackend& operator=(const SlidingWindowVIOBackend&)     = delete;
+    SlidingWindowVIOBackend(SlidingWindowVIOBackend&&) noexcept            = default;
+    SlidingWindowVIOBackend& operator=(SlidingWindowVIOBackend&&) noexcept = default;
 
     [[nodiscard]] VIOResult<VIOOutput> process_frame(
         const drone::ipc::StereoFrame& frame, const std::vector<ImuSample>& imu_samples) override;
@@ -62,19 +65,24 @@ private:
     SWVIOParams       params_;
     StereoCalibration calib_;
     ImuNoiseParams    imu_params_;
+    int               active_cov_dim_ = 0;  // active rows/cols in state_.covariance
 
     // ── Precomputed (constant across lifetime) ─────────────
-    Eigen::Matrix<double, 12, 12> Q_c_;          // continuous-time noise covariance
-    Eigen::MatrixXd               scratch_cov_;  // pre-allocated scratch for augment/marginalize
+    Eigen::Matrix<double, 12, 12> Q_c_;  // continuous-time noise covariance
+
+    // ── Pre-allocated scratch buffers (no hot-path heap alloc) ──
+    Eigen::MatrixXd scratch_cov_;    // for augment/marginalize covariance ops
+    Eigen::MatrixXd cross_scratch_;  // 15 x max_clone_cols, for IMU-clone cross-correlation
+    Eigen::MatrixXd jp_scratch_;     // 6 x max_dim, for augmentation J*P product
 
     // ── Sub-components ─────────────────────────────────────
     std::unique_ptr<IFeatureExtractor> extractor_;
     std::unique_ptr<IStereoMatcher>    matcher_;
 
     // ── Health state machine ───────────────────────────────
-    VIOHealth health_           = VIOHealth::INITIALIZING;
-    int       frames_processed_ = 0;
-    uint64_t  next_clone_id_    = 0;
+    std::atomic<VIOHealth> health_{VIOHealth::INITIALIZING};
+    int                    frames_processed_ = 0;
+    uint64_t               next_clone_id_    = 0;
 };
 
 }  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/swvio_backend.h
+++ b/process3_slam_vio_nav/include/slam/swvio_backend.h
@@ -1,0 +1,80 @@
+// process3_slam_vio_nav/include/slam/swvio_backend.h
+// Sliding-Window Visual-Inertial Odometry (SWVIO) backend.
+//
+// Phase 1: IMU state propagation + state augmentation.
+//   - Propagates IMU error state and covariance through IMU measurements
+//   - Augments state with camera clones at each frame
+//   - Marginalizes oldest clones when the window exceeds max_clones
+//
+// Phase 2 (future): MSCKF-style multi-view feature update.
+//
+// This backend implements IVIOBackend and is registered as "swvio"
+// in the factory function create_vio_backend().
+#pragma once
+
+#include "slam/ifeature_extractor.h"
+#include "slam/istereo_matcher.h"
+#include "slam/ivio_interface.h"
+#include "slam/swvio_types.h"
+#include "slam/types.h"
+#include "slam/vio_types.h"
+
+#include <memory>
+#include <string>
+
+namespace drone::slam {
+
+class SlidingWindowVIOBackend : public IVIOBackend {
+public:
+    /// @param calib             Stereo camera calibration parameters.
+    /// @param imu_params        IMU noise parameters (from datasheet/calibration).
+    /// @param params            SWVIO-specific parameters (window size, thresholds).
+    /// @param init_frames       Frames before transitioning out of INITIALIZING.
+    /// @param good_trace_max    Position trace threshold for NOMINAL health.
+    /// @param degraded_trace_max Position trace threshold for DEGRADED health.
+    SlidingWindowVIOBackend(const StereoCalibration& calib, const ImuNoiseParams& imu_params,
+                            const SWVIOParams& params, int init_frames, double good_trace_max,
+                            double degraded_trace_max);
+
+    VIOResult<VIOOutput> process_frame(const drone::ipc::StereoFrame& frame,
+                                       const std::vector<ImuSample>&  imu_samples) override;
+
+    [[nodiscard]] VIOHealth health() const override;
+
+    [[nodiscard]] std::string name() const override;
+
+private:
+    // ── Core SWVIO operations ──────────────────────────────
+    /// Propagate IMU state and covariance through a sequence of IMU samples.
+    void propagate_imu(const std::vector<ImuSample>& imu_samples);
+
+    /// Clone the current IMU pose into the sliding window.
+    void augment_state(double timestamp);
+
+    /// Remove the oldest camera clone when the window exceeds max_clones.
+    void marginalize_oldest_clone();
+
+    /// Update health state machine based on feature count and covariance.
+    void update_health(int num_features, int num_matches);
+
+    // ── State ──────────────────────────────────────────────
+    SWVIOState        state_;
+    SWVIOParams       params_;
+    StereoCalibration calib_;
+    ImuNoiseParams    imu_params_;
+
+    // ── Sub-components ─────────────────────────────────────
+    std::unique_ptr<IFeatureExtractor> extractor_;
+    std::unique_ptr<IStereoMatcher>    matcher_;
+
+    // ── Health state machine ───────────────────────────────
+    VIOHealth health_             = VIOHealth::INITIALIZING;
+    int       frames_processed_   = 0;
+    int       init_frames_        = 10;
+    double    good_trace_max_     = 0.1;
+    double    degraded_trace_max_ = 1.0;
+
+    uint64_t next_clone_id_ = 0;
+};
+
+}  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/swvio_backend.h
+++ b/process3_slam_vio_nav/include/slam/swvio_backend.h
@@ -26,36 +26,36 @@ namespace drone::slam {
 
 class SlidingWindowVIOBackend : public IVIOBackend {
 public:
-    /// @param calib             Stereo camera calibration parameters.
-    /// @param imu_params        IMU noise parameters (from datasheet/calibration).
-    /// @param params            SWVIO-specific parameters (window size, thresholds).
-    /// @param init_frames       Frames before transitioning out of INITIALIZING.
-    /// @param good_trace_max    Position trace threshold for NOMINAL health.
-    /// @param degraded_trace_max Position trace threshold for DEGRADED health.
+    /// @param calib      Stereo camera calibration parameters.
+    /// @param imu_params IMU noise parameters (from datasheet/calibration).
+    /// @param params     SWVIO-specific parameters (window size, thresholds, health).
     SlidingWindowVIOBackend(const StereoCalibration& calib, const ImuNoiseParams& imu_params,
-                            const SWVIOParams& params, int init_frames, double good_trace_max,
-                            double degraded_trace_max);
+                            const SWVIOParams& params);
 
-    VIOResult<VIOOutput> process_frame(const drone::ipc::StereoFrame& frame,
-                                       const std::vector<ImuSample>&  imu_samples) override;
+    SlidingWindowVIOBackend(const SlidingWindowVIOBackend&)            = delete;
+    SlidingWindowVIOBackend& operator=(const SlidingWindowVIOBackend&) = delete;
+
+    [[nodiscard]] VIOResult<VIOOutput> process_frame(
+        const drone::ipc::StereoFrame& frame, const std::vector<ImuSample>& imu_samples) override;
 
     [[nodiscard]] VIOHealth health() const override;
 
     [[nodiscard]] std::string name() const override;
 
+    [[nodiscard]] int clone_count() const { return static_cast<int>(state_.clones.size()); }
+    [[nodiscard]] int state_dim() const { return state_.state_dim(); }
+
 private:
     // ── Core SWVIO operations ──────────────────────────────
-    /// Propagate IMU state and covariance through a sequence of IMU samples.
     void propagate_imu(const std::vector<ImuSample>& imu_samples);
-
-    /// Clone the current IMU pose into the sliding window.
     void augment_state(double timestamp);
-
-    /// Remove the oldest camera clone when the window exceeds max_clones.
     void marginalize_oldest_clone();
 
-    /// Update health state machine based on feature count and covariance.
-    void update_health(int num_features, int num_matches);
+    /// Update health based on position covariance trace and initialization frame count.
+    void update_health();
+
+    /// Enforce covariance symmetry (call once per frame, not per IMU step).
+    void enforce_symmetry();
 
     // ── State ──────────────────────────────────────────────
     SWVIOState        state_;
@@ -63,18 +63,18 @@ private:
     StereoCalibration calib_;
     ImuNoiseParams    imu_params_;
 
+    // ── Precomputed (constant across lifetime) ─────────────
+    Eigen::Matrix<double, 12, 12> Q_c_;          // continuous-time noise covariance
+    Eigen::MatrixXd               scratch_cov_;  // pre-allocated scratch for augment/marginalize
+
     // ── Sub-components ─────────────────────────────────────
     std::unique_ptr<IFeatureExtractor> extractor_;
     std::unique_ptr<IStereoMatcher>    matcher_;
 
     // ── Health state machine ───────────────────────────────
-    VIOHealth health_             = VIOHealth::INITIALIZING;
-    int       frames_processed_   = 0;
-    int       init_frames_        = 10;
-    double    good_trace_max_     = 0.1;
-    double    degraded_trace_max_ = 1.0;
-
-    uint64_t next_clone_id_ = 0;
+    VIOHealth health_           = VIOHealth::INITIALIZING;
+    int       frames_processed_ = 0;
+    uint64_t  next_clone_id_    = 0;
 };
 
 }  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/swvio_types.h
+++ b/process3_slam_vio_nav/include/slam/swvio_types.h
@@ -1,0 +1,86 @@
+// process3_slam_vio_nav/include/slam/swvio_types.h
+// Types for the Sliding-Window Visual-Inertial Odometry (SWVIO) backend.
+//
+// Defines the error-state parameterization:
+//   IMU state: 15-DOF (orientation[3], position[3], velocity[3],
+//              gyro_bias[3], accel_bias[3])
+//   Camera clone: 6-DOF (orientation[3], position[3])
+//   Full state: 15 + 6*N_clones
+//
+// Covariance is maintained over the full error state and grows/shrinks
+// as camera clones are augmented/marginalized.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace drone::slam {
+
+/// Parameters for the SWVIO backend.
+/// All tunables should be loaded from drone::Config at construction time.
+struct SWVIOParams {
+    int    max_clones            = 15;     // sliding window size
+    int    min_track_length      = 3;      // minimum feature track length for triangulation
+    int    max_gn_iterations     = 5;      // Gauss-Newton iterations per update
+    double convergence_threshold = 1e-6;   // GN convergence criterion
+    double chi2_threshold        = 5.991;  // chi-squared gate for outlier rejection (95%, 2 DOF)
+    double noise_image_pixel     = 1.0;    // image measurement noise (pixels)
+    int    init_frames           = 10;     // frames before transitioning out of INITIALIZING
+    bool   enable_marginalization_prior = true;
+
+    // Gravity vector in world frame (NED convention: [0,0,9.81] for "up"
+    // in accelerometer reading, but gravity acceleration is [0,0,-9.81])
+    Eigen::Vector3d gravity{0, 0, -9.81};
+
+    // IMU-camera extrinsic transformation (identity = co-located sensors)
+    Eigen::Quaterniond T_imu_cam_rotation{Eigen::Quaterniond::Identity()};
+    Eigen::Vector3d    T_imu_cam_translation{Eigen::Vector3d::Zero()};
+};
+
+/// IMU state: full nominal state (position, velocity, orientation, biases).
+struct IMUState {
+    double             timestamp = 0;
+    Eigen::Quaterniond orientation{Eigen::Quaterniond::Identity()};
+    Eigen::Vector3d    position{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d    velocity{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d    gyro_bias{Eigen::Vector3d::Zero()};
+    Eigen::Vector3d    accel_bias{Eigen::Vector3d::Zero()};
+};
+
+/// A camera clone stores the pose at the time a frame was captured.
+/// Used for multi-view geometry constraints in the sliding window.
+struct CameraClone {
+    uint64_t           clone_id  = 0;
+    double             timestamp = 0;
+    Eigen::Quaterniond orientation{Eigen::Quaterniond::Identity()};
+    Eigen::Vector3d    position{Eigen::Vector3d::Zero()};
+};
+
+/// Full SWVIO state: IMU state + sliding window of camera clones + covariance.
+struct SWVIOState {
+    IMUState                 imu;
+    std::vector<CameraClone> clones;
+    Eigen::MatrixXd          covariance;  // (15 + 6*N_clones) x (15 + 6*N_clones)
+
+    // ── Error state indices ─────────────────────────────────
+    static constexpr int kIdxTheta      = 0;   // orientation error (3)
+    static constexpr int kIdxPos        = 3;   // position error (3)
+    static constexpr int kIdxVel        = 6;   // velocity error (3)
+    static constexpr int kIdxBg         = 9;   // gyro bias error (3)
+    static constexpr int kIdxBa         = 12;  // accel bias error (3)
+    static constexpr int kImuStateDim   = 15;
+    static constexpr int kCloneStateDim = 6;  // orientation(3) + position(3)
+
+    /// Total dimension of the error state vector.
+    [[nodiscard]] int state_dim() const {
+        return kImuStateDim + kCloneStateDim * static_cast<int>(clones.size());
+    }
+
+    /// Start index of clone i in the error state vector.
+    [[nodiscard]] int clone_index(int i) const { return kImuStateDim + kCloneStateDim * i; }
+};
+
+}  // namespace drone::slam

--- a/process3_slam_vio_nav/include/slam/swvio_types.h
+++ b/process3_slam_vio_nav/include/slam/swvio_types.h
@@ -41,7 +41,7 @@ struct SWVIOParams {
     Eigen::Quaterniond T_imu_cam_rotation{Eigen::Quaterniond::Identity()};
     Eigen::Vector3d    T_imu_cam_translation{Eigen::Vector3d::Zero()};
 
-    [[nodiscard]] bool validate() const {
+    [[nodiscard]] constexpr bool validate() const {
         return max_clones > 0 && max_clones <= 30 && init_frames > 0 && good_trace_max > 0.0 &&
                degraded_trace_max > good_trace_max && noise_image_pixel > 0.0 &&
                chi2_threshold > 0.0;
@@ -71,7 +71,8 @@ struct CameraClone {
 struct SWVIOState {
     IMUState                imu;
     std::deque<CameraClone> clones;
-    Eigen::MatrixXd         covariance;  // (15 + 6*N_clones) x (15 + 6*N_clones)
+    // Covariance is pre-allocated to max capacity; active_cov_dim_ tracks the used region.
+    Eigen::MatrixXd covariance;  // (15 + 6*N_clones) x (15 + 6*N_clones)
 
     // ── Error state indices ─────────────────────────────────
     static constexpr int kIdxTheta      = 0;   // orientation error (3)

--- a/process3_slam_vio_nav/include/slam/swvio_types.h
+++ b/process3_slam_vio_nav/include/slam/swvio_types.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
+#include <deque>
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -30,6 +30,8 @@ struct SWVIOParams {
     double noise_image_pixel     = 1.0;    // image measurement noise (pixels)
     int    init_frames           = 10;     // frames before transitioning out of INITIALIZING
     bool   enable_marginalization_prior = true;
+    double good_trace_max               = 0.1;  // position trace threshold for NOMINAL health
+    double degraded_trace_max           = 1.0;  // position trace threshold for DEGRADED health
 
     // Gravity vector in world frame (NED convention: [0,0,9.81] for "up"
     // in accelerometer reading, but gravity acceleration is [0,0,-9.81])
@@ -38,6 +40,12 @@ struct SWVIOParams {
     // IMU-camera extrinsic transformation (identity = co-located sensors)
     Eigen::Quaterniond T_imu_cam_rotation{Eigen::Quaterniond::Identity()};
     Eigen::Vector3d    T_imu_cam_translation{Eigen::Vector3d::Zero()};
+
+    [[nodiscard]] bool validate() const {
+        return max_clones > 0 && max_clones <= 30 && init_frames > 0 && good_trace_max > 0.0 &&
+               degraded_trace_max > good_trace_max && noise_image_pixel > 0.0 &&
+               chi2_threshold > 0.0;
+    }
 };
 
 /// IMU state: full nominal state (position, velocity, orientation, biases).
@@ -61,9 +69,9 @@ struct CameraClone {
 
 /// Full SWVIO state: IMU state + sliding window of camera clones + covariance.
 struct SWVIOState {
-    IMUState                 imu;
-    std::vector<CameraClone> clones;
-    Eigen::MatrixXd          covariance;  // (15 + 6*N_clones) x (15 + 6*N_clones)
+    IMUState                imu;
+    std::deque<CameraClone> clones;
+    Eigen::MatrixXd         covariance;  // (15 + 6*N_clones) x (15 + 6*N_clones)
 
     // ── Error state indices ─────────────────────────────────
     static constexpr int kIdxTheta      = 0;   // orientation error (3)

--- a/process3_slam_vio_nav/src/imu_preintegrator.cpp
+++ b/process3_slam_vio_nav/src/imu_preintegrator.cpp
@@ -9,29 +9,15 @@
 
 #include "slam/imu_preintegrator.h"
 
+#include "slam/slam_math.h"
+
 #include <cmath>
 
 namespace drone::slam {
 
-// ── Exp map: so(3) → SO(3) ──────────────────────────────────
-// Rodrigues' formula for the exponential map.
-static Eigen::Quaterniond exp_map(const Eigen::Vector3d& omega_dt) {
-    double theta = omega_dt.norm();
-    if (theta < 1e-10) {
-        // First-order approximation for small angles
-        return Eigen::Quaterniond(1.0, omega_dt.x() * 0.5, omega_dt.y() * 0.5, omega_dt.z() * 0.5)
-            .normalized();
-    }
-    Eigen::Vector3d axis = omega_dt / theta;
-    return Eigen::Quaterniond(Eigen::AngleAxisd(theta, axis));
-}
-
-// ── Skew-symmetric matrix [v]× ──────────────────────────────
-static Eigen::Matrix3d skew(const Eigen::Vector3d& v) {
-    Eigen::Matrix3d m;
-    m << 0, -v.z(), v.y(), v.z(), 0, -v.x(), -v.y(), v.x(), 0;
-    return m;
-}
+// exp_map() and skew() are now in slam/slam_math.h (shared with SWVIO backend)
+using drone::slam::exp_map;
+using drone::slam::skew;
 
 ImuPreintegrator::ImuPreintegrator(ImuNoiseParams params) : params_(params) {}
 

--- a/process3_slam_vio_nav/src/swvio_backend.cpp
+++ b/process3_slam_vio_nav/src/swvio_backend.cpp
@@ -7,8 +7,8 @@
 //   - Oldest-clone marginalization
 //   - Health state machine (covariance-based quality)
 //
-// Phase 2 (future) will add MSCKF-style multi-view feature updates
-// that constrain the accumulated IMU drift.
+// Phase 2 (future) will add sliding-window Gauss-Newton optimization
+// that constrains accumulated IMU drift via multi-view feature updates.
 
 #include "slam/swvio_backend.h"
 
@@ -17,22 +17,25 @@
 #include "util/ilogger.h"
 
 #include <chrono>
+#include <cmath>
 
 namespace drone::slam {
+
+// IMU sample validation thresholds
+constexpr double   kMaxImuAccelMps2  = 200.0;  // ~20g
+constexpr double   kMaxImuGyroRadSec = 35.0;   // ~2000 deg/s
+constexpr double   kMaxDtSec         = 0.1;    // no IMU gap > 100ms
+constexpr uint64_t kMaxTimestampNs   = 10ULL * 365 * 24 * 3600 * 1'000'000'000ULL;  // ~10 years
 
 // ── Constructor ─────────────────────────────────────────────
 SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
                                                  const ImuNoiseParams&    imu_params,
-                                                 const SWVIOParams& params, int init_frames,
-                                                 double good_trace_max, double degraded_trace_max)
+                                                 const SWVIOParams&       params)
     : params_(params)
     , calib_(calib)
     , imu_params_(imu_params)
     , extractor_(std::make_unique<SimulatedFeatureExtractor>())
-    , matcher_(std::make_unique<SimulatedStereoMatcher>(calib))
-    , init_frames_(init_frames)
-    , good_trace_max_(good_trace_max)
-    , degraded_trace_max_(degraded_trace_max) {
+    , matcher_(std::make_unique<SimulatedStereoMatcher>(calib)) {
 
     // Initialize IMU state at origin with identity orientation
     state_.imu.orientation = Eigen::Quaterniond::Identity();
@@ -42,32 +45,43 @@ SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
     state_.imu.accel_bias  = Eigen::Vector3d::Zero();
     state_.imu.timestamp   = 0.0;
 
-    // Initialize covariance: 15x15 for IMU error state only (no clones yet).
-    // Diagonal entries reflect initial uncertainty in each state component.
+    // Initialize covariance: 15x15 for IMU error state only (no clones yet)
     constexpr int kDim = SWVIOState::kImuStateDim;
     state_.covariance  = Eigen::MatrixXd::Zero(kDim, kDim);
 
-    // Orientation uncertainty (rad^2)
     state_.covariance.block<3, 3>(SWVIOState::kIdxTheta,
                                   SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity() * 1e-3;
-    // Position uncertainty (m^2)
     state_.covariance.block<3, 3>(SWVIOState::kIdxPos,
-                                  SWVIOState::kIdxPos) = Eigen::Matrix3d::Identity() * 1e-2;
-    // Velocity uncertainty (m/s)^2
+                                  SWVIOState::kIdxPos)   = Eigen::Matrix3d::Identity() * 1e-2;
     state_.covariance.block<3, 3>(SWVIOState::kIdxVel,
-                                  SWVIOState::kIdxVel) = Eigen::Matrix3d::Identity() * 1e-2;
-    // Gyro bias uncertainty (rad/s)^2
+                                  SWVIOState::kIdxVel)   = Eigen::Matrix3d::Identity() * 1e-2;
     state_.covariance.block<3, 3>(SWVIOState::kIdxBg,
-                                  SWVIOState::kIdxBg) = Eigen::Matrix3d::Identity() * 1e-4;
-    // Accel bias uncertainty (m/s^2)^2
+                                  SWVIOState::kIdxBg)    = Eigen::Matrix3d::Identity() * 1e-4;
     state_.covariance.block<3, 3>(SWVIOState::kIdxBa,
-                                  SWVIOState::kIdxBa) = Eigen::Matrix3d::Identity() * 1e-4;
+                                  SWVIOState::kIdxBa)    = Eigen::Matrix3d::Identity() * 1e-4;
+
+    // Precompute continuous-time noise covariance Q_c (constant across lifetime)
+    const double sg2  = imu_params_.gyro_noise_density * imu_params_.gyro_noise_density;
+    const double sa2  = imu_params_.accel_noise_density * imu_params_.accel_noise_density;
+    const double sbg2 = imu_params_.gyro_random_walk * imu_params_.gyro_random_walk;
+    const double sba2 = imu_params_.accel_random_walk * imu_params_.accel_random_walk;
+
+    Q_c_                   = Eigen::Matrix<double, 12, 12>::Zero();
+    Q_c_.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity() * sg2;
+    Q_c_.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * sa2;
+    Q_c_.block<3, 3>(6, 6) = Eigen::Matrix3d::Identity() * sbg2;
+    Q_c_.block<3, 3>(9, 9) = Eigen::Matrix3d::Identity() * sba2;
+
+    // Pre-allocate scratch covariance buffer — +1 because augmentation
+    // temporarily grows the window to max_clones+1 before marginalization.
+    const int max_dim = SWVIOState::kImuStateDim +
+                        SWVIOState::kCloneStateDim * (params_.max_clones + 1);
+    scratch_cov_ = Eigen::MatrixXd::Zero(max_dim, max_dim);
 }
 
 // ── IMU state propagation ───────────────────────────────────
-// For each consecutive pair of IMU samples, propagates the nominal
-// state forward and updates the error-state covariance using the
-// linearized continuous-time model discretized at the IMU rate.
+// Propagates the nominal state and error-state covariance through
+// a sequence of IMU samples using trapezoidal (midpoint) integration.
 void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_samples) {
     if (imu_samples.size() < 2) {
         return;
@@ -76,6 +90,17 @@ void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_sa
     for (size_t i = 1; i < imu_samples.size(); ++i) {
         const double dt = imu_samples[i].timestamp - imu_samples[i - 1].timestamp;
         if (dt <= 0.0) {
+            continue;
+        }
+
+        // Validate sample: reject NaN/Inf, out-of-range, or large time gaps
+        const auto& accel = imu_samples[i].accel;
+        const auto& gyro  = imu_samples[i].gyro;
+        if (!std::isfinite(accel.x()) || !std::isfinite(accel.y()) || !std::isfinite(accel.z()) ||
+            !std::isfinite(gyro.x()) || !std::isfinite(gyro.y()) || !std::isfinite(gyro.z()) ||
+            accel.norm() > kMaxImuAccelMps2 || gyro.norm() > kMaxImuGyroRadSec || dt > kMaxDtSec) {
+            DRONE_LOG_WARN("[SWVIO] IMU sample {} rejected: accel={:.1f} gyro={:.1f} dt={:.4f}", i,
+                           accel.norm(), gyro.norm(), dt);
             continue;
         }
 
@@ -92,98 +117,50 @@ void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_sa
         const Eigen::Vector3d accel_world = R * accel_mid + params_.gravity;
 
         // ── Nominal state update ────────────────────────────
-        // Position: p += v*dt + 0.5*a*dt^2
         state_.imu.position += state_.imu.velocity * dt + 0.5 * accel_world * dt * dt;
-
-        // Velocity: v += a*dt
         state_.imu.velocity += accel_world * dt;
-
-        // Orientation: q = q * exp(omega*dt)
         state_.imu.orientation = (state_.imu.orientation * exp_map(gyro_mid * dt)).normalized();
-
-        // Update timestamp
-        state_.imu.timestamp = imu_samples[i].timestamp;
+        state_.imu.timestamp   = imu_samples[i].timestamp;
 
         // ── Error-state transition matrix F (15x15) ─────────
-        // Linearization of the error-state dynamics around the current
-        // nominal state. Uses first-order approximation for dt terms.
         Eigen::Matrix<double, 15, 15> F = Eigen::Matrix<double, 15, 15>::Identity();
 
-        // F[theta, theta] = I - skew(omega)*dt (first-order approx of exp(-skew(w)*dt))
-        F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxTheta) -= skew(gyro_mid) * dt;
+        // Cache R*skew(accel_mid) — used in both velocity and position blocks
+        const Eigen::Matrix3d R_skew_a = R * skew(accel_mid);
 
-        // F[theta, bg] = -I*dt (gyro bias effect on orientation)
+        F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxTheta) -= skew(gyro_mid) * dt;
         F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxBg) = -Eigen::Matrix3d::Identity() *
                                                                    dt;
-
-        // F[vel, theta] = -R*skew(a)*dt (orientation error -> velocity error)
-        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxTheta) = -R * skew(accel_mid) * dt;
-
-        // F[vel, ba] = -R*dt (accel bias effect on velocity)
-        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxBa) = -R * dt;
-
-        // F[pos, vel] = I*dt
+        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxTheta) = -R_skew_a * dt;
+        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxBa)    = -R * dt;
         F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxVel) = Eigen::Matrix3d::Identity() * dt;
-
-        // F[pos, theta] = -0.5*R*skew(a)*dt^2
-        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxTheta) = -0.5 * R * skew(accel_mid) *
-                                                                    dt * dt;
-
-        // F[pos, ba] = -0.5*R*dt^2
-        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxBa) = -0.5 * R * dt * dt;
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxTheta) = -0.5 * R_skew_a * dt * dt;
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxBa)    = -0.5 * R * dt * dt;
 
         // ── Noise Jacobian G (15x12) ────────────────────────
-        // Maps continuous-time noise [n_g(3), n_a(3), n_bg(3), n_ba(3)]
-        // to the error state.
         Eigen::Matrix<double, 15, 12> G = Eigen::Matrix<double, 15, 12>::Zero();
 
-        // Gyro noise -> orientation
         G.block<3, 3>(SWVIOState::kIdxTheta, 0) = -Eigen::Matrix3d::Identity() * dt;
+        G.block<3, 3>(SWVIOState::kIdxVel, 3)   = -R * dt;
+        G.block<3, 3>(SWVIOState::kIdxPos, 3)   = -0.5 * R * dt * dt;
+        G.block<3, 3>(SWVIOState::kIdxBg, 6)    = Eigen::Matrix3d::Identity() * dt;
+        G.block<3, 3>(SWVIOState::kIdxBa, 9)    = Eigen::Matrix3d::Identity() * dt;
 
-        // Accel noise -> velocity
-        G.block<3, 3>(SWVIOState::kIdxVel, 3) = -R * dt;
-
-        // Accel noise -> position
-        G.block<3, 3>(SWVIOState::kIdxPos, 3) = -0.5 * R * dt * dt;
-
-        // Gyro bias random walk
-        G.block<3, 3>(SWVIOState::kIdxBg, 6) = Eigen::Matrix3d::Identity() * dt;
-
-        // Accel bias random walk
-        G.block<3, 3>(SWVIOState::kIdxBa, 9) = Eigen::Matrix3d::Identity() * dt;
-
-        // ── Continuous-time noise covariance Q_c (12x12) ────
-        Eigen::Matrix<double, 12, 12> Q_c = Eigen::Matrix<double, 12, 12>::Zero();
-
-        const double sg2  = imu_params_.gyro_noise_density * imu_params_.gyro_noise_density;
-        const double sa2  = imu_params_.accel_noise_density * imu_params_.accel_noise_density;
-        const double sbg2 = imu_params_.gyro_random_walk * imu_params_.gyro_random_walk;
-        const double sba2 = imu_params_.accel_random_walk * imu_params_.accel_random_walk;
-
-        Q_c.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity() * sg2;
-        Q_c.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * sa2;
-        Q_c.block<3, 3>(6, 6) = Eigen::Matrix3d::Identity() * sbg2;
-        Q_c.block<3, 3>(9, 9) = Eigen::Matrix3d::Identity() * sba2;
-
-        // ── Covariance propagation ──────────────────────────
+        // ── Covariance propagation (fixed-size for IMU block) ──
         const int n = state_.state_dim();
 
         // IMU-IMU block: P_ii = F * P_ii * F^T + G * Q_c * G^T
-        const Eigen::MatrixXd P_ii = F * state_.covariance.block<15, 15>(0, 0) * F.transpose() +
-                                     G * Q_c * G.transpose();
+        const Eigen::Matrix<double, 15, 15> P_ii =
+            F * state_.covariance.block<15, 15>(0, 0) * F.transpose() + G * Q_c_ * G.transpose();
         state_.covariance.block<15, 15>(0, 0) = P_ii;
 
         // IMU-clone cross-correlations: P_ij = F * P_ij for each clone j
         if (n > 15) {
             state_.covariance.block(0, 15, 15, n - 15) = F *
                                                          state_.covariance.block(0, 15, 15, n - 15);
-            // Symmetric: P_ji = P_ij^T
             state_.covariance.block(15, 0, n - 15,
                                     15) = state_.covariance.block(0, 15, 15, n - 15).transpose();
         }
-
-        // Enforce symmetry to prevent numerical drift
-        state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
     }
 }
 
@@ -191,7 +168,6 @@ void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_sa
 // Clones the current IMU pose (orientation + position) into the
 // sliding window and expands the covariance accordingly.
 void SlidingWindowVIOBackend::augment_state(double timestamp) {
-    // Create a new camera clone from the current IMU state
     CameraClone clone;
     clone.clone_id    = next_clone_id_++;
     clone.timestamp   = timestamp;
@@ -199,48 +175,40 @@ void SlidingWindowVIOBackend::augment_state(double timestamp) {
     clone.position    = state_.imu.position;
     state_.clones.push_back(clone);
 
-    // Build the augmentation Jacobian J (6x15):
-    // Maps IMU error state to the new clone's error state.
-    //   clone_theta = imu_theta  -> J[0:3, 0:3] = I
-    //   clone_pos   = imu_pos    -> J[3:6, 3:6] = I
+    // Augmentation Jacobian J (6x15): clone pose = IMU pose
     Eigen::Matrix<double, 6, 15> J          = Eigen::Matrix<double, 6, 15>::Zero();
     J.block<3, 3>(0, SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity();
     J.block<3, 3>(3, SWVIOState::kIdxPos)   = Eigen::Matrix3d::Identity();
 
-    // Expand covariance from (n x n) to (n+6 x n+6)
-    const int old_dim = state_.state_dim() - SWVIOState::kCloneStateDim;  // before clone was added
+    // Expand covariance from (old_dim) to (old_dim + 6) using pre-allocated scratch
+    const int old_dim = state_.state_dim() - SWVIOState::kCloneStateDim;
     const int new_dim = state_.state_dim();
 
-    Eigen::MatrixXd P_new = Eigen::MatrixXd::Zero(new_dim, new_dim);
+    scratch_cov_.block(0, 0, old_dim, old_dim) = state_.covariance.block(0, 0, old_dim, old_dim);
 
-    // Copy old covariance
-    P_new.block(0, 0, old_dim, old_dim) = state_.covariance;
-
-    // Cross-correlation: P * J^T (bottom-left and top-right)
-    // J operates on the IMU block (first 15 rows/cols of P)
-    const Eigen::MatrixXd JP            = J * state_.covariance.block(0, 0, 15, old_dim);
-    P_new.block(old_dim, 0, 6, old_dim) = JP;
-    P_new.block(0, old_dim, old_dim, 6) = JP.transpose();
+    // Cross-correlation: J * P_imu (first 15 cols of each row)
+    const Eigen::MatrixXd JP                   = J * state_.covariance.block(0, 0, 15, old_dim);
+    scratch_cov_.block(old_dim, 0, 6, old_dim) = JP;
+    scratch_cov_.block(0, old_dim, old_dim, 6) = JP.transpose();
 
     // New clone's self-covariance: J * P_imu * J^T
-    P_new.block<6, 6>(old_dim, old_dim) = J * state_.covariance.block<15, 15>(0, 0) * J.transpose();
+    scratch_cov_.block<6, 6>(old_dim, old_dim) = J * state_.covariance.block<15, 15>(0, 0) *
+                                                 J.transpose();
 
-    state_.covariance = P_new;
-
-    // Enforce symmetry
-    state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
+    state_.covariance = scratch_cov_.block(0, 0, new_dim, new_dim);
 }
 
 // ── Marginalize oldest clone ────────────────────────────────
-// Removes the oldest camera clone from the state and shrinks
-// the covariance matrix by removing the corresponding rows/cols.
+// Removes the oldest camera clone when the window has more than
+// max_clones entries (window briefly reaches max_clones+1 after
+// augmentation, then shrinks back to max_clones here).
 void SlidingWindowVIOBackend::marginalize_oldest_clone() {
     if (static_cast<int>(state_.clones.size()) <= params_.max_clones) {
         return;
     }
 
-    // Remove the first clone
-    state_.clones.erase(state_.clones.begin());
+    // Remove the first clone (O(1) with deque)
+    state_.clones.pop_front();
 
     // Remove rows/cols [15..20] from covariance (the oldest clone's 6 DOF)
     const int remove_start = SWVIOState::kImuStateDim;
@@ -248,45 +216,43 @@ void SlidingWindowVIOBackend::marginalize_oldest_clone() {
     const int old_dim      = static_cast<int>(state_.covariance.rows());
     const int new_dim      = old_dim - SWVIOState::kCloneStateDim;
 
-    Eigen::MatrixXd P_new = Eigen::MatrixXd::Zero(new_dim, new_dim);
+    // Copy into pre-allocated scratch, skipping the removed block
+    scratch_cov_.block(0, 0, remove_start,
+                       remove_start) = state_.covariance.block(0, 0, remove_start, remove_start);
 
-    // Copy the IMU block (rows/cols 0..14)
-    P_new.block(0, 0, remove_start, remove_start) = state_.covariance.block(0, 0, remove_start,
-                                                                            remove_start);
-
-    // Copy the remaining clones block (rows/cols after the removed one)
     const int after = old_dim - remove_end;
     if (after > 0) {
-        // Bottom-right block
-        P_new.block(remove_start, remove_start, after,
-                    after) = state_.covariance.block(remove_end, remove_end, after, after);
-
-        // Cross-correlations with IMU
-        P_new.block(0, remove_start, remove_start,
-                    after)        = state_.covariance.block(0, remove_end, remove_start, after);
-        P_new.block(remove_start, 0, after,
-                    remove_start) = state_.covariance.block(remove_end, 0, after, remove_start);
+        scratch_cov_.block(remove_start, remove_start, after,
+                           after) = state_.covariance.block(remove_end, remove_end, after, after);
+        scratch_cov_.block(0, remove_start, remove_start,
+                           after) = state_.covariance.block(0, remove_end, remove_start, after);
+        scratch_cov_.block(remove_start, 0, after, remove_start) =
+            state_.covariance.block(remove_end, 0, after, remove_start);
     }
 
-    state_.covariance = P_new;
+    state_.covariance = scratch_cov_.block(0, 0, new_dim, new_dim);
+}
+
+// ── Enforce covariance symmetry ─────────────────────────────
+void SlidingWindowVIOBackend::enforce_symmetry() {
+    state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
 }
 
 // ── Health state machine ────────────────────────────────────
 // Transitions between INITIALIZING -> NOMINAL / DEGRADED / LOST
-// based on frame count and position covariance trace.
-void SlidingWindowVIOBackend::update_health(int /*num_features*/, int /*num_matches*/) {
+// based on initialization frame count and position covariance trace.
+void SlidingWindowVIOBackend::update_health() {
     VIOHealth new_health = health_;
 
-    if (frames_processed_ < init_frames_) {
+    if (frames_processed_ < params_.init_frames) {
         new_health = VIOHealth::INITIALIZING;
     } else {
-        // Compute position covariance trace
         const double pos_trace =
             state_.covariance.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxPos).trace();
 
-        if (pos_trace <= good_trace_max_) {
+        if (pos_trace <= params_.good_trace_max) {
             new_health = VIOHealth::NOMINAL;
-        } else if (pos_trace <= degraded_trace_max_) {
+        } else if (pos_trace <= params_.degraded_trace_max) {
             new_health = VIOHealth::DEGRADED;
         } else {
             new_health = VIOHealth::LOST;
@@ -307,6 +273,12 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
     const auto                    pipeline_start = std::chrono::steady_clock::now();
     const uint64_t                seq            = frame.sequence_number;
     drone::util::FrameDiagnostics diag(seq);
+
+    // Validate frame timestamp
+    if (frame.timestamp_ns > kMaxTimestampNs) {
+        return VIOResult<VIOOutput>::err(VIOError{VIOErrorCode::TrackingLost, "SWVIOBackend",
+                                                  "timestamp_ns out of plausible range", seq});
+    }
 
     VIOOutput output;
     output.frame_id = seq;
@@ -343,16 +315,18 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
     // ── 5. Marginalize if window exceeds max_clones ─────────
     marginalize_oldest_clone();
 
-    // ── 6. Health state machine ─────────────────────────────
+    // ── 6. Enforce covariance symmetry (once per frame) ─────
+    enforce_symmetry();
+
+    // ── 7. Health state machine ─────────────────────────────
     ++frames_processed_;
-    update_health(output.num_features, output.num_stereo_matches);
+    update_health();
     output.health = health_;
 
-    // ── 7. Build output pose from current IMU state ─────────
+    // ── 8. Build output pose from current IMU state ─────────
     output.pose.position    = state_.imu.position;
     output.pose.orientation = state_.imu.orientation;
-    output.pose.timestamp =
-        std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    output.pose.timestamp   = frame_time;
 
     // Extract 6x6 pose covariance (orientation + position blocks)
     output.pose.covariance                   = Eigen::Matrix<double, 6, 6>::Zero();
@@ -369,11 +343,10 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
         case VIOHealth::NOMINAL: output.pose.quality = 2; break;
     }
 
-    // Position covariance trace for monitoring
     output.position_trace =
         state_.covariance.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxPos).trace();
 
-    // ── 8. Pipeline timing ──────────────────────────────────
+    // ── 9. Pipeline timing ──────────────────────────────────
     const auto pipeline_end = std::chrono::steady_clock::now();
     output.total_ms =
         std::chrono::duration<double, std::milli>(pipeline_end - pipeline_start).count();

--- a/process3_slam_vio_nav/src/swvio_backend.cpp
+++ b/process3_slam_vio_nav/src/swvio_backend.cpp
@@ -1,0 +1,392 @@
+// process3_slam_vio_nav/src/swvio_backend.cpp
+// Sliding-Window Visual-Inertial Odometry backend — Phase 1 implementation.
+//
+// Phase 1 provides:
+//   - IMU state propagation with error-state covariance
+//   - Camera clone augmentation into the sliding window
+//   - Oldest-clone marginalization
+//   - Health state machine (covariance-based quality)
+//
+// Phase 2 (future) will add MSCKF-style multi-view feature updates
+// that constrain the accumulated IMU drift.
+
+#include "slam/swvio_backend.h"
+
+#include "slam/slam_math.h"
+#include "util/diagnostic.h"
+#include "util/ilogger.h"
+
+#include <chrono>
+
+namespace drone::slam {
+
+// ── Constructor ─────────────────────────────────────────────
+SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
+                                                 const ImuNoiseParams&    imu_params,
+                                                 const SWVIOParams& params, int init_frames,
+                                                 double good_trace_max, double degraded_trace_max)
+    : params_(params)
+    , calib_(calib)
+    , imu_params_(imu_params)
+    , extractor_(std::make_unique<SimulatedFeatureExtractor>())
+    , matcher_(std::make_unique<SimulatedStereoMatcher>(calib))
+    , init_frames_(init_frames)
+    , good_trace_max_(good_trace_max)
+    , degraded_trace_max_(degraded_trace_max) {
+
+    // Initialize IMU state at origin with identity orientation
+    state_.imu.orientation = Eigen::Quaterniond::Identity();
+    state_.imu.position    = Eigen::Vector3d::Zero();
+    state_.imu.velocity    = Eigen::Vector3d::Zero();
+    state_.imu.gyro_bias   = Eigen::Vector3d::Zero();
+    state_.imu.accel_bias  = Eigen::Vector3d::Zero();
+    state_.imu.timestamp   = 0.0;
+
+    // Initialize covariance: 15x15 for IMU error state only (no clones yet).
+    // Diagonal entries reflect initial uncertainty in each state component.
+    constexpr int kDim = SWVIOState::kImuStateDim;
+    state_.covariance  = Eigen::MatrixXd::Zero(kDim, kDim);
+
+    // Orientation uncertainty (rad^2)
+    state_.covariance.block<3, 3>(SWVIOState::kIdxTheta,
+                                  SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity() * 1e-3;
+    // Position uncertainty (m^2)
+    state_.covariance.block<3, 3>(SWVIOState::kIdxPos,
+                                  SWVIOState::kIdxPos) = Eigen::Matrix3d::Identity() * 1e-2;
+    // Velocity uncertainty (m/s)^2
+    state_.covariance.block<3, 3>(SWVIOState::kIdxVel,
+                                  SWVIOState::kIdxVel) = Eigen::Matrix3d::Identity() * 1e-2;
+    // Gyro bias uncertainty (rad/s)^2
+    state_.covariance.block<3, 3>(SWVIOState::kIdxBg,
+                                  SWVIOState::kIdxBg) = Eigen::Matrix3d::Identity() * 1e-4;
+    // Accel bias uncertainty (m/s^2)^2
+    state_.covariance.block<3, 3>(SWVIOState::kIdxBa,
+                                  SWVIOState::kIdxBa) = Eigen::Matrix3d::Identity() * 1e-4;
+}
+
+// ── IMU state propagation ───────────────────────────────────
+// For each consecutive pair of IMU samples, propagates the nominal
+// state forward and updates the error-state covariance using the
+// linearized continuous-time model discretized at the IMU rate.
+void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_samples) {
+    if (imu_samples.size() < 2) {
+        return;
+    }
+
+    for (size_t i = 1; i < imu_samples.size(); ++i) {
+        const double dt = imu_samples[i].timestamp - imu_samples[i - 1].timestamp;
+        if (dt <= 0.0) {
+            continue;
+        }
+
+        // Bias-corrected IMU readings (midpoint for trapezoidal integration)
+        const Eigen::Vector3d gyro_mid = 0.5 * (imu_samples[i - 1].gyro + imu_samples[i].gyro) -
+                                         state_.imu.gyro_bias;
+        const Eigen::Vector3d accel_mid = 0.5 * (imu_samples[i - 1].accel + imu_samples[i].accel) -
+                                          state_.imu.accel_bias;
+
+        // Current rotation matrix (world <- body)
+        const Eigen::Matrix3d R = state_.imu.orientation.toRotationMatrix();
+
+        // World-frame acceleration (rotate body accel to world + add gravity)
+        const Eigen::Vector3d accel_world = R * accel_mid + params_.gravity;
+
+        // ── Nominal state update ────────────────────────────
+        // Position: p += v*dt + 0.5*a*dt^2
+        state_.imu.position += state_.imu.velocity * dt + 0.5 * accel_world * dt * dt;
+
+        // Velocity: v += a*dt
+        state_.imu.velocity += accel_world * dt;
+
+        // Orientation: q = q * exp(omega*dt)
+        state_.imu.orientation = (state_.imu.orientation * exp_map(gyro_mid * dt)).normalized();
+
+        // Update timestamp
+        state_.imu.timestamp = imu_samples[i].timestamp;
+
+        // ── Error-state transition matrix F (15x15) ─────────
+        // Linearization of the error-state dynamics around the current
+        // nominal state. Uses first-order approximation for dt terms.
+        Eigen::Matrix<double, 15, 15> F = Eigen::Matrix<double, 15, 15>::Identity();
+
+        // F[theta, theta] = I - skew(omega)*dt (first-order approx of exp(-skew(w)*dt))
+        F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxTheta) -= skew(gyro_mid) * dt;
+
+        // F[theta, bg] = -I*dt (gyro bias effect on orientation)
+        F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxBg) = -Eigen::Matrix3d::Identity() *
+                                                                   dt;
+
+        // F[vel, theta] = -R*skew(a)*dt (orientation error -> velocity error)
+        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxTheta) = -R * skew(accel_mid) * dt;
+
+        // F[vel, ba] = -R*dt (accel bias effect on velocity)
+        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxBa) = -R * dt;
+
+        // F[pos, vel] = I*dt
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxVel) = Eigen::Matrix3d::Identity() * dt;
+
+        // F[pos, theta] = -0.5*R*skew(a)*dt^2
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxTheta) = -0.5 * R * skew(accel_mid) *
+                                                                    dt * dt;
+
+        // F[pos, ba] = -0.5*R*dt^2
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxBa) = -0.5 * R * dt * dt;
+
+        // ── Noise Jacobian G (15x12) ────────────────────────
+        // Maps continuous-time noise [n_g(3), n_a(3), n_bg(3), n_ba(3)]
+        // to the error state.
+        Eigen::Matrix<double, 15, 12> G = Eigen::Matrix<double, 15, 12>::Zero();
+
+        // Gyro noise -> orientation
+        G.block<3, 3>(SWVIOState::kIdxTheta, 0) = -Eigen::Matrix3d::Identity() * dt;
+
+        // Accel noise -> velocity
+        G.block<3, 3>(SWVIOState::kIdxVel, 3) = -R * dt;
+
+        // Accel noise -> position
+        G.block<3, 3>(SWVIOState::kIdxPos, 3) = -0.5 * R * dt * dt;
+
+        // Gyro bias random walk
+        G.block<3, 3>(SWVIOState::kIdxBg, 6) = Eigen::Matrix3d::Identity() * dt;
+
+        // Accel bias random walk
+        G.block<3, 3>(SWVIOState::kIdxBa, 9) = Eigen::Matrix3d::Identity() * dt;
+
+        // ── Continuous-time noise covariance Q_c (12x12) ────
+        Eigen::Matrix<double, 12, 12> Q_c = Eigen::Matrix<double, 12, 12>::Zero();
+
+        const double sg2  = imu_params_.gyro_noise_density * imu_params_.gyro_noise_density;
+        const double sa2  = imu_params_.accel_noise_density * imu_params_.accel_noise_density;
+        const double sbg2 = imu_params_.gyro_random_walk * imu_params_.gyro_random_walk;
+        const double sba2 = imu_params_.accel_random_walk * imu_params_.accel_random_walk;
+
+        Q_c.block<3, 3>(0, 0) = Eigen::Matrix3d::Identity() * sg2;
+        Q_c.block<3, 3>(3, 3) = Eigen::Matrix3d::Identity() * sa2;
+        Q_c.block<3, 3>(6, 6) = Eigen::Matrix3d::Identity() * sbg2;
+        Q_c.block<3, 3>(9, 9) = Eigen::Matrix3d::Identity() * sba2;
+
+        // ── Covariance propagation ──────────────────────────
+        const int n = state_.state_dim();
+
+        // IMU-IMU block: P_ii = F * P_ii * F^T + G * Q_c * G^T
+        const Eigen::MatrixXd P_ii = F * state_.covariance.block<15, 15>(0, 0) * F.transpose() +
+                                     G * Q_c * G.transpose();
+        state_.covariance.block<15, 15>(0, 0) = P_ii;
+
+        // IMU-clone cross-correlations: P_ij = F * P_ij for each clone j
+        if (n > 15) {
+            state_.covariance.block(0, 15, 15, n - 15) = F *
+                                                         state_.covariance.block(0, 15, 15, n - 15);
+            // Symmetric: P_ji = P_ij^T
+            state_.covariance.block(15, 0, n - 15,
+                                    15) = state_.covariance.block(0, 15, 15, n - 15).transpose();
+        }
+
+        // Enforce symmetry to prevent numerical drift
+        state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
+    }
+}
+
+// ── State augmentation ──────────────────────────────────────
+// Clones the current IMU pose (orientation + position) into the
+// sliding window and expands the covariance accordingly.
+void SlidingWindowVIOBackend::augment_state(double timestamp) {
+    // Create a new camera clone from the current IMU state
+    CameraClone clone;
+    clone.clone_id    = next_clone_id_++;
+    clone.timestamp   = timestamp;
+    clone.orientation = state_.imu.orientation;
+    clone.position    = state_.imu.position;
+    state_.clones.push_back(clone);
+
+    // Build the augmentation Jacobian J (6x15):
+    // Maps IMU error state to the new clone's error state.
+    //   clone_theta = imu_theta  -> J[0:3, 0:3] = I
+    //   clone_pos   = imu_pos    -> J[3:6, 3:6] = I
+    Eigen::Matrix<double, 6, 15> J          = Eigen::Matrix<double, 6, 15>::Zero();
+    J.block<3, 3>(0, SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity();
+    J.block<3, 3>(3, SWVIOState::kIdxPos)   = Eigen::Matrix3d::Identity();
+
+    // Expand covariance from (n x n) to (n+6 x n+6)
+    const int old_dim = state_.state_dim() - SWVIOState::kCloneStateDim;  // before clone was added
+    const int new_dim = state_.state_dim();
+
+    Eigen::MatrixXd P_new = Eigen::MatrixXd::Zero(new_dim, new_dim);
+
+    // Copy old covariance
+    P_new.block(0, 0, old_dim, old_dim) = state_.covariance;
+
+    // Cross-correlation: P * J^T (bottom-left and top-right)
+    // J operates on the IMU block (first 15 rows/cols of P)
+    const Eigen::MatrixXd JP            = J * state_.covariance.block(0, 0, 15, old_dim);
+    P_new.block(old_dim, 0, 6, old_dim) = JP;
+    P_new.block(0, old_dim, old_dim, 6) = JP.transpose();
+
+    // New clone's self-covariance: J * P_imu * J^T
+    P_new.block<6, 6>(old_dim, old_dim) = J * state_.covariance.block<15, 15>(0, 0) * J.transpose();
+
+    state_.covariance = P_new;
+
+    // Enforce symmetry
+    state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
+}
+
+// ── Marginalize oldest clone ────────────────────────────────
+// Removes the oldest camera clone from the state and shrinks
+// the covariance matrix by removing the corresponding rows/cols.
+void SlidingWindowVIOBackend::marginalize_oldest_clone() {
+    if (static_cast<int>(state_.clones.size()) <= params_.max_clones) {
+        return;
+    }
+
+    // Remove the first clone
+    state_.clones.erase(state_.clones.begin());
+
+    // Remove rows/cols [15..20] from covariance (the oldest clone's 6 DOF)
+    const int remove_start = SWVIOState::kImuStateDim;
+    const int remove_end   = remove_start + SWVIOState::kCloneStateDim;
+    const int old_dim      = static_cast<int>(state_.covariance.rows());
+    const int new_dim      = old_dim - SWVIOState::kCloneStateDim;
+
+    Eigen::MatrixXd P_new = Eigen::MatrixXd::Zero(new_dim, new_dim);
+
+    // Copy the IMU block (rows/cols 0..14)
+    P_new.block(0, 0, remove_start, remove_start) = state_.covariance.block(0, 0, remove_start,
+                                                                            remove_start);
+
+    // Copy the remaining clones block (rows/cols after the removed one)
+    const int after = old_dim - remove_end;
+    if (after > 0) {
+        // Bottom-right block
+        P_new.block(remove_start, remove_start, after,
+                    after) = state_.covariance.block(remove_end, remove_end, after, after);
+
+        // Cross-correlations with IMU
+        P_new.block(0, remove_start, remove_start,
+                    after)        = state_.covariance.block(0, remove_end, remove_start, after);
+        P_new.block(remove_start, 0, after,
+                    remove_start) = state_.covariance.block(remove_end, 0, after, remove_start);
+    }
+
+    state_.covariance = P_new;
+}
+
+// ── Health state machine ────────────────────────────────────
+// Transitions between INITIALIZING -> NOMINAL / DEGRADED / LOST
+// based on frame count and position covariance trace.
+void SlidingWindowVIOBackend::update_health(int /*num_features*/, int /*num_matches*/) {
+    VIOHealth new_health = health_;
+
+    if (frames_processed_ < init_frames_) {
+        new_health = VIOHealth::INITIALIZING;
+    } else {
+        // Compute position covariance trace
+        const double pos_trace =
+            state_.covariance.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxPos).trace();
+
+        if (pos_trace <= good_trace_max_) {
+            new_health = VIOHealth::NOMINAL;
+        } else if (pos_trace <= degraded_trace_max_) {
+            new_health = VIOHealth::DEGRADED;
+        } else {
+            new_health = VIOHealth::LOST;
+        }
+    }
+
+    if (new_health != health_) {
+        DRONE_LOG_INFO("[SWVIO] Health: {} -> {}", vio_health_name(health_),
+                       vio_health_name(new_health));
+        health_ = new_health;
+    }
+}
+
+// ── Main pipeline entry point ───────────────────────────────
+VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
+    const drone::ipc::StereoFrame& frame, const std::vector<ImuSample>& imu_samples) {
+
+    const auto                    pipeline_start = std::chrono::steady_clock::now();
+    const uint64_t                seq            = frame.sequence_number;
+    drone::util::FrameDiagnostics diag(seq);
+
+    VIOOutput output;
+    output.frame_id = seq;
+
+    // ── 1. IMU propagation ──────────────────────────────────
+    if (!imu_samples.empty()) {
+        propagate_imu(imu_samples);
+        output.imu_samples_used = static_cast<int>(imu_samples.size());
+    }
+
+    // ── 2. Feature extraction ───────────────────────────────
+    auto feat_result = extractor_->extract(frame, diag);
+    if (feat_result.is_err()) {
+        output.health = health_;
+        return VIOResult<VIOOutput>::err(std::move(feat_result.error()));
+    }
+
+    auto& feat          = feat_result.value();
+    output.num_features = static_cast<int>(feat.features.size());
+
+    // ── 3. Stereo matching ──────────────────────────────────
+    auto match_result = matcher_->match(frame, feat.features, diag);
+    if (match_result.is_err()) {
+        output.num_stereo_matches = 0;
+        diag.add_warning("SWVIOBackend", "Stereo matching failed — proceeding without matches");
+    } else {
+        output.num_stereo_matches = static_cast<int>(match_result.value().matches.size());
+    }
+
+    // ── 4. State augmentation ───────────────────────────────
+    const double frame_time = static_cast<double>(frame.timestamp_ns) * 1e-9;
+    augment_state(frame_time);
+
+    // ── 5. Marginalize if window exceeds max_clones ─────────
+    marginalize_oldest_clone();
+
+    // ── 6. Health state machine ─────────────────────────────
+    ++frames_processed_;
+    update_health(output.num_features, output.num_stereo_matches);
+    output.health = health_;
+
+    // ── 7. Build output pose from current IMU state ─────────
+    output.pose.position    = state_.imu.position;
+    output.pose.orientation = state_.imu.orientation;
+    output.pose.timestamp =
+        std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
+
+    // Extract 6x6 pose covariance (orientation + position blocks)
+    output.pose.covariance                   = Eigen::Matrix<double, 6, 6>::Zero();
+    output.pose.covariance.block<3, 3>(0, 0) = state_.covariance.block<3, 3>(SWVIOState::kIdxTheta,
+                                                                             SWVIOState::kIdxTheta);
+    output.pose.covariance.block<3, 3>(3, 3) = state_.covariance.block<3, 3>(SWVIOState::kIdxPos,
+                                                                             SWVIOState::kIdxPos);
+
+    // Map health to pose quality
+    switch (health_) {
+        case VIOHealth::LOST: output.pose.quality = 0; break;
+        case VIOHealth::INITIALIZING: [[fallthrough]];
+        case VIOHealth::DEGRADED: output.pose.quality = 1; break;
+        case VIOHealth::NOMINAL: output.pose.quality = 2; break;
+    }
+
+    // Position covariance trace for monitoring
+    output.position_trace =
+        state_.covariance.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxPos).trace();
+
+    // ── 8. Pipeline timing ──────────────────────────────────
+    const auto pipeline_end = std::chrono::steady_clock::now();
+    output.total_ms =
+        std::chrono::duration<double, std::milli>(pipeline_end - pipeline_start).count();
+
+    return VIOResult<VIOOutput>::ok(std::move(output));
+}
+
+VIOHealth SlidingWindowVIOBackend::health() const {
+    return health_;
+}
+
+std::string SlidingWindowVIOBackend::name() const {
+    return "SlidingWindowVIO";
+}
+
+}  // namespace drone::slam

--- a/process3_slam_vio_nav/src/swvio_backend.cpp
+++ b/process3_slam_vio_nav/src/swvio_backend.cpp
@@ -25,7 +25,8 @@ namespace drone::slam {
 constexpr double   kMaxImuAccelMps2  = 200.0;  // ~20g
 constexpr double   kMaxImuGyroRadSec = 35.0;   // ~2000 deg/s
 constexpr double   kMaxDtSec         = 0.1;    // no IMU gap > 100ms
-constexpr uint64_t kMaxTimestampNs   = 10ULL * 365 * 24 * 3600 * 1'000'000'000ULL;  // ~10 years
+constexpr uint64_t kMaxTimestampNs   = 10ULL * 365ULL * 24ULL * 3600ULL *
+                                     1'000'000'000ULL;  // ~10 years
 
 // ── Constructor ─────────────────────────────────────────────
 SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
@@ -37,6 +38,16 @@ SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
     , extractor_(std::make_unique<SimulatedFeatureExtractor>())
     , matcher_(std::make_unique<SimulatedStereoMatcher>(calib)) {
 
+    if (!params_.validate()) {
+        DRONE_LOG_WARN("[SWVIO] Invalid SWVIOParams — using defaults");
+        params_ = SWVIOParams{};
+    }
+
+    // Maximum covariance dimension (with +1 for transient augmentation overshoot)
+    const int max_dim = SWVIOState::kImuStateDim +
+                        SWVIOState::kCloneStateDim * (params_.max_clones + 1);
+    const int max_clone_cols = max_dim - SWVIOState::kImuStateDim;
+
     // Initialize IMU state at origin with identity orientation
     state_.imu.orientation = Eigen::Quaterniond::Identity();
     state_.imu.position    = Eigen::Vector3d::Zero();
@@ -45,9 +56,10 @@ SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
     state_.imu.accel_bias  = Eigen::Vector3d::Zero();
     state_.imu.timestamp   = 0.0;
 
-    // Initialize covariance: 15x15 for IMU error state only (no clones yet)
+    // Covariance pre-allocated to max capacity; active region tracked by active_cov_dim_
     constexpr int kDim = SWVIOState::kImuStateDim;
-    state_.covariance  = Eigen::MatrixXd::Zero(kDim, kDim);
+    state_.covariance  = Eigen::MatrixXd::Zero(max_dim, max_dim);
+    active_cov_dim_    = kDim;
 
     state_.covariance.block<3, 3>(SWVIOState::kIdxTheta,
                                   SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity() * 1e-3;
@@ -72,11 +84,10 @@ SlidingWindowVIOBackend::SlidingWindowVIOBackend(const StereoCalibration& calib,
     Q_c_.block<3, 3>(6, 6) = Eigen::Matrix3d::Identity() * sbg2;
     Q_c_.block<3, 3>(9, 9) = Eigen::Matrix3d::Identity() * sba2;
 
-    // Pre-allocate scratch covariance buffer — +1 because augmentation
-    // temporarily grows the window to max_clones+1 before marginalization.
-    const int max_dim = SWVIOState::kImuStateDim +
-                        SWVIOState::kCloneStateDim * (params_.max_clones + 1);
-    scratch_cov_ = Eigen::MatrixXd::Zero(max_dim, max_dim);
+    // Pre-allocate all scratch buffers (zero hot-path heap allocation)
+    scratch_cov_   = Eigen::MatrixXd::Zero(max_dim, max_dim);
+    cross_scratch_ = Eigen::MatrixXd::Zero(15, max_clone_cols);
+    jp_scratch_    = Eigen::MatrixXd::Zero(6, max_dim);
 }
 
 // ── IMU state propagation ───────────────────────────────────
@@ -125,41 +136,45 @@ void SlidingWindowVIOBackend::propagate_imu(const std::vector<ImuSample>& imu_sa
         // ── Error-state transition matrix F (15x15) ─────────
         Eigen::Matrix<double, 15, 15> F = Eigen::Matrix<double, 15, 15>::Identity();
 
-        // Cache R*skew(accel_mid) — used in both velocity and position blocks
+        // Cache R-derived products used in multiple F/G blocks
         const Eigen::Matrix3d R_skew_a = R * skew(accel_mid);
+        const Eigen::Matrix3d R_dt     = R * dt;
+        const Eigen::Matrix3d R_dt2    = R_dt * dt;
 
         F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxTheta) -= skew(gyro_mid) * dt;
         F.block<3, 3>(SWVIOState::kIdxTheta, SWVIOState::kIdxBg) = -Eigen::Matrix3d::Identity() *
                                                                    dt;
         F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxTheta) = -R_skew_a * dt;
-        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxBa)    = -R * dt;
+        F.block<3, 3>(SWVIOState::kIdxVel, SWVIOState::kIdxBa)    = -R_dt;
         F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxVel) = Eigen::Matrix3d::Identity() * dt;
         F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxTheta) = -0.5 * R_skew_a * dt * dt;
-        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxBa)    = -0.5 * R * dt * dt;
+        F.block<3, 3>(SWVIOState::kIdxPos, SWVIOState::kIdxBa)    = -0.5 * R_dt2;
 
         // ── Noise Jacobian G (15x12) ────────────────────────
         Eigen::Matrix<double, 15, 12> G = Eigen::Matrix<double, 15, 12>::Zero();
 
         G.block<3, 3>(SWVIOState::kIdxTheta, 0) = -Eigen::Matrix3d::Identity() * dt;
-        G.block<3, 3>(SWVIOState::kIdxVel, 3)   = -R * dt;
-        G.block<3, 3>(SWVIOState::kIdxPos, 3)   = -0.5 * R * dt * dt;
+        G.block<3, 3>(SWVIOState::kIdxVel, 3)   = -R_dt;
+        G.block<3, 3>(SWVIOState::kIdxPos, 3)   = -0.5 * R_dt2;
         G.block<3, 3>(SWVIOState::kIdxBg, 6)    = Eigen::Matrix3d::Identity() * dt;
         G.block<3, 3>(SWVIOState::kIdxBa, 9)    = Eigen::Matrix3d::Identity() * dt;
 
         // ── Covariance propagation (fixed-size for IMU block) ──
-        const int n = state_.state_dim();
+        const int n = active_cov_dim_;
 
         // IMU-IMU block: P_ii = F * P_ii * F^T + G * Q_c * G^T
         const Eigen::Matrix<double, 15, 15> P_ii =
             F * state_.covariance.block<15, 15>(0, 0) * F.transpose() + G * Q_c_ * G.transpose();
         state_.covariance.block<15, 15>(0, 0) = P_ii;
 
-        // IMU-clone cross-correlations: P_ij = F * P_ij for each clone j
+        // IMU-clone cross-correlations using pre-allocated scratch (no heap alloc)
         if (n > 15) {
-            state_.covariance.block(0, 15, 15, n - 15) = F *
-                                                         state_.covariance.block(0, 15, 15, n - 15);
-            state_.covariance.block(15, 0, n - 15,
-                                    15) = state_.covariance.block(0, 15, 15, n - 15).transpose();
+            const int clone_cols                           = n - 15;
+            cross_scratch_.leftCols(clone_cols).noalias()  = F * state_.covariance.block(0, 15, 15,
+                                                                                         clone_cols);
+            state_.covariance.block(0, 15, 15, clone_cols) = cross_scratch_.leftCols(clone_cols);
+            state_.covariance.block(15, 0, clone_cols,
+                                    15) = cross_scratch_.leftCols(clone_cols).transpose();
         }
     }
 }
@@ -180,22 +195,19 @@ void SlidingWindowVIOBackend::augment_state(double timestamp) {
     J.block<3, 3>(0, SWVIOState::kIdxTheta) = Eigen::Matrix3d::Identity();
     J.block<3, 3>(3, SWVIOState::kIdxPos)   = Eigen::Matrix3d::Identity();
 
-    // Expand covariance from (old_dim) to (old_dim + 6) using pre-allocated scratch
-    const int old_dim = state_.state_dim() - SWVIOState::kCloneStateDim;
-    const int new_dim = state_.state_dim();
+    const int old_dim = active_cov_dim_;
+    const int new_dim = old_dim + SWVIOState::kCloneStateDim;
 
-    scratch_cov_.block(0, 0, old_dim, old_dim) = state_.covariance.block(0, 0, old_dim, old_dim);
-
-    // Cross-correlation: J * P_imu (first 15 cols of each row)
-    const Eigen::MatrixXd JP                   = J * state_.covariance.block(0, 0, 15, old_dim);
-    scratch_cov_.block(old_dim, 0, 6, old_dim) = JP;
-    scratch_cov_.block(0, old_dim, old_dim, 6) = JP.transpose();
+    // Cross-correlation J*P using pre-allocated scratch (no heap alloc)
+    jp_scratch_.leftCols(old_dim).noalias() = J * state_.covariance.block(0, 0, 15, old_dim);
+    state_.covariance.block(old_dim, 0, 6, old_dim) = jp_scratch_.leftCols(old_dim);
+    state_.covariance.block(0, old_dim, old_dim, 6) = jp_scratch_.leftCols(old_dim).transpose();
 
     // New clone's self-covariance: J * P_imu * J^T
-    scratch_cov_.block<6, 6>(old_dim, old_dim) = J * state_.covariance.block<15, 15>(0, 0) *
-                                                 J.transpose();
+    state_.covariance.block<6, 6>(old_dim, old_dim) = J * state_.covariance.block<15, 15>(0, 0) *
+                                                      J.transpose();
 
-    state_.covariance = scratch_cov_.block(0, 0, new_dim, new_dim);
+    active_cov_dim_ = new_dim;
 }
 
 // ── Marginalize oldest clone ────────────────────────────────
@@ -213,36 +225,48 @@ void SlidingWindowVIOBackend::marginalize_oldest_clone() {
     // Remove rows/cols [15..20] from covariance (the oldest clone's 6 DOF)
     const int remove_start = SWVIOState::kImuStateDim;
     const int remove_end   = remove_start + SWVIOState::kCloneStateDim;
-    const int old_dim      = static_cast<int>(state_.covariance.rows());
+    const int old_dim      = active_cov_dim_;
     const int new_dim      = old_dim - SWVIOState::kCloneStateDim;
 
-    // Copy into pre-allocated scratch, skipping the removed block
-    scratch_cov_.block(0, 0, remove_start,
-                       remove_start) = state_.covariance.block(0, 0, remove_start, remove_start);
-
+    // Shift blocks in-place via scratch to handle overlapping source/dest regions.
+    // Copy each block through scratch sequentially (side-by-side would exceed scratch width).
     const int after = old_dim - remove_end;
     if (after > 0) {
-        scratch_cov_.block(remove_start, remove_start, after,
-                           after) = state_.covariance.block(remove_end, remove_end, after, after);
-        scratch_cov_.block(0, remove_start, remove_start,
+        // Block 1: IMU-to-remaining cross-correlation
+        scratch_cov_.block(0, 0, remove_start,
                            after) = state_.covariance.block(0, remove_end, remove_start, after);
-        scratch_cov_.block(remove_start, 0, after, remove_start) =
+        state_.covariance.block(0, remove_start, remove_start,
+                                after) = scratch_cov_.block(0, 0, remove_start, after);
+
+        // Block 2: Remaining clones self-covariance (after x after, may overlap source)
+        scratch_cov_.block(0, 0, after, after) = state_.covariance.block(remove_end, remove_end,
+                                                                         after, after);
+        state_.covariance.block(remove_start, remove_start, after,
+                                after)         = scratch_cov_.block(0, 0, after, after);
+
+        // Block 3: Remaining-to-IMU cross-correlation
+        scratch_cov_.block(0, 0, after, remove_start) =
             state_.covariance.block(remove_end, 0, after, remove_start);
+        state_.covariance.block(remove_start, 0, after,
+                                remove_start) = scratch_cov_.block(0, 0, after, remove_start);
     }
 
-    state_.covariance = scratch_cov_.block(0, 0, new_dim, new_dim);
+    active_cov_dim_ = new_dim;
 }
 
 // ── Enforce covariance symmetry ─────────────────────────────
 void SlidingWindowVIOBackend::enforce_symmetry() {
-    state_.covariance = 0.5 * (state_.covariance + state_.covariance.transpose());
+    const int n = active_cov_dim_;
+    // Use selfadjointView to avoid allocating a full temporary
+    state_.covariance.topLeftCorner(n, n) =
+        state_.covariance.topLeftCorner(n, n).selfadjointView<Eigen::Upper>();
 }
 
 // ── Health state machine ────────────────────────────────────
 // Transitions between INITIALIZING -> NOMINAL / DEGRADED / LOST
 // based on initialization frame count and position covariance trace.
 void SlidingWindowVIOBackend::update_health() {
-    VIOHealth new_health = health_;
+    VIOHealth new_health = health_.load(std::memory_order_relaxed);
 
     if (frames_processed_ < params_.init_frames) {
         new_health = VIOHealth::INITIALIZING;
@@ -259,10 +283,11 @@ void SlidingWindowVIOBackend::update_health() {
         }
     }
 
-    if (new_health != health_) {
-        DRONE_LOG_INFO("[SWVIO] Health: {} -> {}", vio_health_name(health_),
+    const VIOHealth old_health = health_.load(std::memory_order_relaxed);
+    if (new_health != old_health) {
+        DRONE_LOG_INFO("[SWVIO] Health: {} -> {}", vio_health_name(old_health),
                        vio_health_name(new_health));
-        health_ = new_health;
+        health_.store(new_health, std::memory_order_release);
     }
 }
 
@@ -274,8 +299,8 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
     const uint64_t                seq            = frame.sequence_number;
     drone::util::FrameDiagnostics diag(seq);
 
-    // Validate frame timestamp
-    if (frame.timestamp_ns > kMaxTimestampNs) {
+    // Validate frame timestamp (reject zero and implausibly large values)
+    if (frame.timestamp_ns == 0 || frame.timestamp_ns > kMaxTimestampNs) {
         return VIOResult<VIOOutput>::err(VIOError{VIOErrorCode::TrackingLost, "SWVIOBackend",
                                                   "timestamp_ns out of plausible range", seq});
     }
@@ -292,7 +317,7 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
     // ── 2. Feature extraction ───────────────────────────────
     auto feat_result = extractor_->extract(frame, diag);
     if (feat_result.is_err()) {
-        output.health = health_;
+        output.health = health_.load(std::memory_order_acquire);
         return VIOResult<VIOOutput>::err(std::move(feat_result.error()));
     }
 
@@ -321,7 +346,7 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
     // ── 7. Health state machine ─────────────────────────────
     ++frames_processed_;
     update_health();
-    output.health = health_;
+    output.health = health_.load(std::memory_order_acquire);
 
     // ── 8. Build output pose from current IMU state ─────────
     output.pose.position    = state_.imu.position;
@@ -336,7 +361,8 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
                                                                              SWVIOState::kIdxPos);
 
     // Map health to pose quality
-    switch (health_) {
+    const VIOHealth current_health = health_.load(std::memory_order_acquire);
+    switch (current_health) {
         case VIOHealth::LOST: output.pose.quality = 0; break;
         case VIOHealth::INITIALIZING: [[fallthrough]];
         case VIOHealth::DEGRADED: output.pose.quality = 1; break;
@@ -355,11 +381,12 @@ VIOResult<VIOOutput> SlidingWindowVIOBackend::process_frame(
 }
 
 VIOHealth SlidingWindowVIOBackend::health() const {
-    return health_;
+    return health_.load(std::memory_order_acquire);
 }
 
 std::string SlidingWindowVIOBackend::name() const {
-    return "SlidingWindowVIO";
+    static const std::string kName = "SlidingWindowVIO";
+    return kName;
 }
 
 }  // namespace drone::slam

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -269,6 +269,13 @@ add_drone_test(test_imu_preintegrator test_imu_preintegrator.cpp
 # ── VIO Backend tests ───────────────────────────────────────
 add_drone_test(test_vio_backend     test_vio_backend.cpp
     ${PROJECT_SOURCE_DIR}/process3_slam_vio_nav/src/imu_preintegrator.cpp
+    ${PROJECT_SOURCE_DIR}/process3_slam_vio_nav/src/swvio_backend.cpp
+)
+
+# ── SWVIO Backend tests (Issue #498) ────────────────────────
+add_drone_test(test_swvio_backend   test_swvio_backend.cpp
+    ${PROJECT_SOURCE_DIR}/process3_slam_vio_nav/src/swvio_backend.cpp
+    ${PROJECT_SOURCE_DIR}/process3_slam_vio_nav/src/imu_preintegrator.cpp
 )
 endif()
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -110,7 +110,7 @@ bash deploy/build.sh --test-filter watchdog
 | [Watchdog — Restart Policy](#watchdog--restart-policy) | 1 | 17 | RestartPolicy backoff/thermal, StackStatus, ProcessConfig from_json |
 | [Watchdog — Process Graph](#watchdog--process-graph) | 1 | 27 | Dual-edge dependency graph, topo sort, cascade targets, cycle detection |
 | [Utility](#utility) | 5 | 147 | Config, Result<T,E>, config validator, JSON log sink, latency tracker |
-| [P3 — SLAM / VIO](#p3--slam--vio) | 3 | 49 | Feature extractor, stereo matcher, IMU pre-integrator, VIO backend (covariance quality) |
+| [P3 — SLAM / VIO](#p3--slam--vio) | 5 | 100 | Feature extractor, stereo matcher, IMU pre-integrator, VIO backend, SWVIO backend (Phase 1), slam_math |
 | [Utility — Diagnostics](#utility--diagnostics) | 1 | 12 | FrameDiagnostics collector, ScopedDiagTimer, merge, severity |
 | [P4 — Collision Recovery](#p4--collision-recovery) | 1 | 14 | Post-collision FSM state, waypoint skip, recovery logic |
 | [P4 — Obstacle Prediction](#p4--obstacle-prediction) | 1 | 10 | Dynamic obstacle prediction via UKF velocity vectors |
@@ -129,7 +129,7 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
-| **Total** | **71 C++ + 5 shell** | **1588 + 42 + 250+** | |
+| **Total** | **73 C++ + 5 shell** | **1600 + 42 + 250+** | |
 
 ---
 
@@ -1092,13 +1092,13 @@ Path planner and obstacle avoider tests removed in Issue #207 (covered by
 
 **Key files under test:** `slam/ivio_backend.h`, `slam/ivio_interface.h`, `slam/vio_types.h`
 
-### test_swvio_backend.cpp — 26 tests
+### test_swvio_backend.cpp — 29 tests
 
-**What it tests:** `SlidingWindowVIOBackend` (SWVIO) Phase 1 — IMU propagation, state augmentation, marginalization, covariance dimensions, all health states (INITIALIZING/NOMINAL/DEGRADED/LOST), edge cases (NaN, negative dt, timestamp overflow); `slam_math.h` SO(3) utilities.
+**What it tests:** `SlidingWindowVIOBackend` (SWVIO) Phase 1 — IMU propagation, state augmentation, marginalization, covariance dimensions, all health states (INITIALIZING/NOMINAL/DEGRADED/LOST), edge cases (NaN, negative dt, zero timestamp, timestamp boundary/overflow); `slam_math.h` SO(3) utilities.
 
 | Suite              | Tests | What is validated |
 |--------------------|-------|-------------------|
-| `SWVIOBackendTest` | 16    | Factory registration ("swvio"), frame processing, constant-acceleration IMU propagation (quadratic position with tighter tolerances), stationary gravity compensation, covariance growth, sliding window augmentation with clone_count/state_dim verification, marginalization caps window at max_clones, covariance dimensions match state, health INITIALIZING→NOMINAL/DEGRADED/LOST transitions (4 tests), warmup stays INITIALIZING, empty IMU samples, NaN IMU rejection, negative dt skipping, timestamp overflow rejection |
+| `SWVIOBackendTest` | 19    | Factory registration ("swvio"), frame processing, constant-acceleration IMU propagation (quadratic position, 0.005 tolerance), stationary gravity compensation, covariance growth, sliding window augmentation with clone_count/state_dim verification, marginalization caps window at max_clones, covariance dimensions match state, health INITIALIZING→NOMINAL/DEGRADED/LOST transitions (4 tests), warmup stays INITIALIZING, empty IMU samples, NaN IMU rejection with position assertion, negative dt skipping, zero timestamp rejection, timestamp at-boundary acceptance, timestamp beyond-boundary rejection, timestamp overflow rejection |
 | `SlamMathTest`     | 10    | exp_map identity/small angle/90-degree/180-degree boundary, log_map inverse-of-exp/identity, skew antisymmetry + cross product equivalence, left Jacobian identity/non-trivial, right Jacobian = left(-phi) |
 
 **Key files under test:** `slam/swvio_backend.h`, `slam/swvio_types.h`, `slam/slam_math.h`

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -1092,14 +1092,14 @@ Path planner and obstacle avoider tests removed in Issue #207 (covered by
 
 **Key files under test:** `slam/ivio_backend.h`, `slam/ivio_interface.h`, `slam/vio_types.h`
 
-### test_swvio_backend.cpp — 17 tests
+### test_swvio_backend.cpp — 26 tests
 
-**What it tests:** `SlidingWindowVIOBackend` (SWVIO) Phase 1 — IMU propagation, state augmentation, covariance, health transitions; `slam_math.h` SO(3) utilities.
+**What it tests:** `SlidingWindowVIOBackend` (SWVIO) Phase 1 — IMU propagation, state augmentation, marginalization, covariance dimensions, all health states (INITIALIZING/NOMINAL/DEGRADED/LOST), edge cases (NaN, negative dt, timestamp overflow); `slam_math.h` SO(3) utilities.
 
-| Suite | Tests | What is validated |
-|-------|-------|-------------------|
-| `SWVIOBackendTest` | 8 | Factory registration ("swvio"), frame processing, constant-acceleration IMU propagation (quadratic position), stationary gravity compensation, covariance growth, sliding window augmentation up to max_clones, health INITIALIZING→NOMINAL transition, empty IMU samples edge case |
-| `SlamMathTest` | 9 | exp_map identity/small angle/90-degree, log_map inverse-of-exp/identity, skew antisymmetry + cross product equivalence, left Jacobian identity/non-trivial, right Jacobian = left(-phi) |
+| Suite              | Tests | What is validated |
+|--------------------|-------|-------------------|
+| `SWVIOBackendTest` | 16    | Factory registration ("swvio"), frame processing, constant-acceleration IMU propagation (quadratic position with tighter tolerances), stationary gravity compensation, covariance growth, sliding window augmentation with clone_count/state_dim verification, marginalization caps window at max_clones, covariance dimensions match state, health INITIALIZING→NOMINAL/DEGRADED/LOST transitions (4 tests), warmup stays INITIALIZING, empty IMU samples, NaN IMU rejection, negative dt skipping, timestamp overflow rejection |
+| `SlamMathTest`     | 10    | exp_map identity/small angle/90-degree/180-degree boundary, log_map inverse-of-exp/identity, skew antisymmetry + cross product equivalence, left Jacobian identity/non-trivial, right Jacobian = left(-phi) |
 
 **Key files under test:** `slam/swvio_backend.h`, `slam/swvio_types.h`, `slam/slam_math.h`
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -129,7 +129,7 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
-| **Total** | **70 C++ + 5 shell** | **1553 + 42 + 250+** | |
+| **Total** | **71 C++ + 5 shell** | **1588 + 42 + 250+** | |
 
 ---
 
@@ -1078,17 +1078,30 @@ Path planner and obstacle avoider tests removed in Issue #207 (covered by
 
 **Key files under test:** `slam/imu_preintegrator.h`, `imu_preintegrator.cpp`
 
-### test_vio_backend.cpp — 15 tests
+### test_vio_backend.cpp — 34 tests
 
 **What it tests:** `IVIOBackend` and `SimulatedVIOBackend` — full VIO pipeline and health state machine.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
-| `VIOBackendTest` | 13 | Frame processing, INITIALIZING→NOMINAL health transition, valid pose, IMU consumption, zero-IMU fallback, frame_id propagation, feature/match counts, advancing trajectory, timing recorded, factory create/throw, invalid frame dimensions |
+| `VIOBackendTest` | 18 | Frame processing, INITIALIZING→NOMINAL health transition, valid pose, IMU consumption, zero-IMU fallback, frame_id propagation, feature/match counts, advancing trajectory, timing recorded, factory create/throw, invalid frame dimensions, covariance quality thresholds |
+| `VIOCovarianceTest` | 8 | Covariance-based quality thresholds, trace-to-health mapping |
+| `GazeboFullVIOTest` | 6 | Gazebo full-pipeline VIO backend processing and health |
 | `VIOHealthTest` | 1 | Health enum name strings |
 | `VIOErrorTest` | 1 | `VIOError::to_string()` format |
 
-**Key files under test:** `slam/ivio_backend.h`, `slam/vio_types.h`
+**Key files under test:** `slam/ivio_backend.h`, `slam/ivio_interface.h`, `slam/vio_types.h`
+
+### test_swvio_backend.cpp — 17 tests
+
+**What it tests:** `SlidingWindowVIOBackend` (SWVIO) Phase 1 — IMU propagation, state augmentation, covariance, health transitions; `slam_math.h` SO(3) utilities.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `SWVIOBackendTest` | 8 | Factory registration ("swvio"), frame processing, constant-acceleration IMU propagation (quadratic position), stationary gravity compensation, covariance growth, sliding window augmentation up to max_clones, health INITIALIZING→NOMINAL transition, empty IMU samples edge case |
+| `SlamMathTest` | 9 | exp_map identity/small angle/90-degree, log_map inverse-of-exp/identity, skew antisymmetry + cross product equivalence, left Jacobian identity/non-trivial, right Jacobian = left(-phi) |
+
+**Key files under test:** `slam/swvio_backend.h`, `slam/swvio_types.h`, `slam/slam_math.h`
 
 ---
 

--- a/tests/test_swvio_backend.cpp
+++ b/tests/test_swvio_backend.cpp
@@ -6,9 +6,9 @@
 //   - IMU propagation: constant acceleration -> quadratic position
 //   - Stationary test: gravity-only IMU -> position near origin
 //   - Covariance growth during propagation
-//   - State augmentation: clone window grows up to max_clones
-//   - Health transitions: INITIALIZING -> NOMINAL after N frames
-//   - Edge case: empty IMU samples
+//   - State augmentation: window grows, then marginalization caps it
+//   - Health transitions: INITIALIZING -> NOMINAL / DEGRADED / LOST
+//   - Edge cases: empty IMU, NaN input, negative dt, timestamp overflow
 //   - slam_math.h utility functions (exp_map, log_map, Jacobians)
 
 #include "slam/ivio_backend.h"
@@ -17,6 +17,7 @@
 #include "slam/vio_types.h"
 
 #include <cmath>
+#include <limits>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -67,6 +68,12 @@ static std::vector<ImuSample> make_imu_forward_accel(double t0, double t1, doubl
     return samples;
 }
 
+static std::unique_ptr<SlidingWindowVIOBackend> make_swvio(SWVIOParams params = {}) {
+    StereoCalibration calib;
+    ImuNoiseParams    imu_params;
+    return std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, params);
+}
+
 // ═══════════════════════════════════════════════════════════
 // Factory tests
 // ═══════════════════════════════════════════════════════════
@@ -113,7 +120,6 @@ TEST(SWVIOBackendTest, IMUPropagationConstantAccel) {
         ASSERT_TRUE(result.is_ok());
 
         if (f > 0) {
-            // Position should be monotonically increasing in X
             EXPECT_GT(result.value().pose.position.x(), last_pos.x())
                 << "Frame " << f << ": X position should increase under forward acceleration";
         }
@@ -121,9 +127,10 @@ TEST(SWVIOBackendTest, IMUPropagationConstantAccel) {
     }
 
     // After ~0.33s at 1 m/s^2: position ~ 0.5 * 1 * 0.33^2 ~ 0.054m
-    EXPECT_GT(last_pos.x(), 0.01) << "Should have moved forward significantly";
-    EXPECT_LT(std::abs(last_pos.y()), 0.01) << "No lateral motion expected";
-    EXPECT_LT(std::abs(last_pos.z()), 0.01) << "No vertical motion (gravity compensated)";
+    const double expected_x = 0.5 * 1.0 * 0.33 * 0.33;
+    EXPECT_NEAR(last_pos.x(), expected_x, 0.02) << "Should approximate s = 0.5*a*t^2";
+    EXPECT_NEAR(last_pos.y(), 0.0, 0.005) << "No lateral motion expected";
+    EXPECT_NEAR(last_pos.z(), 0.0, 0.005) << "No vertical motion (gravity compensated)";
 }
 
 TEST(SWVIOBackendTest, StationaryGravityOnly) {
@@ -138,7 +145,7 @@ TEST(SWVIOBackendTest, StationaryGravityOnly) {
 
         auto result = backend->process_frame(frame, imu);
         ASSERT_TRUE(result.is_ok());
-        EXPECT_LT(result.value().pose.position.norm(), 0.1)
+        EXPECT_LT(result.value().pose.position.norm(), 0.05)
             << "Frame " << f << ": position should stay near origin when stationary";
     }
 }
@@ -164,7 +171,6 @@ TEST(SWVIOBackendTest, CovarianceGrowsDuringPropagation) {
         EXPECT_GE(trace, 0.0) << "Position trace should be non-negative";
 
         if (f > 0) {
-            // Covariance should grow with each IMU-only propagation (no vision updates)
             EXPECT_GT(trace, prev_trace)
                 << "Frame " << f << ": covariance trace should grow without vision updates";
         }
@@ -173,29 +179,71 @@ TEST(SWVIOBackendTest, CovarianceGrowsDuringPropagation) {
 }
 
 // ═══════════════════════════════════════════════════════════
-// State augmentation tests
+// State augmentation and marginalization tests
 // ═══════════════════════════════════════════════════════════
 
 TEST(SWVIOBackendTest, StateAugmentationGrowsWindow) {
     SWVIOParams params;
-    params.max_clones = 5;  // small window for testing
+    params.max_clones = 5;
 
-    StereoCalibration calib;
-    ImuNoiseParams    imu_params;
-    auto backend = std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, params, 3, 0.1,
-                                                             1.0);
+    auto backend = make_swvio(params);
 
-    // Process 10 frames — window should grow to 5 then hold steady via marginalization
-    for (int f = 0; f < 10; ++f) {
+    for (int f = 0; f < 5; ++f) {
         auto         frame = make_frame(static_cast<uint64_t>(f + 1));
         const double t0    = f * 0.033;
         const double t1    = (f + 1) * 0.033;
         auto         imu   = make_imu_stationary(t0, t1);
 
         auto result = backend->process_frame(frame, imu);
-        ASSERT_TRUE(result.is_ok()) << "Frame " << f << " should process successfully";
+        ASSERT_TRUE(result.is_ok());
+
+        EXPECT_EQ(backend->clone_count(), f + 1)
+            << "Window should grow by 1 clone per frame before reaching max";
+        EXPECT_EQ(backend->state_dim(), 15 + 6 * (f + 1));
     }
-    // The system should not crash even after exceeding max_clones
+}
+
+TEST(SWVIOBackendTest, MarginalizationCapsWindow) {
+    SWVIOParams params;
+    params.max_clones = 3;
+
+    auto backend = make_swvio(params);
+
+    // Process 6 frames with max_clones=3
+    for (int f = 0; f < 6; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok());
+    }
+
+    // After 6 frames with max_clones=3, window should be capped
+    EXPECT_LE(backend->clone_count(), 3) << "Clone count should not exceed max_clones";
+    EXPECT_EQ(backend->state_dim(), 15 + 6 * backend->clone_count());
+}
+
+TEST(SWVIOBackendTest, CovarianceDimensionsMatchState) {
+    SWVIOParams params;
+    params.max_clones = 4;
+
+    auto backend = make_swvio(params);
+
+    for (int f = 0; f < 8; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok());
+
+        // state_dim() should always match 15 + 6*clone_count
+        const int expected_dim = 15 + 6 * backend->clone_count();
+        EXPECT_EQ(backend->state_dim(), expected_dim) << "Frame " << f << ": state_dim mismatch";
+    }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -204,13 +252,11 @@ TEST(SWVIOBackendTest, StateAugmentationGrowsWindow) {
 
 TEST(SWVIOBackendTest, HealthTransitionsToNominal) {
     SWVIOParams params;
-    params.init_frames = 3;  // fast init for testing
+    params.init_frames        = 3;
+    params.good_trace_max     = 100.0;  // very high — should be NOMINAL after init
+    params.degraded_trace_max = 1000.0;
 
-    StereoCalibration calib;
-    ImuNoiseParams    imu_params;
-    auto backend = std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, params, 3, 0.1,
-                                                             1.0);
-
+    auto backend = make_swvio(params);
     EXPECT_EQ(backend->health(), VIOHealth::INITIALIZING);
 
     for (int f = 0; f < 5; ++f) {
@@ -222,8 +268,71 @@ TEST(SWVIOBackendTest, HealthTransitionsToNominal) {
         (void)backend->process_frame(frame, imu);
     }
 
-    // After 5 frames with init_frames=3, should have left INITIALIZING
-    EXPECT_NE(backend->health(), VIOHealth::INITIALIZING);
+    EXPECT_EQ(backend->health(), VIOHealth::NOMINAL)
+        << "Should be NOMINAL with high trace thresholds";
+}
+
+TEST(SWVIOBackendTest, HealthDegradedWhenTraceExceedsGoodMax) {
+    SWVIOParams params;
+    params.init_frames        = 1;
+    params.good_trace_max     = 1e-10;  // impossibly tight — position trace will exceed this
+    params.degraded_trace_max = 100.0;  // but won't exceed this
+
+    auto backend = make_swvio(params);
+
+    for (int f = 0; f < 3; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        (void)backend->process_frame(frame, imu);
+    }
+
+    EXPECT_EQ(backend->health(), VIOHealth::DEGRADED)
+        << "Should be DEGRADED when trace > good_trace_max but < degraded_trace_max";
+}
+
+TEST(SWVIOBackendTest, HealthLostWhenTraceExceedsDegradedMax) {
+    SWVIOParams params;
+    params.init_frames        = 1;
+    params.good_trace_max     = 1e-10;
+    params.degraded_trace_max = 1e-10;  // impossibly tight — will exceed both thresholds
+
+    auto backend = make_swvio(params);
+
+    for (int f = 0; f < 3; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        (void)backend->process_frame(frame, imu);
+    }
+
+    EXPECT_EQ(backend->health(), VIOHealth::LOST)
+        << "Should be LOST when trace exceeds degraded_trace_max";
+}
+
+TEST(SWVIOBackendTest, HealthStaysInitializingDuringWarmup) {
+    SWVIOParams params;
+    params.init_frames = 10;
+
+    auto backend = make_swvio(params);
+    EXPECT_EQ(backend->health(), VIOHealth::INITIALIZING);
+
+    // Process 5 frames (less than init_frames=10)
+    for (int f = 0; f < 5; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        (void)backend->process_frame(frame, imu);
+    }
+
+    EXPECT_EQ(backend->health(), VIOHealth::INITIALIZING)
+        << "Should stay INITIALIZING before init_frames reached";
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -236,9 +345,72 @@ TEST(SWVIOBackendTest, EmptyIMUSamplesHandled) {
 
     std::vector<ImuSample> empty_samples;
     auto                   result = backend->process_frame(frame, empty_samples);
-    // Should handle gracefully — no crash, returns valid output
     ASSERT_TRUE(result.is_ok());
     EXPECT_EQ(result.value().imu_samples_used, 0);
+}
+
+TEST(SWVIOBackendTest, NaNIMUSampleRejected) {
+    auto backend = make_swvio();
+    auto frame   = make_frame(1);
+
+    std::vector<ImuSample> samples;
+    ImuSample              s0;
+    s0.timestamp = 0.0;
+    s0.accel     = Eigen::Vector3d(0, 0, 9.81);
+    s0.gyro      = Eigen::Vector3d::Zero();
+    samples.push_back(s0);
+
+    ImuSample s1;
+    s1.timestamp = 0.01;
+    s1.accel     = Eigen::Vector3d(std::numeric_limits<double>::quiet_NaN(), 0, 9.81);
+    s1.gyro      = Eigen::Vector3d::Zero();
+    samples.push_back(s1);
+
+    // Should not crash; NaN sample is skipped
+    auto result = backend->process_frame(frame, samples);
+    ASSERT_TRUE(result.is_ok());
+}
+
+TEST(SWVIOBackendTest, NegativeDtIMUSamplesSkipped) {
+    auto backend = make_swvio();
+    auto frame   = make_frame(1);
+
+    // Non-monotonic timestamps — backward sample should be skipped
+    std::vector<ImuSample> samples;
+    ImuSample              s0;
+    s0.timestamp = 0.01;
+    s0.accel     = Eigen::Vector3d(0, 0, 9.81);
+    s0.gyro      = Eigen::Vector3d::Zero();
+    samples.push_back(s0);
+
+    ImuSample s1;
+    s1.timestamp = 0.005;  // backward in time
+    s1.accel     = Eigen::Vector3d(0, 0, 9.81);
+    s1.gyro      = Eigen::Vector3d::Zero();
+    samples.push_back(s1);
+
+    ImuSample s2;
+    s2.timestamp = 0.02;
+    s2.accel     = Eigen::Vector3d(0, 0, 9.81);
+    s2.gyro      = Eigen::Vector3d::Zero();
+    samples.push_back(s2);
+
+    auto result = backend->process_frame(frame, samples);
+    ASSERT_TRUE(result.is_ok());
+    // Position should stay near origin (gravity-compensated, only valid samples used)
+    EXPECT_LT(result.value().pose.position.norm(), 0.05);
+}
+
+TEST(SWVIOBackendTest, TimestampOverflowRejected) {
+    auto backend = create_vio_backend("swvio");
+    auto frame   = make_frame(1);
+
+    // Set timestamp_ns to a value that would overflow when converted to seconds
+    frame.timestamp_ns = std::numeric_limits<uint64_t>::max();
+
+    auto imu    = make_imu_stationary(0.0, 0.033);
+    auto result = backend->process_frame(frame, imu);
+    EXPECT_TRUE(result.is_err()) << "Should reject implausible timestamp";
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -246,7 +418,6 @@ TEST(SWVIOBackendTest, EmptyIMUSamplesHandled) {
 // ═══════════════════════════════════════════════════════════
 
 TEST(SlamMathTest, ExpMapIdentity) {
-    // Zero rotation -> identity quaternion
     Eigen::Vector3d zero = Eigen::Vector3d::Zero();
     auto            q    = exp_map(zero);
     EXPECT_NEAR(q.w(), 1.0, 1e-10);
@@ -254,7 +425,6 @@ TEST(SlamMathTest, ExpMapIdentity) {
 }
 
 TEST(SlamMathTest, ExpMapSmallAngle) {
-    // Small angle -> first-order approximation
     Eigen::Vector3d small_angle(1e-12, 0, 0);
     auto            q = exp_map(small_angle);
     EXPECT_NEAR(q.w(), 1.0, 1e-6);
@@ -262,18 +432,26 @@ TEST(SlamMathTest, ExpMapSmallAngle) {
 }
 
 TEST(SlamMathTest, ExpMap90Degrees) {
-    // 90-degree rotation about Z
     Eigen::Vector3d omega(0, 0, M_PI / 2.0);
     auto            q = exp_map(omega);
-    // Should rotate [1,0,0] to [0,1,0]
     Eigen::Vector3d v = q * Eigen::Vector3d(1, 0, 0);
     EXPECT_NEAR(v.x(), 0.0, 1e-10);
     EXPECT_NEAR(v.y(), 1.0, 1e-10);
     EXPECT_NEAR(v.z(), 0.0, 1e-10);
 }
 
+TEST(SlamMathTest, ExpMap180Degrees) {
+    // Pi rotation about Z axis — boundary case for Rodrigues
+    Eigen::Vector3d omega(0, 0, M_PI);
+    auto            q = exp_map(omega);
+    // Should rotate [1,0,0] to [-1,0,0]
+    Eigen::Vector3d v = q * Eigen::Vector3d(1, 0, 0);
+    EXPECT_NEAR(v.x(), -1.0, 1e-10);
+    EXPECT_NEAR(v.y(), 0.0, 1e-10);
+    EXPECT_NEAR(v.z(), 0.0, 1e-10);
+}
+
 TEST(SlamMathTest, LogMapInverseOfExpMap) {
-    // log(exp(omega)) should return omega
     Eigen::Vector3d omega(0.1, -0.2, 0.3);
     auto            q   = exp_map(omega);
     auto            phi = log_map(q);
@@ -291,10 +469,8 @@ TEST(SlamMathTest, SkewSymmetric) {
     Eigen::Vector3d v(1, 2, 3);
     auto            m = skew(v);
 
-    // Skew matrix should be antisymmetric
     EXPECT_NEAR((m + m.transpose()).norm(), 0.0, 1e-10);
 
-    // skew(v) * u = v x u
     Eigen::Vector3d u(4, 5, 6);
     Eigen::Vector3d cross       = v.cross(u);
     Eigen::Vector3d skew_result = m * u;
@@ -308,14 +484,10 @@ TEST(SlamMathTest, LeftJacobianIdentityForSmallPhi) {
 }
 
 TEST(SlamMathTest, LeftJacobianNonTrivial) {
-    // For a non-trivial rotation, the Jacobian should not be identity
     Eigen::Vector3d phi(0.5, -0.3, 0.1);
     auto            J = left_jacobian_SO3(phi);
 
-    // J should be close to I for small angles but not exactly I
     EXPECT_GT((J - Eigen::Matrix3d::Identity()).norm(), 0.01);
-
-    // J should be invertible (det != 0)
     EXPECT_GT(std::abs(J.determinant()), 1e-6);
 }
 

--- a/tests/test_swvio_backend.cpp
+++ b/tests/test_swvio_backend.cpp
@@ -1,0 +1,328 @@
+// tests/test_swvio_backend.cpp
+// Unit tests for the Sliding-Window VIO (SWVIO) backend — Phase 1.
+//
+// Tests cover:
+//   - Factory registration ("swvio" backend name)
+//   - IMU propagation: constant acceleration -> quadratic position
+//   - Stationary test: gravity-only IMU -> position near origin
+//   - Covariance growth during propagation
+//   - State augmentation: clone window grows up to max_clones
+//   - Health transitions: INITIALIZING -> NOMINAL after N frames
+//   - Edge case: empty IMU samples
+//   - slam_math.h utility functions (exp_map, log_map, Jacobians)
+
+#include "slam/ivio_backend.h"
+#include "slam/slam_math.h"
+#include "slam/swvio_backend.h"
+#include "slam/vio_types.h"
+
+#include <cmath>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace drone::slam;
+
+// ── Helpers ──────────────────────────────────────────────────
+
+static drone::ipc::StereoFrame make_frame(uint64_t seq, uint32_t w = 640, uint32_t h = 480) {
+    drone::ipc::StereoFrame f{};
+    f.sequence_number = seq;
+    f.width           = w;
+    f.height          = h;
+    f.timestamp_ns    = seq * 33'333'000ULL;  // ~30Hz
+    return f;
+}
+
+static std::vector<ImuSample> make_imu_stationary(double t0, double t1, int n = 4) {
+    // Gravity-compensating accelerometer reading: body frame sees [0, 0, +9.81]
+    // when stationary (accelerometer measures specific force = -gravity in body frame,
+    // which for identity orientation = [0, 0, 9.81]).
+    std::vector<ImuSample> samples;
+    samples.reserve(static_cast<size_t>(n));
+    const double dt = (t1 - t0) / static_cast<double>(n - 1);
+    for (int i = 0; i < n; ++i) {
+        ImuSample s;
+        s.timestamp = t0 + static_cast<double>(i) * dt;
+        s.accel     = Eigen::Vector3d(0, 0, 9.81);  // gravity compensation
+        s.gyro      = Eigen::Vector3d::Zero();
+        samples.push_back(s);
+    }
+    return samples;
+}
+
+static std::vector<ImuSample> make_imu_forward_accel(double t0, double t1, double accel_x = 1.0,
+                                                     int n = 4) {
+    // Forward acceleration of accel_x m/s^2 in body X, with gravity compensation on Z
+    std::vector<ImuSample> samples;
+    samples.reserve(static_cast<size_t>(n));
+    const double dt = (t1 - t0) / static_cast<double>(n - 1);
+    for (int i = 0; i < n; ++i) {
+        ImuSample s;
+        s.timestamp = t0 + static_cast<double>(i) * dt;
+        s.accel     = Eigen::Vector3d(accel_x, 0, 9.81);
+        s.gyro      = Eigen::Vector3d::Zero();
+        samples.push_back(s);
+    }
+    return samples;
+}
+
+// ═══════════════════════════════════════════════════════════
+// Factory tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, FactoryCreatesSWVIO) {
+    auto backend = create_vio_backend("swvio");
+    ASSERT_NE(backend, nullptr);
+    EXPECT_EQ(backend->name(), "SlidingWindowVIO");
+    EXPECT_EQ(backend->health(), VIOHealth::INITIALIZING);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Basic processing tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, ProcessesFrameSuccessfully) {
+    auto backend = create_vio_backend("swvio");
+    auto frame   = make_frame(1);
+    auto imu     = make_imu_stationary(0.0, 0.033);
+
+    auto result = backend->process_frame(frame, imu);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().frame_id, 1u);
+    EXPECT_GT(result.value().num_features, 0);
+}
+
+// ═══════════════════════════════════════════════════════════
+// IMU propagation tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, IMUPropagationConstantAccel) {
+    auto backend = create_vio_backend("swvio");
+
+    // Apply 1 m/s^2 forward acceleration for ~0.33s (10 frames at 30Hz)
+    // Expected position: ~0.5 * 1 * 0.33^2 ~ 0.054m in X
+    Eigen::Vector3d last_pos = Eigen::Vector3d::Zero();
+    for (int f = 0; f < 10; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_forward_accel(t0, t1, 1.0);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok());
+
+        if (f > 0) {
+            // Position should be monotonically increasing in X
+            EXPECT_GT(result.value().pose.position.x(), last_pos.x())
+                << "Frame " << f << ": X position should increase under forward acceleration";
+        }
+        last_pos = result.value().pose.position;
+    }
+
+    // After ~0.33s at 1 m/s^2: position ~ 0.5 * 1 * 0.33^2 ~ 0.054m
+    EXPECT_GT(last_pos.x(), 0.01) << "Should have moved forward significantly";
+    EXPECT_LT(std::abs(last_pos.y()), 0.01) << "No lateral motion expected";
+    EXPECT_LT(std::abs(last_pos.z()), 0.01) << "No vertical motion (gravity compensated)";
+}
+
+TEST(SWVIOBackendTest, StationaryGravityOnly) {
+    auto backend = create_vio_backend("swvio");
+
+    // Process 20 frames with gravity-only IMU — position should stay near origin
+    for (int f = 0; f < 20; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok());
+        EXPECT_LT(result.value().pose.position.norm(), 0.1)
+            << "Frame " << f << ": position should stay near origin when stationary";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// Covariance tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, CovarianceGrowsDuringPropagation) {
+    auto backend = create_vio_backend("swvio");
+
+    double prev_trace = -1.0;
+    for (int f = 0; f < 5; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok());
+
+        const double trace = result.value().position_trace;
+        EXPECT_GE(trace, 0.0) << "Position trace should be non-negative";
+
+        if (f > 0) {
+            // Covariance should grow with each IMU-only propagation (no vision updates)
+            EXPECT_GT(trace, prev_trace)
+                << "Frame " << f << ": covariance trace should grow without vision updates";
+        }
+        prev_trace = trace;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// State augmentation tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, StateAugmentationGrowsWindow) {
+    SWVIOParams params;
+    params.max_clones = 5;  // small window for testing
+
+    StereoCalibration calib;
+    ImuNoiseParams    imu_params;
+    auto backend = std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, params, 3, 0.1,
+                                                             1.0);
+
+    // Process 10 frames — window should grow to 5 then hold steady via marginalization
+    for (int f = 0; f < 10; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        auto result = backend->process_frame(frame, imu);
+        ASSERT_TRUE(result.is_ok()) << "Frame " << f << " should process successfully";
+    }
+    // The system should not crash even after exceeding max_clones
+}
+
+// ═══════════════════════════════════════════════════════════
+// Health transition tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, HealthTransitionsToNominal) {
+    SWVIOParams params;
+    params.init_frames = 3;  // fast init for testing
+
+    StereoCalibration calib;
+    ImuNoiseParams    imu_params;
+    auto backend = std::make_unique<SlidingWindowVIOBackend>(calib, imu_params, params, 3, 0.1,
+                                                             1.0);
+
+    EXPECT_EQ(backend->health(), VIOHealth::INITIALIZING);
+
+    for (int f = 0; f < 5; ++f) {
+        auto         frame = make_frame(static_cast<uint64_t>(f + 1));
+        const double t0    = f * 0.033;
+        const double t1    = (f + 1) * 0.033;
+        auto         imu   = make_imu_stationary(t0, t1);
+
+        (void)backend->process_frame(frame, imu);
+    }
+
+    // After 5 frames with init_frames=3, should have left INITIALIZING
+    EXPECT_NE(backend->health(), VIOHealth::INITIALIZING);
+}
+
+// ═══════════════════════════════════════════════════════════
+// Edge case tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SWVIOBackendTest, EmptyIMUSamplesHandled) {
+    auto backend = create_vio_backend("swvio");
+    auto frame   = make_frame(1);
+
+    std::vector<ImuSample> empty_samples;
+    auto                   result = backend->process_frame(frame, empty_samples);
+    // Should handle gracefully — no crash, returns valid output
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().imu_samples_used, 0);
+}
+
+// ═══════════════════════════════════════════════════════════
+// slam_math.h utility tests
+// ═══════════════════════════════════════════════════════════
+
+TEST(SlamMathTest, ExpMapIdentity) {
+    // Zero rotation -> identity quaternion
+    Eigen::Vector3d zero = Eigen::Vector3d::Zero();
+    auto            q    = exp_map(zero);
+    EXPECT_NEAR(q.w(), 1.0, 1e-10);
+    EXPECT_NEAR(q.vec().norm(), 0.0, 1e-10);
+}
+
+TEST(SlamMathTest, ExpMapSmallAngle) {
+    // Small angle -> first-order approximation
+    Eigen::Vector3d small_angle(1e-12, 0, 0);
+    auto            q = exp_map(small_angle);
+    EXPECT_NEAR(q.w(), 1.0, 1e-6);
+    EXPECT_NEAR(q.vec().norm(), 0.0, 1e-6);
+}
+
+TEST(SlamMathTest, ExpMap90Degrees) {
+    // 90-degree rotation about Z
+    Eigen::Vector3d omega(0, 0, M_PI / 2.0);
+    auto            q = exp_map(omega);
+    // Should rotate [1,0,0] to [0,1,0]
+    Eigen::Vector3d v = q * Eigen::Vector3d(1, 0, 0);
+    EXPECT_NEAR(v.x(), 0.0, 1e-10);
+    EXPECT_NEAR(v.y(), 1.0, 1e-10);
+    EXPECT_NEAR(v.z(), 0.0, 1e-10);
+}
+
+TEST(SlamMathTest, LogMapInverseOfExpMap) {
+    // log(exp(omega)) should return omega
+    Eigen::Vector3d omega(0.1, -0.2, 0.3);
+    auto            q   = exp_map(omega);
+    auto            phi = log_map(q);
+    EXPECT_NEAR(phi.x(), omega.x(), 1e-10);
+    EXPECT_NEAR(phi.y(), omega.y(), 1e-10);
+    EXPECT_NEAR(phi.z(), omega.z(), 1e-10);
+}
+
+TEST(SlamMathTest, LogMapIdentity) {
+    auto phi = log_map(Eigen::Quaterniond::Identity());
+    EXPECT_NEAR(phi.norm(), 0.0, 1e-10);
+}
+
+TEST(SlamMathTest, SkewSymmetric) {
+    Eigen::Vector3d v(1, 2, 3);
+    auto            m = skew(v);
+
+    // Skew matrix should be antisymmetric
+    EXPECT_NEAR((m + m.transpose()).norm(), 0.0, 1e-10);
+
+    // skew(v) * u = v x u
+    Eigen::Vector3d u(4, 5, 6);
+    Eigen::Vector3d cross       = v.cross(u);
+    Eigen::Vector3d skew_result = m * u;
+    EXPECT_NEAR((cross - skew_result).norm(), 0.0, 1e-10);
+}
+
+TEST(SlamMathTest, LeftJacobianIdentityForSmallPhi) {
+    Eigen::Vector3d small_phi = Eigen::Vector3d::Zero();
+    auto            J         = left_jacobian_SO3(small_phi);
+    EXPECT_NEAR((J - Eigen::Matrix3d::Identity()).norm(), 0.0, 1e-10);
+}
+
+TEST(SlamMathTest, LeftJacobianNonTrivial) {
+    // For a non-trivial rotation, the Jacobian should not be identity
+    Eigen::Vector3d phi(0.5, -0.3, 0.1);
+    auto            J = left_jacobian_SO3(phi);
+
+    // J should be close to I for small angles but not exactly I
+    EXPECT_GT((J - Eigen::Matrix3d::Identity()).norm(), 0.01);
+
+    // J should be invertible (det != 0)
+    EXPECT_GT(std::abs(J.determinant()), 1e-6);
+}
+
+TEST(SlamMathTest, RightJacobianRelation) {
+    // J_r(phi) = J_l(-phi)
+    Eigen::Vector3d phi(0.4, -0.2, 0.6);
+    auto            J_r     = right_jacobian_SO3(phi);
+    auto            J_l_neg = left_jacobian_SO3(-phi);
+    EXPECT_NEAR((J_r - J_l_neg).norm(), 0.0, 1e-10);
+}

--- a/tests/test_swvio_backend.cpp
+++ b/tests/test_swvio_backend.cpp
@@ -128,7 +128,7 @@ TEST(SWVIOBackendTest, IMUPropagationConstantAccel) {
 
     // After ~0.33s at 1 m/s^2: position ~ 0.5 * 1 * 0.33^2 ~ 0.054m
     const double expected_x = 0.5 * 1.0 * 0.33 * 0.33;
-    EXPECT_NEAR(last_pos.x(), expected_x, 0.02) << "Should approximate s = 0.5*a*t^2";
+    EXPECT_NEAR(last_pos.x(), expected_x, 0.005) << "Should approximate s = 0.5*a*t^2";
     EXPECT_NEAR(last_pos.y(), 0.0, 0.005) << "No lateral motion expected";
     EXPECT_NEAR(last_pos.z(), 0.0, 0.005) << "No vertical motion (gravity compensated)";
 }
@@ -295,9 +295,10 @@ TEST(SWVIOBackendTest, HealthDegradedWhenTraceExceedsGoodMax) {
 
 TEST(SWVIOBackendTest, HealthLostWhenTraceExceedsDegradedMax) {
     SWVIOParams params;
-    params.init_frames        = 1;
-    params.good_trace_max     = 1e-10;
-    params.degraded_trace_max = 1e-10;  // impossibly tight — will exceed both thresholds
+    params.init_frames    = 1;
+    params.good_trace_max = 1e-10;
+    params.degraded_trace_max =
+        2e-10;  // both impossibly tight, but degraded > good (validate() contract)
 
     auto backend = make_swvio(params);
 
@@ -366,9 +367,11 @@ TEST(SWVIOBackendTest, NaNIMUSampleRejected) {
     s1.gyro      = Eigen::Vector3d::Zero();
     samples.push_back(s1);
 
-    // Should not crash; NaN sample is skipped
+    // Should not crash; NaN sample is skipped, state stays near origin
     auto result = backend->process_frame(frame, samples);
     ASSERT_TRUE(result.is_ok());
+    EXPECT_LT(result.value().pose.position.norm(), 0.01)
+        << "NaN sample should be skipped — position must stay near origin";
 }
 
 TEST(SWVIOBackendTest, NegativeDtIMUSamplesSkipped) {
@@ -401,6 +404,16 @@ TEST(SWVIOBackendTest, NegativeDtIMUSamplesSkipped) {
     EXPECT_LT(result.value().pose.position.norm(), 0.05);
 }
 
+TEST(SWVIOBackendTest, ZeroTimestampRejected) {
+    auto backend       = create_vio_backend("swvio");
+    auto frame         = make_frame(1);
+    frame.timestamp_ns = 0;
+
+    auto imu    = make_imu_stationary(0.0, 0.033);
+    auto result = backend->process_frame(frame, imu);
+    EXPECT_TRUE(result.is_err()) << "Should reject zero timestamp";
+}
+
 TEST(SWVIOBackendTest, TimestampOverflowRejected) {
     auto backend = create_vio_backend("swvio");
     auto frame   = make_frame(1);
@@ -411,6 +424,31 @@ TEST(SWVIOBackendTest, TimestampOverflowRejected) {
     auto imu    = make_imu_stationary(0.0, 0.033);
     auto result = backend->process_frame(frame, imu);
     EXPECT_TRUE(result.is_err()) << "Should reject implausible timestamp";
+}
+
+TEST(SWVIOBackendTest, TimestampAtBoundaryAccepted) {
+    auto backend = create_vio_backend("swvio");
+    auto frame   = make_frame(1);
+
+    // 10 years in nanoseconds — the maximum accepted value
+    constexpr uint64_t kMaxTimestampNs = 10ULL * 365ULL * 24ULL * 3600ULL * 1'000'000'000ULL;
+    frame.timestamp_ns                 = kMaxTimestampNs;
+
+    auto imu    = make_imu_stationary(0.0, 0.033);
+    auto result = backend->process_frame(frame, imu);
+    EXPECT_TRUE(result.is_ok()) << "Timestamp at 10-year boundary should be accepted";
+}
+
+TEST(SWVIOBackendTest, TimestampBeyondBoundaryRejected) {
+    auto backend = create_vio_backend("swvio");
+    auto frame   = make_frame(1);
+
+    constexpr uint64_t kMaxTimestampNs = 10ULL * 365ULL * 24ULL * 3600ULL * 1'000'000'000ULL;
+    frame.timestamp_ns                 = kMaxTimestampNs + 1;
+
+    auto imu    = make_imu_stationary(0.0, 0.033);
+    auto result = backend->process_frame(frame, imu);
+    EXPECT_TRUE(result.is_err()) << "Timestamp beyond 10-year boundary should be rejected";
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/tools/cosys_populate_scene/main.cpp
+++ b/tools/cosys_populate_scene/main.cpp
@@ -205,8 +205,8 @@ int do_spawn(const Args& args) {
             try {
                 const auto returned = rpc.simSpawnObject(name, asset, pose, scale, physics);
                 std::cout << "  + " << name << "  <-  " << asset << "  at (" << x << ", " << y
-                          << ", " << z << ", yaw=" << yaw_deg << "°)"
-                          << "  -> " << returned << "\n";
+                          << ", " << z << ", yaw=" << yaw_deg << "°)" << "  -> " << returned
+                          << "\n";
                 stamp << returned << "\n";
                 ++spawned;
             } catch (const std::exception& e) {


### PR DESCRIPTION
## Summary

- Implements the Sliding-Window VIO (SWVIO) backend Phase 1: IMU error-state propagation with covariance, camera clone augmentation into a sliding window, and oldest-clone marginalization
- Extracts shared SO(3)/SE(3) math utilities (exp_map, log_map, skew, Jacobians) from imu_preintegrator.cpp into reusable slam_math.h
- Registers "swvio" backend in the IVIOBackend factory; extracts IVIOBackend pure interface into ivio_interface.h to break circular include dependency

## Changes

| File | Action | Description |
|------|--------|-------------|
| `slam_math.h` | New | Shared SO(3)/SE(3) math: exp_map, log_map, skew, left/right Jacobian |
| `swvio_types.h` | New | SWVIOParams, IMUState, CameraClone, SWVIOState |
| `swvio_backend.h` | New | SlidingWindowVIOBackend class declaration |
| `ivio_interface.h` | New | Extracted IVIOBackend pure interface |
| `swvio_backend.cpp` | New | Core: IMU propagation, augmentation, marginalization, health FSM |
| `test_swvio_backend.cpp` | New | 17 tests (8 backend + 9 slam_math) |
| `imu_preintegrator.cpp` | Modified | Use shared slam_math.h |
| `ivio_backend.h` | Modified | Interface extraction + factory "swvio" case |
| `default.json` | Modified | Added slam.vio.swvio config section |

## Test plan

- [x] Build: zero warnings (-Werror -Wall -Wextra)
- [x] Format: clang-format-18 clean
- [x] 1588 tests, 100% pass rate (17 new)
- [x] IMU propagation physics validated (constant accel → monotonic position)
- [x] Stationarity validated (gravity-only → stays at origin)
- [x] Covariance growth validated (trace increases without vision updates)
- [ ] Gazebo integration test (Phase 3)

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)