### PR TITLE
fix(#499): YOLO 256x144 frame downgrade — Cosys camera per-section lookup (Bug #1)

### DIFF
--- a/common/hal/include/hal/cosys_camera.h
+++ b/common/hal/include/hal/cosys_camera.h
@@ -13,6 +13,7 @@
 #pragma once
 #ifdef HAVE_COSYS_AIRSIM
 
+#include "hal/cosys_name_resolver.h"
 #include "hal/cosys_rpc_client.h"
 #include "hal/icamera.h"
 #include "util/config.h"
@@ -62,30 +63,19 @@ public:
     ///   2. top-level `cosys_airsim.camera_name`
     ///   3. literal default "front_center"
     ///
-    /// This lets each backend instance bind to its own AirSim camera (required
-    /// for multi-camera setups) while preserving a project-wide default.
-    /// Extracted as a static helper so it can be unit-tested without
-    /// instantiating the backend (which requires a live RPC client).
+    /// Thin wrapper around the shared `drone::hal::resolve_camera_name` free
+    /// function. Kept as a static method on the backend to preserve the
+    /// call-sites and unit-test signature introduced in Issue #499.
     [[nodiscard]] static std::string resolve_camera_name(const drone::Config& cfg,
                                                          const std::string&   section) {
-        if (!section.empty()) {
-            const auto per_section = cfg.get<std::string>(section + ".camera_name", "");
-            if (!per_section.empty()) return per_section;
-        }
-        return cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::CAMERA_NAME),
-                                    "front_center");
+        return drone::hal::resolve_camera_name(cfg, section);
     }
 
     /// Resolve AirSim vehicle name with the same precedence as `resolve_camera_name`,
-    /// defaulting to "Drone0".
+    /// defaulting to "Drone0". Thin wrapper around the shared free function.
     [[nodiscard]] static std::string resolve_vehicle_name(const drone::Config& cfg,
                                                           const std::string&   section) {
-        if (!section.empty()) {
-            const auto per_section = cfg.get<std::string>(section + ".vehicle_name", "");
-            if (!per_section.empty()) return per_section;
-        }
-        return cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::VEHICLE_NAME),
-                                    "Drone0");
+        return drone::hal::resolve_vehicle_name(cfg, section);
     }
 
     /// @param client   Shared RPC client (manages connection lifecycle)
@@ -189,14 +179,18 @@ private:
     CapturedFrame build_frame(const FrameData& data, bool new_frame) {
         CapturedFrame frame;
         frame.timestamp_ns = data.timestamp_ns;
-        frame.sequence     = new_frame ? sequence_.fetch_add(1, std::memory_order_relaxed)
-                                       : sequence_.load(std::memory_order_relaxed);
-        frame.width        = data.width;
-        frame.height       = data.height;
-        frame.channels     = data.channels;
-        frame.stride       = data.width * data.channels;
-        frame.data         = data.pixels;  // copy from cached FrameData
-        frame.valid        = true;
+        // memory_order_relaxed: ICamera is single-consumer per contract — only one
+        // thread ever calls capture(), so the sequence counter needs no
+        // cross-thread synchronisation. The atomic guarantees read tearing
+        // safety vs. open() which also writes sequence_ during initialisation.
+        frame.sequence = new_frame ? sequence_.fetch_add(1, std::memory_order_relaxed)
+                                   : sequence_.load(std::memory_order_relaxed);
+        frame.width    = data.width;
+        frame.height   = data.height;
+        frame.channels = data.channels;
+        frame.stride   = data.width * data.channels;
+        frame.data     = data.pixels;  // copy from cached FrameData
+        frame.valid    = true;
         return frame;
     }
 
@@ -223,12 +217,15 @@ private:
         // Surfaces a class of silent failures where AirSim auto-creates a
         // camera with default 256x144 CaptureSettings because the requested
         // name is not declared in server-side settings.json (Bug #499 Bug #1).
-        bool first_frame_logged = false;
+        bool first_frame_verified = false;
 
         while (open_.load(std::memory_order_acquire)) {
             try {
-                // Use with_client() to prevent TOCTOU race on disconnect
-                bool got_frame = client_->with_client([&](auto& rpc) {
+                // Use with_client() to prevent TOCTOU race on disconnect.
+                // `rpc_executed` reflects whether the client was available and
+                // the lambda ran — NOT whether a frame was decoded (that check
+                // lives inside the lambda, which returns void).
+                bool rpc_executed = client_->with_client([&](auto& rpc) {
                     auto responses = rpc.simGetImages(requests, vehicle_name_);
 
                     if (responses.empty() || responses[0].image_data_uint8.empty()) {
@@ -274,8 +271,8 @@ private:
                     // If not, the camera name likely isn't declared in settings.json
                     // and AirSim silently auto-created it with 256x144 defaults —
                     // we WARN so the mismatch is obvious in the logs.
-                    if (!first_frame_logged) {
-                        first_frame_logged = true;
+                    if (!first_frame_verified) {
+                        first_frame_verified = true;
                         if (w == width_ && h == height_) {
                             DRONE_LOG_INFO(
                                 "[CosysCamera] First frame received: camera='{}' {}x{} (as "
@@ -292,8 +289,9 @@ private:
                     }
                 });
 
-                if (!got_frame) {
-                    // RPC client disconnected — skip this tick
+                if (!rpc_executed) {
+                    // RPC client disconnected — with_client() short-circuited
+                    // without running the lambda, so no frame was fetched.
                     DRONE_LOG_WARN("[CosysCamera] RPC disconnected — skipping frame");
                 }
 

--- a/common/hal/include/hal/cosys_camera.h
+++ b/common/hal/include/hal/cosys_camera.h
@@ -57,19 +57,47 @@ public:
         uint64_t             timestamp_ns{0};  ///< Capture timestamp
     };
 
+    /// Resolve AirSim camera name with precedence:
+    ///   1. `<section>.camera_name` (e.g. "video_capture.mission_cam.camera_name")
+    ///   2. top-level `cosys_airsim.camera_name`
+    ///   3. literal default "front_center"
+    ///
+    /// This lets each backend instance bind to its own AirSim camera (required
+    /// for multi-camera setups) while preserving a project-wide default.
+    /// Extracted as a static helper so it can be unit-tested without
+    /// instantiating the backend (which requires a live RPC client).
+    [[nodiscard]] static std::string resolve_camera_name(const drone::Config& cfg,
+                                                         const std::string&   section) {
+        if (!section.empty()) {
+            const auto per_section = cfg.get<std::string>(section + ".camera_name", "");
+            if (!per_section.empty()) return per_section;
+        }
+        return cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::CAMERA_NAME),
+                                    "front_center");
+    }
+
+    /// Resolve AirSim vehicle name with the same precedence as `resolve_camera_name`,
+    /// defaulting to "Drone0".
+    [[nodiscard]] static std::string resolve_vehicle_name(const drone::Config& cfg,
+                                                          const std::string&   section) {
+        if (!section.empty()) {
+            const auto per_section = cfg.get<std::string>(section + ".vehicle_name", "");
+            if (!per_section.empty()) return per_section;
+        }
+        return cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::VEHICLE_NAME),
+                                    "Drone0");
+    }
+
     /// @param client   Shared RPC client (manages connection lifecycle)
     /// @param cfg      Loaded configuration
     /// @param section  Config path prefix (e.g. "video_capture.mission_cam")
     explicit CosysCameraBackend(std::shared_ptr<CosysRpcClient> client, const drone::Config& cfg,
                                 const std::string& section)
         : client_(std::move(client))
-        , camera_name_(cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::CAMERA_NAME),
-                                            "front_center"))
-        , vehicle_name_(cfg.get<std::string>(
-              std::string(drone::cfg_key::cosys_airsim::VEHICLE_NAME), "Drone0")) {
-        (void)section;  // section reserved for future per-camera config
-        DRONE_LOG_INFO("[CosysCamera] Created for {} camera='{}' vehicle='{}'", client_->endpoint(),
-                       camera_name_, vehicle_name_);
+        , camera_name_(resolve_camera_name(cfg, section))
+        , vehicle_name_(resolve_vehicle_name(cfg, section)) {
+        DRONE_LOG_INFO("[CosysCamera] Created for {} camera='{}' vehicle='{}' (section='{}')",
+                       client_->endpoint(), camera_name_, vehicle_name_, section);
     }
 
     ~CosysCameraBackend() override { close(); }
@@ -191,6 +219,12 @@ private:
                                            /* pixels_as_float */ false,
                                            /* compress */ false)};
 
+        // One-shot dimension verification on the first successful frame.
+        // Surfaces a class of silent failures where AirSim auto-creates a
+        // camera with default 256x144 CaptureSettings because the requested
+        // name is not declared in server-side settings.json (Bug #499 Bug #1).
+        bool first_frame_logged = false;
+
         while (open_.load(std::memory_order_acquire)) {
             try {
                 // Use with_client() to prevent TOCTOU race on disconnect
@@ -235,6 +269,27 @@ private:
                     fd.timestamp_ns = static_cast<uint64_t>(std::max(decltype(ts_ns){0}, ts_ns));
 
                     frame_buffer_.write(std::move(fd));
+
+                    // One-shot: verify AirSim returned the dimensions we requested.
+                    // If not, the camera name likely isn't declared in settings.json
+                    // and AirSim silently auto-created it with 256x144 defaults —
+                    // we WARN so the mismatch is obvious in the logs.
+                    if (!first_frame_logged) {
+                        first_frame_logged = true;
+                        if (w == width_ && h == height_) {
+                            DRONE_LOG_INFO(
+                                "[CosysCamera] First frame received: camera='{}' {}x{} (as "
+                                "requested)",
+                                camera_name_, w, h);
+                        } else {
+                            DRONE_LOG_WARN(
+                                "[CosysCamera] First frame dimension MISMATCH: camera='{}' "
+                                "returned {}x{} but {}x{} was requested. The camera name may "
+                                "not be declared in AirSim settings.json (server-side), causing "
+                                "AirSim to auto-create it with default CaptureSettings.",
+                                camera_name_, w, h, width_, height_);
+                        }
+                    }
                 });
 
                 if (!got_frame) {

--- a/common/hal/include/hal/cosys_camera.h
+++ b/common/hal/include/hal/cosys_camera.h
@@ -58,34 +58,16 @@ public:
         uint64_t             timestamp_ns{0};  ///< Capture timestamp
     };
 
-    /// Resolve AirSim camera name with precedence:
-    ///   1. `<section>.camera_name` (e.g. "video_capture.mission_cam.camera_name")
-    ///   2. top-level `cosys_airsim.camera_name`
-    ///   3. literal default "front_center"
-    ///
-    /// Thin wrapper around the shared `drone::hal::resolve_camera_name` free
-    /// function. Kept as a static method on the backend to preserve the
-    /// call-sites and unit-test signature introduced in Issue #499.
-    [[nodiscard]] static std::string resolve_camera_name(const drone::Config& cfg,
-                                                         const std::string&   section) {
-        return drone::hal::resolve_camera_name(cfg, section);
-    }
-
-    /// Resolve AirSim vehicle name with the same precedence as `resolve_camera_name`,
-    /// defaulting to "Drone0". Thin wrapper around the shared free function.
-    [[nodiscard]] static std::string resolve_vehicle_name(const drone::Config& cfg,
-                                                          const std::string&   section) {
-        return drone::hal::resolve_vehicle_name(cfg, section);
-    }
-
     /// @param client   Shared RPC client (manages connection lifecycle)
     /// @param cfg      Loaded configuration
     /// @param section  Config path prefix (e.g. "video_capture.mission_cam")
+    ///                 Per-section `camera_name`/`vehicle_name` override the
+    ///                 top-level `cosys_airsim.*` keys — see Issue #499 Bug #1.
     explicit CosysCameraBackend(std::shared_ptr<CosysRpcClient> client, const drone::Config& cfg,
                                 const std::string& section)
         : client_(std::move(client))
-        , camera_name_(resolve_camera_name(cfg, section))
-        , vehicle_name_(resolve_vehicle_name(cfg, section)) {
+        , camera_name_(drone::hal::resolve_camera_name(cfg, section))
+        , vehicle_name_(drone::hal::resolve_vehicle_name(cfg, section)) {
         DRONE_LOG_INFO("[CosysCamera] Created for {} camera='{}' vehicle='{}' (section='{}')",
                        client_->endpoint(), camera_name_, vehicle_name_, section);
     }

--- a/common/hal/include/hal/cosys_depth.h
+++ b/common/hal/include/hal/cosys_depth.h
@@ -19,6 +19,7 @@
 #pragma once
 #ifdef HAVE_COSYS_AIRSIM
 
+#include "hal/cosys_name_resolver.h"
 #include "hal/cosys_rpc_client.h"
 #include "hal/idepth_estimator.h"
 #include "util/config.h"
@@ -45,27 +46,26 @@ namespace drone::hal {
 /// to get metric depth per pixel. Returns DepthMap with confidence=0.95
 /// (ground truth from simulator, not perfect due to rendering artifacts).
 ///
-/// Config keys:
-///   cosys_airsim.host         (default "127.0.0.1")
-///   cosys_airsim.port         (default 41451)
-///   cosys_airsim.camera_name  (default "front_center")
-///   cosys_airsim.vehicle_name (default "Drone0")
+/// Config keys (with precedence: `<section>.<subkey>` → top-level → default):
+///   `<section>.camera_name`  → `cosys_airsim.camera_name`  (default "front_center")
+///   `<section>.vehicle_name` → `cosys_airsim.vehicle_name` (default "Drone0")
+///   cosys_airsim.host        (default "127.0.0.1")
+///   cosys_airsim.port        (default 41451)
 class CosysDepthBackend : public IDepthEstimator {
 public:
     /// Construct from shared RPC client and config.
     /// @param client   Shared RPC client (manages connection lifecycle)
     /// @param cfg      Loaded configuration
-    /// @param section  Config path prefix (e.g. "perception.depth_estimator")
+    /// @param section  Config path prefix (e.g. "perception.depth_estimator").
+    ///                 Per-section `camera_name`/`vehicle_name` override the
+    ///                 top-level `cosys_airsim.*` keys — see Issue #499 Bug #1.
     explicit CosysDepthBackend(std::shared_ptr<CosysRpcClient> client, const drone::Config& cfg,
                                const std::string& section)
         : client_(std::move(client))
-        , camera_name_(cfg.get<std::string>(std::string(drone::cfg_key::cosys_airsim::CAMERA_NAME),
-                                            "front_center"))
-        , vehicle_name_(cfg.get<std::string>(
-              std::string(drone::cfg_key::cosys_airsim::VEHICLE_NAME), "Drone0")) {
-        (void)section;  // section reserved for future per-estimator config
-        DRONE_LOG_INFO("[CosysDepth] Created for {} camera='{}' vehicle='{}'", client_->endpoint(),
-                       camera_name_, vehicle_name_);
+        , camera_name_(drone::hal::resolve_camera_name(cfg, section))
+        , vehicle_name_(drone::hal::resolve_vehicle_name(cfg, section)) {
+        DRONE_LOG_INFO("[CosysDepth] Created for {} camera='{}' vehicle='{}' (section='{}')",
+                       client_->endpoint(), camera_name_, vehicle_name_, section);
     }
 
     // Non-copyable, non-movable (owns RPC connection state reference)

--- a/common/hal/include/hal/cosys_name_resolver.h
+++ b/common/hal/include/hal/cosys_name_resolver.h
@@ -1,0 +1,67 @@
+// common/hal/include/hal/cosys_name_resolver.h
+// Shared name-resolution helpers for Cosys-AirSim HAL backends.
+//
+// Both CosysCameraBackend (RGB) and CosysDepthBackend (depth) need to resolve
+// AirSim camera and vehicle names with the same precedence ladder:
+//   1. Per-section override (e.g. `video_capture.mission_cam.camera_name`)
+//   2. Top-level fallback (e.g. `cosys_airsim.camera_name`)
+//   3. Hard-coded default
+//
+// An explicit empty string at the per-section key is treated as "absent" so a
+// stray `"camera_name": ""` in a scenario override cannot silently shadow the
+// top-level default. See Issue #499 Bug #1 for the original motivation.
+//
+// Free functions (not class statics) so new Cosys backends can reuse them
+// without taking a dependency on any specific backend class.
+//
+// Issue: #499
+#pragma once
+#ifdef HAVE_COSYS_AIRSIM
+
+#include "util/config.h"
+#include "util/config_keys.h"
+
+#include <string>
+
+namespace drone::hal {
+
+/// Core name resolver: per-section override → top-level key → hard-coded default.
+///
+/// @param cfg                 Loaded configuration
+/// @param section             Config path prefix (e.g. "video_capture.mission_cam"),
+///                            empty to skip per-section lookup
+/// @param per_section_subkey  Sub-key appended to section (e.g. ".camera_name")
+/// @param top_level_key       Fully-qualified fallback key (e.g. "cosys_airsim.camera_name")
+/// @param default_value       Hard-coded default when neither key is present
+[[nodiscard]] inline std::string resolve_airsim_name(const drone::Config& cfg,
+                                                     const std::string&   section,
+                                                     const char*          per_section_subkey,
+                                                     const char*          top_level_key,
+                                                     const char*          default_value) {
+    if (!section.empty()) {
+        const auto per_section = cfg.get<std::string>(section + per_section_subkey, "");
+        // Empty value must not shadow top-level: treat "" as "absent".
+        if (!per_section.empty()) return per_section;
+    }
+    return cfg.get<std::string>(top_level_key, default_value);
+}
+
+/// Resolve AirSim camera name:
+///   `<section>.camera_name` → `cosys_airsim.camera_name` → "front_center".
+[[nodiscard]] inline std::string resolve_camera_name(const drone::Config& cfg,
+                                                     const std::string&   section) {
+    return resolve_airsim_name(cfg, section, ".camera_name",
+                               drone::cfg_key::cosys_airsim::CAMERA_NAME, "front_center");
+}
+
+/// Resolve AirSim vehicle name:
+///   `<section>.vehicle_name` → `cosys_airsim.vehicle_name` → "Drone0".
+[[nodiscard]] inline std::string resolve_vehicle_name(const drone::Config& cfg,
+                                                      const std::string&   section) {
+    return resolve_airsim_name(cfg, section, ".vehicle_name",
+                               drone::cfg_key::cosys_airsim::VEHICLE_NAME, "Drone0");
+}
+
+}  // namespace drone::hal
+
+#endif  // HAVE_COSYS_AIRSIM

--- a/config/cosys_airsim_dev.json
+++ b/config/cosys_airsim_dev.json
@@ -6,7 +6,7 @@
     "cosys_airsim": {
         "host": "127.0.0.1",
         "port": 41451,
-        "camera_name": "front_center",
+        "camera_name": "mission_cam",
         "radar_name": "lidar",
         "_comment_radar_name": "Matches the Lidar sensor declared in cosys_settings.json. AirSim sensor lookup is exact-match.",
         "imu_name": "imu",

--- a/config/default.json
+++ b/config/default.json
@@ -276,7 +276,8 @@
         "_comment": "Cosys-AirSim simulation settings (used when backend=cosys_airsim)",
         "host": "127.0.0.1",
         "port": 41451,
-        "camera_name": "front_center",
+        "camera_name": "mission_cam",
+        "_camera_name_comment": "Must match a Cameras entry in ~/Documents/AirSim/settings.json — unknown names get silently downgraded to 256x144 (Issue #499)",
         "radar_name": "radar",
         "imu_name": "imu",
         "vehicle_name": "Drone0"

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -628,6 +628,33 @@ else
 
 ---
 
+### Fix #499a — Cosys Camera Silently Downgraded to 256×144 (Issue #499, Bug #1)
+
+**Date:** 2026-04-18
+**Severity:** High (perception non-functional in Tier 3 dev profile — 0 detections across 39 inference frames)
+**Files:** `config/cosys_airsim_dev.json`, `common/hal/include/hal/cosys_camera.h`, `tests/test_cosys_camera_config.cpp` (new), `tests/CMakeLists.txt`
+
+**Bug:** YOLO received 256×144 frames from `CosysCameraBackend` even though the config declared `video_capture.mission_cam.{width:1280,height:720}`. The backend's own log line cheerfully reported `"Opened camera='front_center' on 127.0.0.1:41451 (1280x720@30Hz)"` — every RPC response was a 256×144 thumbnail. Scenario 30 completed flight paths but produced 0 object detections.
+
+**Root Cause:** Three compounding issues:
+
+1. **Config mismatch.** `config/cosys_airsim_dev.json` declared `cosys_airsim.camera_name: "front_center"`, but the server-side `~/Documents/AirSim/settings.json` only declared `mission_cam` (1280×720) and `DepthCam` (640×480). When a client requests a camera name not in `settings.json`, AirSim's `AirSimSettings::getCamera()` auto-creates it with default `CaptureSettings` — **width=256, height=144** (confirmed at `third_party/cosys-airsim/AirLib/include/common/AirSimSettings.hpp:174`).
+2. **Dead per-section config.** The `CosysCameraBackend` constructor accepted a `section` parameter (e.g. `"video_capture.mission_cam"`) but ignored it with `(void)section`. Scenario 30 already had a correct per-camera override (`camera_name: "mission_cam"` under `video_capture.mission_cam`) — it was dead config that never routed to AirSim.
+3. **No dimension verification.** The open() log line printed the *requested* dimensions, never what AirSim actually returned. 30× resolution downgrade produced no observable signal in logs; only YOLO's zero-detection count eventually surfaced the problem.
+
+**Fix:**
+
+- `config/cosys_airsim_dev.json`: `cosys_airsim.camera_name` → `"mission_cam"` so the requested name matches `settings.json`.
+- `CosysCameraBackend`: added `static` helpers `resolve_camera_name` / `resolve_vehicle_name` implementing a precedence ladder `<section>.camera_name` → `cosys_airsim.camera_name` → default. Constructor wired to them. Static so the resolution logic is unit-testable without a live RPC client.
+- `retrieval_loop()`: one-shot first-frame dimension log. If `(resp.width, resp.height)` matches the requested `(width_, height_)` → INFO with "as requested". If it differs → WARN with the returned vs requested values plus a hint that the camera may not be declared in `settings.json`. Flag is a local variable in the thread loop — no member state required.
+- New unit test `tests/test_cosys_camera_config.cpp` (5 tests, gated on `HAVE_COSYS_AIRSIM`): per-section override, top-level fallback, default fallback, empty-section fallthrough, empty-value-treated-as-absent.
+
+**Impact:** Dev-profile perception stack now receives the configured 1280×720 frames. Future misconfigurations of the same class will surface within seconds of the first successful frame instead of silently propagating a 30× resolution downgrade through the IPC bus. The precedence ladder also unblocks multi-camera Tier 3 setups (mission + depth + front-center), where each backend instance needs to map to a distinct AirSim camera.
+
+**Found by:** Live scenario 30 run on 2026-04-17 — drone flew waypoints successfully but `TrackerSink` reported 0 frames published and YOLO inference completed with 0 detections across 39 frames. Root-caused by inspecting AirSim's `AirSimSettings::getCamera()` auto-create behaviour against the dev-profile's `camera_name` value.
+
+---
+
 ### Fix #51 — Depth Anything V2 ONNX Model Incompatible with OpenCV DNN (Issue #455)
 
 **Date:** 2026-04-14

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -651,6 +651,14 @@ else
 
 **Impact:** Dev-profile perception stack now receives the configured 1280×720 frames. Future misconfigurations of the same class will surface within seconds of the first successful frame instead of silently propagating a 30× resolution downgrade through the IPC bus. The precedence ladder also unblocks multi-camera Tier 3 setups (mission + depth + front-center), where each backend instance needs to map to a distinct AirSim camera.
 
+**Follow-up (PR #501 review):** Review flagged the same bug class in three adjacent files. Fixes extended as part of the same PR:
+
+- `common/hal/include/hal/cosys_depth.h` — constructor was reading `cosys_airsim.camera_name` / `vehicle_name` directly and discarding the `section` parameter with `(void)section`. Now calls the shared resolver so per-section overrides work for depth too.
+- `config/default.json` — `cosys_airsim.camera_name` was still `"front_center"` (matched the dev-profile bug, not the canonical `settings.json` name). Changed to `"mission_cam"` with an inline `_camera_name_comment` explaining that the value must match the server-side `settings.json` Cameras entry.
+- `tools/cosys_smoke_test.cpp` — hardcoded `"front_center"` in the RGB and depth requests. Now loads `config/default.json` and uses the shared resolver; prints the resolved camera name at startup so developers can see which AirSim camera the smoke test is targeting.
+- `common/hal/include/hal/cosys_name_resolver.h` (new) — consolidated `resolve_camera_name` / `resolve_vehicle_name` as free functions atop a single `resolve_airsim_name(cfg, section, subkey, top_level_key, default)` primitive. `CosysCameraBackend`'s static methods become 1-line wrappers preserving the existing unit-test surface.
+- `tests/test_cosys_camera_config.cpp` — added symmetric `EmptyPerSectionVehicleNameTreatedAsAbsent` test so the empty-value-not-shadowing guarantee is verified for both resolvers. Hardened temp-file writer with an `ofstream::good()` guard. Test count in this file rose 5 → 6.
+
 **Found by:** Live scenario 30 run on 2026-04-17 — drone flew waypoints successfully but `TrackerSink` reported 0 frames published and YOLO inference completed with 0 detections across 39 frames. Root-caused by inspecting AirSim's `AirSimSettings::getCamera()` auto-create behaviour against the dev-profile's `camera_name` value.
 
 ---

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -2996,4 +2996,27 @@ Directory lifecycle: `_RUNNING` → `_PASS`/`_FAIL` on completion, `_ABORTED` on
 
 ---
 
-_Last updated after Improvement #71 (issue #479). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._
+### Improvement #72 — Cosys Camera Config Lookup + First-Frame Dimension Log (Issue #499, Bug #1)
+
+**Date:** 2026-04-18
+**Category:** Bug Fix — Perception / Tier 3 simulation
+**Issues:** [#499](https://github.com/nmohamaya/companion_software_stack/issues/499)
+
+**What:**
+
+- **Config fix** — `config/cosys_airsim_dev.json`: `cosys_airsim.camera_name` changed from `"front_center"` to `"mission_cam"` so the requested camera matches the name declared in the server-side `settings.json`. Previously, AirSim silently auto-created the `"front_center"` camera with default 256×144 `CaptureSettings` (confirmed at `third_party/cosys-airsim/AirLib/include/common/AirSimSettings.hpp:174`) — YOLO received 256×144 thumbnails and produced 0 detections across 39 inference frames.
+- **Per-section lookup** — `CosysCameraBackend` now resolves `camera_name` / `vehicle_name` with a precedence ladder: `<section>.camera_name` → `cosys_airsim.camera_name` → default `"front_center"` (`"Drone0"` for vehicle). The constructor previously ignored its `section` parameter with `(void)section`, so scenario 30's per-camera override (already present in `scenarios/30_cosys_static.json`) was dead config. The new logic also enables multi-camera setups (e.g. mission + depth + front-center) to map each backend instance to a distinct AirSim camera.
+- **Name resolution helpers** — Extracted as `static` members (`resolve_camera_name`, `resolve_vehicle_name`) so they can be unit-tested without instantiating the backend (which would require a live RPC client).
+- **First-frame dimension log** — `retrieval_loop()` now emits a one-shot log line on the first successful frame showing the AirSim-returned `(width, height)`. If they differ from what was requested, the log level is WARN and the message explicitly suggests the camera may not be declared in server-side `settings.json`. This would have surfaced Bug #1 within seconds of the first run instead of letting 256×144 frames silently propagate through IPC. Flag is a local variable in the thread loop — no member state needed.
+- **New unit test** — `tests/test_cosys_camera_config.cpp` (5 tests, gated on `HAVE_COSYS_AIRSIM`): per-section overrides top-level, top-level used when per-section absent, defaults apply when neither set, empty section falls through, empty per-section value treated as absent. No RPC required.
+
+**Files added:** `tests/test_cosys_camera_config.cpp`
+**Files modified:** `config/cosys_airsim_dev.json`, `common/hal/include/hal/cosys_camera.h`, `tests/CMakeLists.txt`
+
+**Why:** This is Bug #1 of Issue #499. Scenario 30's 2026-04-17 runs flew waypoints but produced zero detections — the cause was not a model or detector issue but a silent 30× resolution downgrade at the camera-HAL boundary. The fix is defence-in-depth: (1) a correct default on the dev profile so the immediate symptom goes away, (2) a precedence ladder so scenario overrides actually take effect, and (3) a first-frame dimension log so any future mismatch is loud instead of silent. Bug #2 (collide-and-stick at WP3) is tracked as a separate follow-up.
+
+**Test count:** +5 (gated on `HAVE_COSYS_AIRSIM`; machines without the SDK compile the TU to empty, so the CI baseline is unchanged — see [tests/TESTS.md](../../tests/TESTS.md)).
+
+---
+
+_Last updated after Improvement #72 (issue #499, Bug #1). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -246,6 +246,13 @@ endif()
 # ── Cosys-AirSim HAL backend tests (Issue #434) ────────────
 add_drone_test(test_cosys_hal_backends test_cosys_hal_backends.cpp)
 
+# ── Cosys camera config-lookup tests (Issue #499, Bug #1) ──
+# Verifies the per-section → top-level → default precedence ladder used by
+# CosysCameraBackend. Whole test body is gated on HAVE_COSYS_AIRSIM (set as
+# INTERFACE definition on drone_hal when the SDK is found); without the SDK
+# the translation unit compiles to an empty TU, which is harmless.
+add_drone_test(test_cosys_camera_config test_cosys_camera_config.cpp)
+
 # ── Cosys-AirSim FC link tests (Issue #490) ───────────────
 # SimpleFlight-via-AirSim-RPC backend — tests run without a live AirSim
 # server; all command paths should return false when disconnected.

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -129,7 +129,8 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
-| **Total** | **70 C++ + 5 shell** | **1553 + 42 + 250+** | |
+| [HAL — Cosys-AirSim Camera Config](#test_cosys_camera_configcpp--5-tests) | 1 | 5 | CosysCameraBackend name-resolution precedence: per-section → top-level → default (gated on `HAVE_COSYS_AIRSIM`) |
+| **Total** | **71 C++ + 5 shell** | **1571 (no SDK) / 1576 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -337,6 +338,22 @@ Compiled with `HAVE_MAVSDK`.  Tests gracefully handle missing PX4 SITL.
 **Key files under test:** `hal/cosys_fc_link.h`, `hal/cosys_rpc_client.h`, `hal/hal_factory.h`
 
 **Why:** Tier 3 (Cosys-AirSim) uses SimpleFlight instead of PX4 because PX4+Cosys HIL is broken upstream (PX4 #24033, AirSim #5018). This backend is the Tier-3 counterpart to `MavlinkFCLink`. The tests verify the failure paths that flight-critical code depends on (no crash, no hang, no arbitrary truthy result when the simulator isn't running).
+
+---
+
+## HAL — Cosys-AirSim Camera Config
+
+### test_cosys_camera_config.cpp — 5 tests
+
+**What it tests:** `CosysCameraBackend::resolve_camera_name` / `resolve_vehicle_name` — the name-resolution precedence ladder introduced to fix Issue #499, Bug #1. Whole TU is gated on `HAVE_COSYS_AIRSIM`; machines without the SDK compile it to empty.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `CosysCameraConfigTest` | 5 | `<section>.camera_name` overrides `cosys_airsim.camera_name`; top-level used when per-section absent; defaults `"front_center"` / `"Drone0"` used when neither set; empty section falls through to top-level; empty per-section value treated as absent (does not shadow top-level) |
+
+**Key files under test:** `hal/cosys_camera.h` (static helpers `resolve_camera_name`, `resolve_vehicle_name`).
+
+**Why:** Regression test for the silent 256×144 downgrade that made scenario 30 produce zero detections for 39 YOLO inference frames. No RPC required — the helpers are `static` by design so the resolution logic can be unit-tested without instantiating the backend (which would need a live AirSim server). See BUG_FIXES.md → Fix #499a.
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -130,7 +130,7 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
 | [HAL — Cosys-AirSim Camera Config](#test_cosys_camera_configcpp--5-tests) | 1 | 5 | CosysCameraBackend name-resolution precedence: per-section → top-level → default (gated on `HAVE_COSYS_AIRSIM`) |
-| **Total** | **71 C++ + 5 shell** | **1571 (no SDK) / 1576 (+SDK) + 42 + 250+** | |
+| **Total** | **71 C++ + 5 shell** | **1554 (no SDK) / 1590 (+SDK) + 42 + 250+** | |
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -52,7 +52,7 @@
 | `perception` | Kalman tracker, fusion engine (UKF+camera+radar), color contour, YOLOv8 | ~189 |
 | `mission` | Mission FSM, FaultManager, D* Lite, ObstacleAvoider3D, geofence, event bus | ~287 |
 | `comms` | MavlinkSim and GCSLink | ~13 |
-| `hal` | Simulated, Gazebo, MAVLink, and plugin HAL backends | ~136 |
+| `hal` | Simulated, Gazebo, MAVLink, and plugin HAL backends | ~137 |
 | `payload` | GimbalController servo simulation | ~34 |
 | `monitor` | P7 system monitor (CPU/memory/thermal, ISysInfo, process context) | ~64 |
 | `util` | Config, Result, latency tracker, JSON log, correlation, replay dispatch | ~251 |
@@ -129,8 +129,8 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — PluginLoader](#hal--pluginloader) | 2 | 13 | PluginHandle RAII, PluginLoader dlopen/dlsym, PluginRegistry (HAVE_PLUGINS only) |
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
-| [HAL — Cosys-AirSim Camera Config](#test_cosys_camera_configcpp--5-tests) | 1 | 5 | CosysCameraBackend name-resolution precedence: per-section → top-level → default (gated on `HAVE_COSYS_AIRSIM`) |
-| **Total** | **71 C++ + 5 shell** | **1554 (no SDK) / 1590 (+SDK) + 42 + 250+** | |
+| [HAL — Cosys-AirSim Camera Config](#test_cosys_camera_configcpp--6-tests) | 1 | 6 | CosysCameraBackend name-resolution precedence: per-section → top-level → default, plus symmetric empty-value-not-shadowing for vehicle_name (gated on `HAVE_COSYS_AIRSIM`) |
+| **Total** | **71 C++ + 5 shell** | **1554 (no SDK) / 1591 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -343,15 +343,15 @@ Compiled with `HAVE_MAVSDK`.  Tests gracefully handle missing PX4 SITL.
 
 ## HAL — Cosys-AirSim Camera Config
 
-### test_cosys_camera_config.cpp — 5 tests
+### test_cosys_camera_config.cpp — 6 tests
 
 **What it tests:** `CosysCameraBackend::resolve_camera_name` / `resolve_vehicle_name` — the name-resolution precedence ladder introduced to fix Issue #499, Bug #1. Whole TU is gated on `HAVE_COSYS_AIRSIM`; machines without the SDK compile it to empty.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
-| `CosysCameraConfigTest` | 5 | `<section>.camera_name` overrides `cosys_airsim.camera_name`; top-level used when per-section absent; defaults `"front_center"` / `"Drone0"` used when neither set; empty section falls through to top-level; empty per-section value treated as absent (does not shadow top-level) |
+| `CosysCameraConfigTest` | 6 | `<section>.camera_name` overrides `cosys_airsim.camera_name`; top-level used when per-section absent; defaults `"front_center"` / `"Drone0"` used when neither set; empty section falls through to top-level; empty per-section value treated as absent for both camera_name and vehicle_name (does not shadow top-level) |
 
-**Key files under test:** `hal/cosys_camera.h` (static helpers `resolve_camera_name`, `resolve_vehicle_name`).
+**Key files under test:** `hal/cosys_name_resolver.h` (free functions `resolve_camera_name`, `resolve_vehicle_name`, `resolve_airsim_name`), `hal/cosys_camera.h` (thin static wrappers).
 
 **Why:** Regression test for the silent 256×144 downgrade that made scenario 30 produce zero detections for 39 YOLO inference frames. No RPC required — the helpers are `static` by design so the resolution logic can be unit-tested without instantiating the backend (which would need a live AirSim server). See BUG_FIXES.md → Fix #499a.
 

--- a/tests/test_cosys_camera_config.cpp
+++ b/tests/test_cosys_camera_config.cpp
@@ -51,6 +51,11 @@ std::string write_temp_config(const std::string& json_content) {
     std::ofstream ofs(path);
     ofs << json_content;
     ofs.close();
+    // Guard against silent write failures — a failed temp-file write would
+    // otherwise surface as a confusing cfg.load() assertion downstream.
+    if (!ofs.good()) {
+        ADD_FAILURE() << "Failed to write temp config at " << path;
+    }
     temp_files().push_back(path);
     return path;
 }
@@ -146,6 +151,25 @@ TEST(CosysCameraConfigTest, EmptyPerSectionValueTreatedAsAbsent) {
 
     EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
               "mission_cam");
+}
+
+TEST(CosysCameraConfigTest, EmptyPerSectionVehicleNameTreatedAsAbsent) {
+    // Symmetric check for vehicle_name — the empty-string-not-shadowing
+    // guarantee must apply equally to both resolvers so a scenario override
+    // with `"vehicle_name": ""` cannot silently route RPCs to the wrong
+    // vehicle (or, worse, to AirSim's empty-name default).
+    const auto    path = write_temp_config(R"({
+        "cosys_airsim": { "vehicle_name": "Hero" },
+        "video_capture": {
+            "mission_cam": { "vehicle_name": "" }
+        }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    EXPECT_EQ(
+        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
+        "Hero");
 }
 
 #endif  // HAVE_COSYS_AIRSIM

--- a/tests/test_cosys_camera_config.cpp
+++ b/tests/test_cosys_camera_config.cpp
@@ -14,7 +14,7 @@
 //   3. Defaults ("front_center" / "Drone0") apply when neither key is set
 #ifdef HAVE_COSYS_AIRSIM
 
-#include "hal/cosys_camera.h"
+#include "hal/cosys_name_resolver.h"
 #include "util/config.h"
 
 #include <atomic>
@@ -86,11 +86,8 @@ TEST(CosysCameraConfigTest, PerSectionOverridesTopLevel) {
     drone::Config cfg;
     ASSERT_TRUE(cfg.load(path));
 
-    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
-              "mission_cam");
-    EXPECT_EQ(
-        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
-        "Hero");
+    EXPECT_EQ(drone::hal::resolve_camera_name(cfg, "video_capture.mission_cam"), "mission_cam");
+    EXPECT_EQ(drone::hal::resolve_vehicle_name(cfg, "video_capture.mission_cam"), "Hero");
 }
 
 TEST(CosysCameraConfigTest, TopLevelUsedWhenPerSectionAbsent) {
@@ -104,11 +101,8 @@ TEST(CosysCameraConfigTest, TopLevelUsedWhenPerSectionAbsent) {
     ASSERT_TRUE(cfg.load(path));
 
     // No per-section camera_name → falls back to cosys_airsim.camera_name
-    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
-              "mission_cam");
-    EXPECT_EQ(
-        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
-        "Drone0");
+    EXPECT_EQ(drone::hal::resolve_camera_name(cfg, "video_capture.mission_cam"), "mission_cam");
+    EXPECT_EQ(drone::hal::resolve_vehicle_name(cfg, "video_capture.mission_cam"), "Drone0");
 }
 
 TEST(CosysCameraConfigTest, DefaultUsedWhenNeitherSet) {
@@ -117,11 +111,8 @@ TEST(CosysCameraConfigTest, DefaultUsedWhenNeitherSet) {
     drone::Config cfg;
     ASSERT_TRUE(cfg.load(path));
 
-    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
-              "front_center");
-    EXPECT_EQ(
-        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
-        "Drone0");
+    EXPECT_EQ(drone::hal::resolve_camera_name(cfg, "video_capture.mission_cam"), "front_center");
+    EXPECT_EQ(drone::hal::resolve_vehicle_name(cfg, "video_capture.mission_cam"), "Drone0");
 }
 
 TEST(CosysCameraConfigTest, EmptySectionFallsThroughToTopLevel) {
@@ -133,7 +124,7 @@ TEST(CosysCameraConfigTest, EmptySectionFallsThroughToTopLevel) {
     drone::Config cfg;
     ASSERT_TRUE(cfg.load(path));
 
-    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, ""), "mission_cam");
+    EXPECT_EQ(drone::hal::resolve_camera_name(cfg, ""), "mission_cam");
 }
 
 TEST(CosysCameraConfigTest, EmptyPerSectionValueTreatedAsAbsent) {
@@ -149,8 +140,7 @@ TEST(CosysCameraConfigTest, EmptyPerSectionValueTreatedAsAbsent) {
     drone::Config cfg;
     ASSERT_TRUE(cfg.load(path));
 
-    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
-              "mission_cam");
+    EXPECT_EQ(drone::hal::resolve_camera_name(cfg, "video_capture.mission_cam"), "mission_cam");
 }
 
 TEST(CosysCameraConfigTest, EmptyPerSectionVehicleNameTreatedAsAbsent) {
@@ -167,9 +157,7 @@ TEST(CosysCameraConfigTest, EmptyPerSectionVehicleNameTreatedAsAbsent) {
     drone::Config cfg;
     ASSERT_TRUE(cfg.load(path));
 
-    EXPECT_EQ(
-        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
-        "Hero");
+    EXPECT_EQ(drone::hal::resolve_vehicle_name(cfg, "video_capture.mission_cam"), "Hero");
 }
 
 #endif  // HAVE_COSYS_AIRSIM

--- a/tests/test_cosys_camera_config.cpp
+++ b/tests/test_cosys_camera_config.cpp
@@ -1,0 +1,151 @@
+// tests/test_cosys_camera_config.cpp
+// Unit tests for CosysCameraBackend config-lookup precedence (Issue #499, Bug #1).
+//
+// Bug #1 background:
+//   AirSim silently auto-creates a requested camera with default 256x144
+//   CaptureSettings when the name is not declared in server-side settings.json.
+//   The dev profile shipped with "cosys_airsim.camera_name":"front_center"
+//   while settings.json only declared "mission_cam" — so YOLO received
+//   256x144 thumbnails, producing 0 detections for 39 inference frames.
+//
+// These tests verify the name-resolution logic (no RPC required):
+//   1. Per-section <section>.camera_name overrides top-level
+//   2. Top-level cosys_airsim.camera_name is used when per-section is absent
+//   3. Defaults ("front_center" / "Drone0") apply when neither key is set
+#ifdef HAVE_COSYS_AIRSIM
+
+#include "hal/cosys_camera.h"
+#include "util/config.h"
+
+#include <atomic>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+namespace {
+
+// Track temp files so we can unlink them on process exit.
+std::vector<std::string>& temp_files() {
+    static std::vector<std::string> files;
+    return files;
+}
+
+// Write JSON to a unique temp file and return the path. Uses mkstemps() where
+// available; falls back to PID+counter naming in sandboxed environments.
+std::string write_temp_config(const std::string& json_content) {
+    char        tmpl[] = "/tmp/test_cosys_camera_cfg_XXXXXX.json";
+    int         fd     = ::mkstemps(tmpl, 5);  // 5 = strlen(".json")
+    std::string path;
+    if (fd < 0) {
+        static std::atomic<int> counter{0};
+        path = "/tmp/test_cosys_camera_cfg_" + std::to_string(::getpid()) + "_" +
+               std::to_string(counter.fetch_add(1)) + ".json";
+    } else {
+        ::close(fd);
+        path.assign(tmpl);
+    }
+    std::ofstream ofs(path);
+    ofs << json_content;
+    ofs.close();
+    temp_files().push_back(path);
+    return path;
+}
+
+struct TempFileCleanup {
+    ~TempFileCleanup() {
+        for (const auto& f : temp_files()) std::remove(f.c_str());
+    }
+};
+TempFileCleanup g_cleanup;
+
+}  // namespace
+
+// ═══════════════════════════════════════════════════════════
+// resolve_camera_name — precedence ladder
+// ═══════════════════════════════════════════════════════════
+
+TEST(CosysCameraConfigTest, PerSectionOverridesTopLevel) {
+    const auto    path = write_temp_config(R"({
+        "cosys_airsim": { "camera_name": "front_center", "vehicle_name": "Drone0" },
+        "video_capture": {
+            "mission_cam": {
+                "camera_name": "mission_cam",
+                "vehicle_name": "Hero"
+            }
+        }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
+              "mission_cam");
+    EXPECT_EQ(
+        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
+        "Hero");
+}
+
+TEST(CosysCameraConfigTest, TopLevelUsedWhenPerSectionAbsent) {
+    const auto    path = write_temp_config(R"({
+        "cosys_airsim": { "camera_name": "mission_cam", "vehicle_name": "Drone0" },
+        "video_capture": {
+            "mission_cam": { "backend": "cosys_airsim" }
+        }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    // No per-section camera_name → falls back to cosys_airsim.camera_name
+    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
+              "mission_cam");
+    EXPECT_EQ(
+        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
+        "Drone0");
+}
+
+TEST(CosysCameraConfigTest, DefaultUsedWhenNeitherSet) {
+    // Completely empty config — no cosys_airsim section, no per-section overrides.
+    const auto    path = write_temp_config(R"({})");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
+              "front_center");
+    EXPECT_EQ(
+        drone::hal::CosysCameraBackend::resolve_vehicle_name(cfg, "video_capture.mission_cam"),
+        "Drone0");
+}
+
+TEST(CosysCameraConfigTest, EmptySectionFallsThroughToTopLevel) {
+    // If a caller passes an empty section (e.g. legacy call sites), the
+    // per-section lookup must be skipped cleanly — top-level wins.
+    const auto    path = write_temp_config(R"({
+        "cosys_airsim": { "camera_name": "mission_cam" }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, ""), "mission_cam");
+}
+
+TEST(CosysCameraConfigTest, EmptyPerSectionValueTreatedAsAbsent) {
+    // An explicit empty string at the per-section key must not shadow the
+    // top-level value — otherwise a JSON typo could silently disable the
+    // top-level default.
+    const auto    path = write_temp_config(R"({
+        "cosys_airsim": { "camera_name": "mission_cam" },
+        "video_capture": {
+            "mission_cam": { "camera_name": "" }
+        }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+
+    EXPECT_EQ(drone::hal::CosysCameraBackend::resolve_camera_name(cfg, "video_capture.mission_cam"),
+              "mission_cam");
+}
+
+#endif  // HAVE_COSYS_AIRSIM

--- a/tools/cosys_smoke_test.cpp
+++ b/tools/cosys_smoke_test.cpp
@@ -6,8 +6,14 @@
 //   1. Start UE5 with Blocks, press Play (server listens on 41451)
 //   2. Compile via tools/build_cosys_smoke_test.sh
 //   3. Run the binary
+//
+// Camera/vehicle names come from `config/default.json` (via the shared
+// cosys_name_resolver), so the smoke test stays in lock-step with the runtime
+// stack instead of hard-coding "front_center" (Issue #499).
 #define HAVE_COSYS_AIRSIM 1
+#include "hal/cosys_name_resolver.h"
 #include "hal/cosys_rpc_client.h"
+#include "util/config.h"
 
 #include <common/common_utils/StrictMode.hpp>
 STRICT_MODE_OFF
@@ -17,12 +23,30 @@ STRICT_MODE_ON
 #include <chrono>
 #include <cmath>
 #include <iostream>
+#include <string>
 #include <thread>
 
 int main() {
     using namespace msr::airlib;
 
     std::cout << "=== Cosys-AirSim Smoke Test ===" << std::endl;
+
+    // Load config so the smoke test targets the same AirSim camera/vehicle
+    // names as the runtime stack. If the config is missing or unloadable,
+    // fall through to resolver defaults ("front_center" / "Drone0").
+    drone::Config cfg;
+    const char*   cfg_path = "config/default.json";
+    if (!cfg.load(cfg_path)) {
+        std::cout << "[warn] Could not load " << cfg_path
+                  << " — using resolver defaults (front_center / Drone0)" << std::endl;
+    }
+    // Pass empty section: smoke test has no per-section context, so the
+    // resolver falls through to the top-level `cosys_airsim.*` keys.
+    const std::string camera_name  = drone::hal::resolve_camera_name(cfg, "");
+    const std::string vehicle_name = drone::hal::resolve_vehicle_name(cfg, "");
+    std::cout << "[config] Targeting camera='" << camera_name << "' vehicle='" << vehicle_name
+              << "'" << std::endl;
+
     drone::hal::CosysRpcClient client("127.0.0.1", 41451);
 
     if (!client.connect()) {
@@ -62,13 +86,14 @@ int main() {
     // ── Test 2: Camera (RGB Scene) ──────────────────────────
     // NOTE: Pass vehicle_name — wrong/missing name has caused UE5 crashes in the past
     // (ASimModeBase::getCamera segfault when camera not found).
-    std::cout << "\n[2/3] Camera RGB (simGetImages Scene, front_center, Drone0)" << std::endl;
+    std::cout << "\n[2/3] Camera RGB (simGetImages Scene, " << camera_name << ", " << vehicle_name
+              << ")" << std::endl;
     client.with_client([&](auto& rpc) {
         try {
             std::vector<ImageCaptureBase::ImageRequest> requests = {
-                ImageCaptureBase::ImageRequest("front_center", ImageCaptureBase::ImageType::Scene,
+                ImageCaptureBase::ImageRequest(camera_name, ImageCaptureBase::ImageType::Scene,
                                                /*pixels_as_float*/ false, /*compress*/ false)};
-            auto responses = rpc.simGetImages(requests, "");
+            auto responses = rpc.simGetImages(requests, vehicle_name);
             if (responses.empty()) {
                 std::cerr << "  [FAIL] empty response" << std::endl;
                 ++failed;
@@ -92,13 +117,14 @@ int main() {
     });
 
     // ── Test 3: Depth ───────────────────────────────────────
-    std::cout << "\n[3/3] Depth (simGetImages DepthPerspective, front_center, Drone0)" << std::endl;
+    std::cout << "\n[3/3] Depth (simGetImages DepthPerspective, " << camera_name << ", "
+              << vehicle_name << ")" << std::endl;
     client.with_client([&](auto& rpc) {
         try {
-            std::vector<ImageCaptureBase::ImageRequest> requests  = {ImageCaptureBase::ImageRequest(
-                "front_center", ImageCaptureBase::ImageType::DepthPerspective,
+            std::vector<ImageCaptureBase::ImageRequest> requests = {ImageCaptureBase::ImageRequest(
+                camera_name, ImageCaptureBase::ImageType::DepthPerspective,
                 /*pixels_as_float*/ true, /*compress*/ false)};
-            auto                                        responses = rpc.simGetImages(requests, "");
+            auto responses = rpc.simGetImages(requests, vehicle_name);
             if (responses.empty()) {
                 std::cerr << "  [FAIL] empty response" << std::endl;
                 ++failed;


### PR DESCRIPTION
## Summary

Addresses **Bug #1** of #499. Bug #2 (collide-and-stick) is a follow-up PR.

YOLO received 256×144 thumbnails instead of the configured 1280×720 across every Cosys-AirSim Tier 3 run, producing 0 detections in 39 inference frames.

**Root cause:** `config/cosys_airsim_dev.json` declared `camera_name: "front_center"`, but the server-side `~/Documents/AirSim/settings.json` only declared `mission_cam` and `DepthCam`. When AirSim receives a request for a camera name not in `settings.json`, it silently auto-creates the camera with the upstream defaults — `width=256, height=144` ([AirSimSettings.hpp:174](third_party/cosys-airsim/AirLib/include/common/AirSimSettings.hpp#L174)). The backend's `open()` log showed "1280x720@30Hz" because it logged the *requested* dims, never what AirSim actually returned.

## Changes

- **`config/cosys_airsim_dev.json`** — `cosys_airsim.camera_name`: `"front_center"` → `"mission_cam"` to match `settings.json`.
- **`common/hal/include/hal/cosys_camera.h`** — wire the `(void)section` constructor parameter to a precedence ladder: `<section>.camera_name` → `cosys_airsim.camera_name` → `"front_center"`. Same ladder for `vehicle_name`. Scenario 30 already had a per-camera override in the right scope; this makes it actually take effect and unblocks multi-camera Tier 3 setups.
- **First-frame dimension check** — on the first successful RPC response, log actual `(width, height)` and emit `WARN` if they don't match the requested dims. Would have caught this bug in seconds instead of silently running broken.
- **`tests/test_cosys_camera_config.cpp`** (new, 5 tests, gated on `HAVE_COSYS_AIRSIM`) — covers the precedence ladder including the edge cases: empty-string override, empty section, neither set.
- **Docs** — PROGRESS.md (#72), BUG_FIXES.md (#499a), TESTS.md totals.

## Test plan

- [x] `bash deploy/build.sh` — zero warnings.
- [x] `./tests/run_tests.sh` — 1590/1590 pass (+SDK), 100%.
- [x] `clang-format-18 --dry-run --Werror` — clean.
- [ ] Manual: user re-runs scenario 30 on the desktop; confirms YOLO log shows `frame 1280x720` and detections > 0 against the spawned chair/couch/bush.

## Out of scope

- **Bug #2 — collide-and-stick at WP3** — separate follow-up. Radar + occupancy grid worked in the failing run (539 occupied cells, 339 D\*Lite replans); the collision is a planner/avoider issue, not perception.
- Writing `settings.json` from scenario config.
- Runtime `CaptureSettings` propagation (AirSim doesn't reliably support this at runtime; `settings.json` remains canonical).

Closes #499 (Bug #1 half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)