### PR TITLE
feat(#594): Cosys GT emitter — per-frame ground truth for baseline capture

### DIFF
--- a/config/scenarios/29_cosys_perception.json
+++ b/config/scenarios/29_cosys_perception.json
@@ -1,5 +1,14 @@
 {
     "_comment": "Scenario 29: Cosys-AirSim Perception — Tier 3 photorealistic simulation with YOLO + Depth Anything V2 + native radar emulation.",
+    "gt_class_map": {
+        "_comment": "Ground-truth class map for #573 baseline capture. Mirrors scenario 30 for now — #29 currently runs against the default Blocks world without a populated scene; expand when this scenario grows its own scene file. See docs/guides/CONFIG_GUIDE.md → 'gt_class_map' and issue #594.",
+        "person_*":  { "class_id": 0,   "class_name": "person" },
+        "chair_*":   { "class_id": 56,  "class_name": "chair" },
+        "couch_*":   { "class_id": 57,  "class_name": "couch" },
+        "bush_*":    { "class_id": 58,  "class_name": "potted plant" },
+        "pillar_*":  { "class_id": 100, "class_name": "obstacle" },
+        "wall_*":    { "class_id": 100, "class_name": "obstacle" }
+    },
     "scenario": {
         "name": "cosys_perception",
         "description": "Full perception stack on Tier 3 photorealistic simulator. Flies a 5-waypoint mission with YOLO object detection (YOLOv8s dev / YOLOv8m cloud), Depth Anything V2 depth estimation, LiDAR-emulated radar fusion, and UKF tracking. Validates end-to-end ML perception pipeline with Cosys-AirSim camera, radar, IMU, and depth backends. No HD-map static obstacles — perception-driven avoidance only.",

--- a/config/scenarios/30_cosys_static.json
+++ b/config/scenarios/30_cosys_static.json
@@ -2,6 +2,15 @@
     "_comment": "Scenario 30: Cosys-AirSim static proving ground — Tier 3 flight through populated Blocks env with stationary obstacles only (pillars, walls, chairs, couches, bushes, mannequins). Exercises depth → occupancy grid → D*Lite → potential-field avoider. Dynamic-obstacle counterpart is scenario 31.",
     "_epic": "#480 Phase A",
     "_issue": "#479",
+    "gt_class_map": {
+        "_comment": "Ground-truth class map for #573 baseline capture. Keys match spawned-object names in config/scenes/cosys_static.json — trailing `*` is a prefix wildcard. class_id values use COCO indices where a COCO class exists; non-COCO obstacles (pillars, walls) use custom id 100. See docs/guides/CONFIG_GUIDE.md → 'gt_class_map' and issue #594.",
+        "person_*":  { "class_id": 0,   "class_name": "person" },
+        "chair_*":   { "class_id": 56,  "class_name": "chair" },
+        "couch_*":   { "class_id": 57,  "class_name": "couch" },
+        "bush_*":    { "class_id": 58,  "class_name": "potted plant" },
+        "pillar_*":  { "class_id": 100, "class_name": "obstacle" },
+        "wall_*":    { "class_id": 100, "class_name": "obstacle" }
+    },
     "scenario": {
         "name": "cosys_static",
         "description": "Flight through a populated Blocks environment with 9 static obstacles spawned via RPC. Validates every perception stage (radar, YOLO, depth) actually produces non-zero output, occupancy grid fills with known obstacles, and the avoider at least touches the plan.",

--- a/docs/architecture/SIMULATION_ARCHITECTURE.md
+++ b/docs/architecture/SIMULATION_ARCHITECTURE.md
@@ -1,5 +1,15 @@
 # Simulation Architecture
 
+> **Scope:** this document covers the **Gazebo SITL** (Tier 2) simulation architecture in depth, plus the Tier 1 pure-simulated path. It does NOT cover the **Cosys-AirSim** (Tier 3) photorealistic simulation — Cosys is a separate runtime with its own RPC API, vehicle model, and scenario set. For Cosys:
+>
+> - **Why we added Cosys:** see [ADR-011 — Cosys-AirSim photorealistic simulation](../adr/ADR-011-cosys-airsim-photorealistic-simulation.md).
+> - **How to set up Cosys locally:** see [COSYS_SETUP.md](../guides/COSYS_SETUP.md).
+> - **Cosys HAL backends:** `CosysCameraBackend`, `CosysIMUBackend`, `CosysRadarBackend` (LiDAR-as-radar proxy), `CosysDepthBackend`, `CosysFCLinkBackend` — implemented in `common/hal/src/cosys_*.cpp`, all gated behind `HAVE_COSYS_AIRSIM`.
+> - **Cosys scenarios:** `#29 cosys_perception` (mixed dynamic) and `#30 cosys_static` (static proving ground). See `config/scenarios/29_*.json` / `30_*.json` and `tests/run_scenario_cosys.sh`.
+> - **Benchmark-harness ground-truth emitter for Cosys:** segmentation-mask-based per-frame GT via `simGetSegmentationImage` + `simListSceneObjects`. Design and rationale in [`docs/design/perception_v2_detailed_design.md` § 13 "Ground-truth emitter"](../design/perception_v2_detailed_design.md) (gitignored draft during the active rewrite; will be committed once the design stabilises).
+>
+> A dedicated `COSYS_SIMULATION_ARCHITECTURE.md` is a known gap — tracked in [docs/tracking/IMPROVEMENTS.md](../tracking/IMPROVEMENTS.md).
+
 ## Table of Contents
 
 1. [Overview](#overview)

--- a/docs/guides/CONFIG_GUIDE.md
+++ b/docs/guides/CONFIG_GUIDE.md
@@ -437,6 +437,30 @@ Scenario configs in `config/scenarios/` follow this structure:
 - **`pass_criteria`** — automated verification checks (log patterns, process liveness)
 - **`tier`** — 1 = simulated (no Gazebo), 2 = Gazebo SITL required
 
+### `gt_class_map` (optional, benchmark-harness only)
+
+Scenarios that will be used for baseline capture (Epic #523 → issue #573) must declare a `gt_class_map` that translates the simulator's object names into the COCO-style class IDs the perception metrics framework consumes. The mapping is per-scenario rather than global so each scenario file is self-contained and auditable. Supports glob-style wildcards on the simulator-name side.
+
+```jsonc
+{
+    "scenario": { ... },
+    "gt_class_map": {
+        "SK_Mannequin*":    { "class_id": 0,  "class_name": "person" },
+        "SM_Car*":          { "class_id": 2,  "class_name": "car" },
+        "SM_TrafficCone*":  { "class_id": 10, "class_name": "obstacle" },
+        "SM_Chair*":        { "class_id": 56, "class_name": "chair" }
+    },
+    "config_overrides": { ... }
+}
+```
+
+- **Key** — object-name pattern matched against the simulator's object list. `*` is a trailing wildcard (e.g. `SK_Mannequin*` matches `SK_Mannequin_01`, `SK_Mannequin_02`, …).
+- **`class_id`** — integer class index; should match the COCO taxonomy if comparing against a COCO-trained detector.
+- **`class_name`** — human-readable name for the JSONL ground-truth output.
+- Objects whose simulator name matches no entry are dropped from GT (treated as "not a class the detector is expected to find").
+
+`gt_class_map` is consumed by the ground-truth emitter (issue #594). If absent, the scenario runs normally but produces no ground truth — baseline capture silently skips detection metrics for that scenario.
+
 ### Available Scenarios
 
 | # | Name | Tier | What it tests |

--- a/docs/tracking/IMPROVEMENTS.md
+++ b/docs/tracking/IMPROVEMENTS.md
@@ -18,6 +18,15 @@ Running list of improvements noticed in passing while doing other work. Not urge
 
 ### 2026-04-20
 
+#### 10. `COSYS_SIMULATION_ARCHITECTURE.md` — parallel to the existing Gazebo doc
+
+- **Priority:** P3
+- **Category:** docs (architecture reference)
+- **Noticed while:** filing issue #594 (GT emitter) — the existing `docs/architecture/SIMULATION_ARCHITECTURE.md` is Gazebo-only despite Cosys now being comparable in complexity (HAL backends, segmentation, `simSpawnObject` scene population, scenarios #29/#30, GT emitter).
+- **Current state:** Cosys architecture is scattered across ADR-011 (the "why"), `docs/guides/COSYS_SETUP.md` (the "how-to-install"), and inline comments in `common/hal/src/cosys_*.cpp`. No single reference doc for the runtime architecture.
+- **Proposed fix:** create `docs/architecture/COSYS_SIMULATION_ARCHITECTURE.md` mirroring the Gazebo doc's structure — HAL-mapping, RPC-surface inventory, scenario population via `simSpawnObject`, segmentation pipeline, GT-emitter integration, known limitations. Cross-link from the Gazebo doc and from COSYS_SETUP.md.
+- **When worth doing:** after the #594 (GT emitter) + #573 (baseline capture) work stabilises the Cosys-side patterns — then we document what actually shipped rather than chasing a moving target.
+
 #### 5. Stage-name constants (eliminate magic-string drift across P2/P4/tests)
 
 - **Priority:** P3

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3141,4 +3141,56 @@ The `LatencyProfiler` holds a `std::mutex`, which conflicts with the observabili
 
 ---
 
-_Last updated after Improvement #76 (profiler wiring, #571 follow-up). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._
+### Improvement #77 — Ground-truth Emitter (Issue #594, Epic #523 CP0 part 3)
+
+**Date:** 2026-04-20
+**Category:** Testing / Benchmark harness
+**Issues:** [#594](https://github.com/nmohamaya/companion_software_stack/issues/594) · parent [#523](https://github.com/nmohamaya/companion_software_stack/issues/523) · meta-epic [#514](https://github.com/nmohamaya/companion_software_stack/issues/514)
+
+**What:** Per-frame ground-truth emitter — the second prerequisite for #573 baseline capture. Queries the simulator for visible objects and produces JSONL records consumable by the #570 metrics framework.
+
+Shape:
+
+- `IGroundTruthEmitter` interface + `GtDetection` / `FrameGroundTruth` / `GtCameraPose` types in `tests/benchmark/gt_emitter.h`.
+- `GtClassMap` — loads per-scenario `gt_class_map` config, supports exact-match + trailing-`*` wildcard patterns, translates simulator object names to `{class_id, class_name}`.
+- `to_json_line()` — single-line JSONL serialiser, round-trips cleanly through `nlohmann::json::parse`.
+- **Cosys-AirSim backend** (PR 1, this commit) using AirSim's built-in detection API (`simAddDetectionFilterMeshName` + `simGetDetections`) — bbox + relative pose + object name come from the simulator pre-computed. Stable `gt_track_id` derived from object name via `std::hash`. Occlusion placeholder (0.0) since the detection API filters to visible-only; proper occlusion score tracked in IMPROVEMENTS.md as a follow-up.
+- **Gazebo backend** (PR 2, follow-up) — covers scenarios #02/#18/#21.
+
+Design decisions captured in `docs/design/perception_v2_detailed_design.md` §13 (ground-truth emitter section):
+
+1. **Approach B (per-frame dynamic)** over static-config GT — honest for dynamic scenes.
+2. **Stable `gt_track_id` across FoV exits** — the simulator has omniscient identity, so no dormant-track guessing needed. Out-of-FoV → emit nothing; re-enter → same track_id.
+3. **Per-scenario `gt_class_map`** — each scenario's config file is self-contained.
+4. **Occlusion as first-class field** with a placeholder value for now.
+
+**Files added:**
+- `tests/benchmark/gt_emitter.h` — interface + types (~160 lines)
+- `tests/benchmark/gt_emitter.cpp` — shared impl (GtClassMap::load, lookup, to_json_line) (~110 lines)
+- `tests/benchmark/cosys_gt_emitter.cpp` — Cosys backend (~220 lines, HAVE_COSYS_AIRSIM-gated)
+- `tests/test_gt_emitter.cpp` — 11 unit tests (shared layer only; Cosys needs live AirSim)
+
+**Files modified:**
+- `config/scenarios/29_cosys_perception.json` + `30_cosys_static.json` — add `gt_class_map`
+- `docs/design/perception_v2_detailed_design.md` — §13 ground-truth emitter section (gitignored draft)
+- `docs/architecture/SIMULATION_ARCHITECTURE.md` — scope note clarifying Gazebo focus + pointers to Cosys docs
+- `docs/guides/CONFIG_GUIDE.md` — `gt_class_map` scenario-config key documentation
+- `docs/tracking/IMPROVEMENTS.md` — entry #10 for a future `COSYS_SIMULATION_ARCHITECTURE.md`
+- `tests/CMakeLists.txt` — new `test_gt_emitter` target
+- `tests/TESTS.md` — suite entry + total count
+
+**Why:** Baseline capture (#573) needs per-frame GT bboxes to compute TP/FP/FN, MOTA, ID-switch, fragmentation against the pre-rewrite pipeline's output. Without this emitter those numbers can't be produced honestly on scenes with dynamic objects (3 of 5 target scenarios). The Cosys-first split lets us start baseline capture on #29/#30 while the Gazebo backend (PR 2) comes online for #02/#18/#21.
+
+**Test count:** +11 in `test_gt_emitter`. 1650 → 1661 (+SDK).
+
+**Universal acceptance criteria:** design doc updated; no license obligations change.
+
+**Follow-ups tracked in IMPROVEMENTS.md:**
+
+- Gazebo GT emitter (PR 2 under the same issue #594).
+- Proper occlusion score via segmentation-mask pixel accounting.
+- `COSYS_SIMULATION_ARCHITECTURE.md` parallel to the Gazebo doc.
+
+---
+
+_Last updated after Improvement #77 (GT emitter PR 1, #594). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,23 @@ add_drone_test(test_latency_profiler test_latency_profiler.cpp)
 # Guards the wiring contract without needing a full scenario run.
 add_drone_test(test_latency_profiler_dump test_latency_profiler_dump.cpp)
 
+# ── GT emitter tests (Issue #594 — Epic #523, PR 1 Cosys backend) ─
+# Shared-layer tests only (GtClassMap + to_json_line). The Cosys backend
+# itself needs a live AirSim server and is covered by scenario tests #29/#30.
+# When built with HAVE_COSYS_AIRSIM, the Cosys .cpp is linked in and the
+# factory resolves at link time; otherwise the backend .cpp is empty.
+add_drone_test(test_gt_emitter
+    test_gt_emitter.cpp
+    benchmark/gt_emitter.cpp
+    benchmark/cosys_gt_emitter.cpp
+)
+target_include_directories(test_gt_emitter PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_compile_definitions(test_gt_emitter PRIVATE
+    PROJECT_CONFIG_DIR="${PROJECT_SOURCE_DIR}/config"
+)
+
 # ── Thread Heartbeat & Watchdog tests ────────────────────────
 add_drone_test(test_thread_heartbeat test_thread_heartbeat.cpp)
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -133,7 +133,8 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — Perception Metrics](#test_perception_metricscpp--25-tests) | 1 | 25 | TP/FP/FN, per-class AP (PASCAL VOC 11-point), MOTA/MOTP, ID switches, fragmentations, confusion matrix, IoU math, N=1000×1000 perf budget |
 | [Benchmark — Latency Profiler](#test_latency_profilercpp--15-tests) | 1 | 15 | Per-stage percentile aggregation, correlation-ID-tagged trace ring, ScopedLatency RAII timer, thread-safe concurrent writes, JSON snapshot, overhead budget |
 | [Benchmark — Profiler Dump Smoke](#test_latency_profiler_dumpcpp--3-tests) | 1 | 3 | Simulated P2/P4 wiring pattern — concurrent workers record via ScopedLatency, dump to JSON on disk, parse back, verify no lost records |
-| **Total** | **74 C++ + 5 shell** | **1609 (no SDK) / 1650 (+SDK) + 42 + 250+** | |
+| [Benchmark — GT Emitter](#test_gt_emittercpp--11-tests) | 1 | 11 | GtClassMap pattern match (exact / wildcard / first-wins); load-from-scenario-config (well-formed, missing, malformed); JSONL serialisation round-trip with quote-and-backslash escaping |
+| **Total** | **75 C++ + 5 shell** | **1624 (no SDK) / 1665 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -1065,6 +1066,21 @@ expensive modulo operations.
 **Why these tests matter:** DR-022 permits mutex-protected `ScopedLatency` on flight-critical threads under three conditions (priority isolation, bounded hold-time, config gating). This test guards condition 3 (the `std::optional` null path actually produces zero I/O) and the lossless-record invariant (no race dropping records). Without this, a refactor that breaks the "profiler → file" pipeline would only surface during a full scenario run.
 
 **Key files under test:** `util/latency_profiler.h`, plus the main.cpp wiring patterns in `process2_perception/` and `process4_mission_planner/`.
+
+---
+
+### test_gt_emitter.cpp — 11 tests
+
+**What it tests:** `drone::benchmark::GtClassMap` (scenario-config-driven class mapping) + `to_json_line` (JSONL serialisation) — the shared layer of the ground-truth emitter (#594 / Epic #523). The Cosys backend itself needs a live AirSim server and is covered by scenario integration tests (#29, #30).
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `GtClassMap` | 8 | Empty map → every lookup is nullopt; exact-match patterns (no wildcard) hit only the literal name; trailing `*` wildcard matches any prefix; first-registered pattern wins on overlap; `load(drone::Config)` reads the `gt_class_map` section correctly; missing key → empty map (no crash); malformed entries (non-object, missing `class_id`/`class_name`) are silently dropped; `patterns()` returns the registered pattern strings in order |
+| `GtEmitterJson` | 3 | `to_json_line` produces single-line JSON (no embedded newlines), parses cleanly via `nlohmann::json`, round-trips every field (timestamp, frame_sequence, camera pose, per-object class/bbox/gt_track_id/occlusion/distance_m); empty objects array serialises cleanly; class_name containing `"` and `\` characters round-trips through parse without corruption |
+
+**Why these tests matter:** The GT emitter is consumed by every baseline-capture run (#573) and every subsequent perception-v2 PR's scoring. A silent drop on a malformed config entry, an off-by-one on wildcard matching, or a JSON-escape bug in `to_json_line` would silently corrupt the TP/FP/FN numbers the whole rewrite is measured against.
+
+**Key files under test:** `tests/benchmark/gt_emitter.h`, `tests/benchmark/gt_emitter.cpp`. The Cosys backend (`tests/benchmark/cosys_gt_emitter.cpp`) compiles into the test target for link-coverage but is not directly exercised (needs a live AirSim server).
 
 ---
 

--- a/tests/benchmark/cosys_gt_emitter.cpp
+++ b/tests/benchmark/cosys_gt_emitter.cpp
@@ -1,0 +1,228 @@
+// tests/benchmark/cosys_gt_emitter.cpp
+//
+// Cosys-AirSim backend for IGroundTruthEmitter (Issue #594 PR 1).
+// Gated by HAVE_COSYS_AIRSIM — compiles to an empty TU without the SDK.
+//
+// Uses AirSim's built-in detection API:
+//   simAddDetectionFilterMeshName(camera, image_type, pattern)  — register a
+//                                                                 class filter
+//   simSetDetectionFilterRadius(camera, image_type, radius_cm)  — visibility
+//   simGetDetections(camera, image_type)                         — per-frame pull
+//
+// AirSim returns `vector<DetectionInfo>` with name + 2D bbox + 3D bbox +
+// relative_pose already computed — we only need class-map translation and
+// stable identity assignment.
+
+#ifdef HAVE_COSYS_AIRSIM
+
+#include "benchmark/gt_emitter.h"
+#include "hal/cosys_rpc_client.h"
+#include "util/config.h"
+#include "util/config_keys.h"
+#include "util/ilogger.h"
+
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace drone::benchmark {
+
+namespace {
+
+// Cosys camera we attach detection filters to. Matches the key used by
+// CosysCameraBackend (config/cosys_airsim.json → camera_name).
+constexpr const char*                              kDefaultCameraName       = "mission_cam";
+constexpr const char*                              kDefaultVehicleName      = "Drone0";
+constexpr float                                    kDefaultDetectionRadiusM = 100.0F;  // metres
+constexpr msr::airlib::ImageCaptureBase::ImageType kImageType =
+    msr::airlib::ImageCaptureBase::ImageType::Scene;
+
+// Hash a simulator object name into a stable uint32 track id. Same input →
+// same output across processes / runs; different names → different ids with
+// overwhelming probability. The GT consumer only needs stability across
+// frames of a single run, which this easily provides.
+[[nodiscard]] uint32_t stable_track_id_from_name(std::string_view name) {
+    const std::uint64_t h = std::hash<std::string_view>{}(name);
+    // Fold 64 → 32 bits; lower 32 are fine because we don't need the id to
+    // round-trip back to the name.
+    return static_cast<std::uint32_t>(h) ^ static_cast<std::uint32_t>(h >> 32U);
+}
+
+class CosysGtEmitter : public IGroundTruthEmitter {
+public:
+    CosysGtEmitter(std::shared_ptr<drone::hal::CosysRpcClient> rpc, std::string camera_name,
+                   std::string vehicle_name, float detection_radius_m, GtClassMap class_map)
+        : rpc_(std::move(rpc))
+        , camera_name_(std::move(camera_name))
+        , vehicle_name_(std::move(vehicle_name))
+        , detection_radius_m_(detection_radius_m)
+        , class_map_(std::move(class_map)) {}
+
+    /// Register AirSim detection filters for every pattern in the class map.
+    /// Must be called after the RPC client connects. Returns true if the RPC
+    /// was reachable (individual filter-add failures are logged at WARN but
+    /// do not fail the whole operation — a partial filter set is still useful).
+    [[nodiscard]] bool register_filters(const std::vector<std::string>& patterns) {
+        if (!rpc_ || !rpc_->is_connected() || class_map_.empty()) {
+            return false;
+        }
+        return rpc_->with_client([&](auto& rpc) {
+            // Clear any pre-existing filter so repeated runs don't accumulate.
+            try {
+                rpc.simClearDetectionMeshNames(camera_name_, kImageType, vehicle_name_);
+            } catch (const std::exception& e) {
+                DRONE_LOG_WARN("[GT-Cosys] simClearDetectionMeshNames failed: {}", e.what());
+            }
+            try {
+                // AirSim takes radius in centimetres.
+                rpc.simSetDetectionFilterRadius(camera_name_, kImageType,
+                                                detection_radius_m_ * 100.0F, vehicle_name_);
+            } catch (const std::exception& e) {
+                DRONE_LOG_WARN("[GT-Cosys] simSetDetectionFilterRadius failed: {}", e.what());
+            }
+            for (const auto& pattern : patterns) {
+                try {
+                    // AirSim accepts trailing-* wildcards in mesh_name (same
+                    // syntax GtClassMap uses), so we register patterns verbatim.
+                    rpc.simAddDetectionFilterMeshName(camera_name_, kImageType, pattern,
+                                                      vehicle_name_);
+                } catch (const std::exception& e) {
+                    DRONE_LOG_WARN("[GT-Cosys] simAddDetectionFilterMeshName({}) failed: {}",
+                                   pattern, e.what());
+                }
+            }
+        });
+    }
+
+    std::optional<FrameGroundTruth> emit(uint64_t timestamp_ns, uint64_t frame_sequence) override {
+        if (!rpc_ || !rpc_->is_connected() || class_map_.empty()) {
+            return std::nullopt;
+        }
+
+        std::vector<msr::airlib::DetectionInfo> detections;
+        msr::airlib::Pose                       vehicle_pose{};
+        const bool                              ok = rpc_->with_client([&](auto& rpc) {
+            try {
+                detections = rpc.simGetDetections(camera_name_, kImageType, vehicle_name_);
+                vehicle_pose = rpc.simGetVehiclePose(vehicle_name_);
+            } catch (const std::exception& e) {
+                DRONE_LOG_WARN("[GT-Cosys] RPC error during emit: {}", e.what());
+                detections.clear();
+            }
+        });
+        if (!ok) {
+            return std::nullopt;
+        }
+
+        FrameGroundTruth frame;
+        frame.timestamp_ns   = timestamp_ns;
+        frame.frame_sequence = frame_sequence;
+        frame.camera_pose    = to_camera_pose(vehicle_pose);
+        frame.objects.reserve(detections.size());
+
+        for (const auto& d : detections) {
+            const auto cls = class_map_.lookup(d.name);
+            if (!cls) {
+                continue;  // Not in our tracked class set — drop.
+            }
+
+            GtDetection g;
+            g.class_id    = cls->class_id;
+            g.class_name  = cls->class_name;
+            g.gt_track_id = stable_track_id_from_name(d.name);
+            g.bbox        = to_bbox(d.box2D);
+            // AirSim's detection API filters to visible objects already, so
+            // everything we see is at least partly visible. A proper occlusion
+            // ratio requires segmentation-mask accounting — tracked as a
+            // follow-up (see IMPROVEMENTS.md entry for GT occlusion score).
+            g.occlusion  = 0.0F;
+            g.distance_m = distance_to_object(d.relative_pose);
+
+            frame.objects.push_back(std::move(g));
+        }
+        return frame;
+    }
+
+    [[nodiscard]] std::string_view backend_name() const noexcept override { return "cosys"; }
+
+private:
+    static GtCameraPose to_camera_pose(const msr::airlib::Pose& p) {
+        GtCameraPose out;
+        out.translation[0] = p.position.x();
+        out.translation[1] = p.position.y();
+        out.translation[2] = p.position.z();
+        out.quaternion[0]  = p.orientation.w();
+        out.quaternion[1]  = p.orientation.x();
+        out.quaternion[2]  = p.orientation.y();
+        out.quaternion[3]  = p.orientation.z();
+        return out;
+    }
+
+    static BBox2D to_bbox(const msr::airlib::Box2D& b) {
+        BBox2D out;
+        out.x = b.min.x();
+        out.y = b.min.y();
+        out.w = b.max.x() - b.min.x();
+        out.h = b.max.y() - b.min.y();
+        return out;
+    }
+
+    static float distance_to_object(const msr::airlib::Pose& relative_pose) {
+        const float dx = relative_pose.position.x();
+        const float dy = relative_pose.position.y();
+        const float dz = relative_pose.position.z();
+        return std::sqrt(dx * dx + dy * dy + dz * dz);
+    }
+
+    std::shared_ptr<drone::hal::CosysRpcClient> rpc_;
+    std::string                                 camera_name_;
+    std::string                                 vehicle_name_;
+    float                                       detection_radius_m_;
+    GtClassMap                                  class_map_;
+};
+
+}  // namespace
+
+std::unique_ptr<IGroundTruthEmitter> create_cosys_gt_emitter(const drone::Config& full_cfg) {
+    auto class_map = GtClassMap::load(full_cfg);
+    if (class_map.empty()) {
+        DRONE_LOG_INFO("[GT-Cosys] No `gt_class_map` in scenario config — emitter disabled");
+        return nullptr;
+    }
+
+    const std::string host   = full_cfg.get<std::string>(drone::cfg_key::cosys_airsim::HOST,
+                                                         "127.0.0.1");
+    const int         port   = full_cfg.get<int>(drone::cfg_key::cosys_airsim::PORT, 41451);
+    const std::string camera = full_cfg.get<std::string>(drone::cfg_key::cosys_airsim::CAMERA_NAME,
+                                                         kDefaultCameraName);
+    const std::string vehicle =
+        full_cfg.get<std::string>(drone::cfg_key::cosys_airsim::VEHICLE_NAME, kDefaultVehicleName);
+    const float radius_m = full_cfg.get<float>("benchmark.gt_detection_radius_m",
+                                               kDefaultDetectionRadiusM);
+
+    auto rpc = std::make_shared<drone::hal::CosysRpcClient>(host, static_cast<uint16_t>(port));
+    if (!rpc->connect()) {
+        DRONE_LOG_WARN("[GT-Cosys] Could not connect to {}:{} — emitter disabled", host, port);
+        return nullptr;
+    }
+
+    const auto patterns = class_map.patterns();
+    auto       emitter = std::make_unique<CosysGtEmitter>(std::move(rpc), camera, vehicle, radius_m,
+                                                          std::move(class_map));
+    if (!emitter->register_filters(patterns)) {
+        DRONE_LOG_WARN(
+            "[GT-Cosys] Filter registration failed — emitter constructed but may emit nothing");
+    }
+    DRONE_LOG_INFO("[GT-Cosys] Emitter ready — camera={} vehicle={} radius={}m", camera, vehicle,
+                   radius_m);
+    return emitter;
+}
+
+}  // namespace drone::benchmark
+
+#endif  // HAVE_COSYS_AIRSIM

--- a/tests/benchmark/gt_emitter.cpp
+++ b/tests/benchmark/gt_emitter.cpp
@@ -1,0 +1,109 @@
+// tests/benchmark/gt_emitter.cpp
+//
+// Shared implementation for the GT emitter — class-map parsing and JSON
+// serialisation. Backend-specific emitters live in their own .cpp files
+// (gated behind HAVE_COSYS_AIRSIM / HAVE_GAZEBO).
+
+#include "benchmark/gt_emitter.h"
+
+#include "util/config.h"
+
+#include <sstream>
+
+#include <nlohmann/json.hpp>
+
+namespace drone::benchmark {
+
+// ────────────────────────────────────────────────────────────────────────────
+// GtClassMap
+// ────────────────────────────────────────────────────────────────────────────
+
+GtClassMap::GtClassMap(std::vector<PatternEntry> patterns) : patterns_(std::move(patterns)) {}
+
+GtClassMap GtClassMap::load(const drone::Config& scenario_cfg) {
+    // Scenario configs declare `gt_class_map` as a top-level key. If absent,
+    // the returned section is an empty object — we produce an empty map,
+    // which disables GT emission for the scenario (callers short-circuit).
+    const auto map_json = scenario_cfg.section("gt_class_map");
+    if (!map_json.is_object() || map_json.empty()) {
+        return GtClassMap{{}};
+    }
+
+    std::vector<PatternEntry> patterns;
+    patterns.reserve(map_json.size());
+    for (auto it = map_json.begin(); it != map_json.end(); ++it) {
+        if (!it.value().is_object()) continue;
+        const auto& v = it.value();
+        if (!v.contains("class_id") || !v.contains("class_name")) continue;
+        PatternEntry pe;
+        pe.pattern          = it.key();
+        pe.entry.class_id   = v.value("class_id", 0U);
+        pe.entry.class_name = v.value("class_name", std::string{});
+        patterns.push_back(std::move(pe));
+    }
+    return GtClassMap{std::move(patterns)};
+}
+
+std::vector<std::string> GtClassMap::patterns() const {
+    std::vector<std::string> out;
+    out.reserve(patterns_.size());
+    for (const auto& pe : patterns_) {
+        out.push_back(pe.pattern);
+    }
+    return out;
+}
+
+std::optional<GtClassMap::Entry> GtClassMap::lookup(std::string_view object_name) const {
+    for (const auto& pe : patterns_) {
+        // Trailing-`*` glob: pattern "SK_Mannequin*" matches any name that
+        // starts with "SK_Mannequin". A pattern with no `*` is an exact match.
+        const bool has_wildcard = !pe.pattern.empty() && pe.pattern.back() == '*';
+        if (has_wildcard) {
+            const std::string_view prefix{pe.pattern.data(), pe.pattern.size() - 1};
+            if (object_name.size() >= prefix.size() &&
+                object_name.compare(0, prefix.size(), prefix) == 0) {
+                return pe.entry;
+            }
+        } else if (object_name == pe.pattern) {
+            return pe.entry;
+        }
+    }
+    return std::nullopt;
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// JSONL serialisation
+// ────────────────────────────────────────────────────────────────────────────
+
+std::string to_json_line(const FrameGroundTruth& frame) {
+    // Build via nlohmann::json for correctness (handles string escaping) but
+    // serialise via dump(-1) for compact single-line output — matches the
+    // #570 perception_metrics JSON style and parses cheaply line-by-line.
+    nlohmann::json j;
+    j["timestamp_ns"]   = frame.timestamp_ns;
+    j["frame_sequence"] = frame.frame_sequence;
+
+    nlohmann::json pose;
+    pose["translation"] = {frame.camera_pose.translation[0], frame.camera_pose.translation[1],
+                           frame.camera_pose.translation[2]};
+    pose["quaternion"]  = {frame.camera_pose.quaternion[0], frame.camera_pose.quaternion[1],
+                           frame.camera_pose.quaternion[2], frame.camera_pose.quaternion[3]};
+    j["camera_pose"]    = std::move(pose);
+
+    nlohmann::json objects = nlohmann::json::array();
+    for (const auto& o : frame.objects) {
+        nlohmann::json obj;
+        obj["class_id"]    = o.class_id;
+        obj["class_name"]  = o.class_name;
+        obj["gt_track_id"] = o.gt_track_id;
+        obj["bbox"]        = {{"x", o.bbox.x}, {"y", o.bbox.y}, {"w", o.bbox.w}, {"h", o.bbox.h}};
+        obj["occlusion"]   = o.occlusion;
+        obj["distance_m"]  = o.distance_m;
+        objects.push_back(std::move(obj));
+    }
+    j["objects"] = std::move(objects);
+
+    return j.dump();  // compact, single line, no trailing newline
+}
+
+}  // namespace drone::benchmark

--- a/tests/benchmark/gt_emitter.h
+++ b/tests/benchmark/gt_emitter.h
@@ -1,0 +1,158 @@
+// tests/benchmark/gt_emitter.h
+//
+// Ground-truth emitter for the perception benchmark harness (Issue #594,
+// Epic #523). Consumed by baseline capture (#573) to produce TP/FP/FN and
+// MOTA/MOTP metrics against the pre-rewrite pipeline.
+//
+// Design summary (see docs/design/perception_v2_detailed_design.md § 13):
+//   - Per-frame dynamic emission from simulator APIs (not static config).
+//   - Stable `gt_track_id` across FoV exits — the simulator has omniscient
+//     object identity, so re-entering objects emit the same track_id.
+//   - Out-of-FoV / heavily occluded objects are NOT emitted that frame.
+//   - Pluggable backend: Cosys (PR 1, this header) or Gazebo (PR 2, follow-up).
+//
+// Scope: pure C++17, header-only type declarations + small free functions.
+// Backend implementations live in separate .cpp files gated behind
+// `HAVE_COSYS_AIRSIM` / `HAVE_GAZEBO`.
+
+#pragma once
+
+#include "benchmark/perception_metrics.h"  // BBox2D
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace drone {
+class Config;
+}
+
+namespace drone::benchmark {
+
+// ────────────────────────────────────────────────────────────────────────────
+// Data types — plug into perception_metrics::FrameData on the consumer side
+// ────────────────────────────────────────────────────────────────────────────
+
+/// 6-DoF camera pose captured alongside the frame. Stored in the GT record so
+/// downstream consumers can correlate without a separate pose log.
+struct GtCameraPose {
+    float translation[3]{0.0F, 0.0F, 0.0F};       // world-frame, metres
+    float quaternion[4]{1.0F, 0.0F, 0.0F, 0.0F};  // w, x, y, z
+};
+
+/// One ground-truth detection — what the simulator says was visible in the
+/// frame, before the detector/tracker saw it.
+struct GtDetection {
+    uint32_t    class_id{0};       // COCO-style index; matches the detector's output
+    std::string class_name{};      // human-readable, for the JSONL output
+    BBox2D      bbox{};            // image-space (reuses perception_metrics::BBox2D)
+    uint32_t    gt_track_id{0};    // stable simulator identity; same object → same id
+    float       occlusion{0.0F};   // 0 = fully visible, 1 = fully occluded
+    float       distance_m{0.0F};  // Euclidean distance from camera to object centre
+};
+
+/// One frame's ground truth. Writeable as one JSON object per line (JSONL) so
+/// a long run appends cheaply.
+struct FrameGroundTruth {
+    uint64_t                 timestamp_ns{0};
+    uint64_t                 frame_sequence{0};
+    GtCameraPose             camera_pose{};
+    std::vector<GtDetection> objects{};
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Class map — translates simulator object names → (class_id, class_name)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Loads a `gt_class_map` table from a scenario config and matches simulator
+/// object names against its patterns. Supports trailing-`*` glob only — the
+/// goal is human-auditable config, not a regex mini-language.
+///
+/// Example config entry (see docs/guides/CONFIG_GUIDE.md → "Scenario Config"):
+///
+///     "gt_class_map": {
+///         "SK_Mannequin*":  { "class_id": 0, "class_name": "person" },
+///         "SM_Car*":        { "class_id": 2, "class_name": "car" }
+///     }
+///
+/// `lookup("SK_Mannequin_01")` returns `{ class_id: 0, class_name: "person" }`.
+/// Objects whose name matches no pattern return `std::nullopt` — they're
+/// dropped from GT (treated as "not a class the detector is expected to find").
+class GtClassMap {
+public:
+    struct Entry {
+        uint32_t    class_id{0};
+        std::string class_name{};
+    };
+
+    /// Load from a scenario config's `gt_class_map` section. If the key is
+    /// absent, the map is empty (every lookup returns nullopt — effectively
+    /// disabling GT emission for that scenario).
+    [[nodiscard]] static GtClassMap load(const drone::Config& scenario_cfg);
+
+    /// Direct construction — used by tests and by factory helpers.
+    struct PatternEntry {
+        std::string pattern;  // trailing-`*` glob, or exact match if no `*`
+        Entry       entry;
+    };
+    explicit GtClassMap(std::vector<PatternEntry> patterns);
+
+    [[nodiscard]] bool        empty() const noexcept { return patterns_.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return patterns_.size(); }
+
+    /// Match `object_name` against registered patterns. First match wins.
+    /// Returns nullopt if no pattern matches.
+    [[nodiscard]] std::optional<Entry> lookup(std::string_view object_name) const;
+
+    /// Return just the pattern strings — used by backend emitters that pass
+    /// the patterns to the simulator's detection-filter API (e.g. Cosys
+    /// `simAddDetectionFilterMeshName`).
+    [[nodiscard]] std::vector<std::string> patterns() const;
+
+private:
+    std::vector<PatternEntry> patterns_;
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Emitter interface
+// ────────────────────────────────────────────────────────────────────────────
+
+class IGroundTruthEmitter {
+public:
+    virtual ~IGroundTruthEmitter() = default;
+
+    /// Produce one GT record for the frame at `timestamp_ns` / `frame_sequence`.
+    /// Returns nullopt if the simulator is unreachable or returned no data —
+    /// callers should treat this as "skip this frame" rather than an error.
+    [[nodiscard]] virtual std::optional<FrameGroundTruth> emit(uint64_t timestamp_ns,
+                                                               uint64_t frame_sequence) = 0;
+
+    /// Human-readable backend name — goes into log lines ("cosys", "gazebo").
+    [[nodiscard]] virtual std::string_view backend_name() const noexcept = 0;
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// JSONL serialisation — one frame per line, appendable
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Serialise a frame to a single JSON line (no trailing newline). Callers
+/// that stream to a file should append a `\n` themselves.
+[[nodiscard]] std::string to_json_line(const FrameGroundTruth& frame);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Backend factories — gated at compile time
+// ────────────────────────────────────────────────────────────────────────────
+
+#ifdef HAVE_COSYS_AIRSIM
+/// Build a Cosys-AirSim GT emitter. Reads host/port/camera/vehicle from the
+/// `cosys_airsim` section of `full_cfg` and `gt_class_map` from the scenario
+/// config (which is typically merged into `full_cfg` by the scenario loader).
+/// Returns nullptr if the config or the class map is empty (no GT to emit).
+[[nodiscard]] std::unique_ptr<IGroundTruthEmitter> create_cosys_gt_emitter(
+    const drone::Config& full_cfg);
+#endif
+
+}  // namespace drone::benchmark

--- a/tests/test_gt_emitter.cpp
+++ b/tests/test_gt_emitter.cpp
@@ -1,0 +1,182 @@
+// tests/test_gt_emitter.cpp
+//
+// Unit tests for the ground-truth emitter shared layer (Issue #594 PR 1).
+// Focus: GtClassMap pattern matching and JSONL serialisation. The Cosys
+// backend itself needs a live AirSim server and is covered by the scenario
+// integration tests (#29, #30).
+
+#include "benchmark/gt_emitter.h"
+#include "util/config.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace db = drone::benchmark;
+
+namespace {
+
+// Materialise a tiny JSON config with the given `gt_class_map` block, load it
+// via drone::Config, return the parsed map. Saves each test from having to
+// write its own temp-file boilerplate.
+db::GtClassMap load_map_from_json(const nlohmann::json& gt_class_map_block) {
+    nlohmann::json root = {{"gt_class_map", gt_class_map_block}};
+    const auto     path = std::filesystem::temp_directory_path() / "drone_test_gt_class_map.json";
+    {
+        std::ofstream out(path);
+        out << root.dump();
+    }
+    drone::Config               cfg;
+    [[maybe_unused]] const auto ok = cfg.load(path.string());
+    std::error_code             ec;
+    std::filesystem::remove(path, ec);
+    return db::GtClassMap::load(cfg);
+}
+
+}  // namespace
+
+// ────────────────────────────────────────────────────────────────────────────
+// GtClassMap — pattern matching
+// ────────────────────────────────────────────────────────────────────────────
+
+TEST(GtClassMap, EmptyMapLooksUpEverythingAsNullopt) {
+    db::GtClassMap map{{}};
+    EXPECT_TRUE(map.empty());
+    EXPECT_FALSE(map.lookup("anything").has_value());
+}
+
+TEST(GtClassMap, ExactMatchMatchesOnlyExactName) {
+    db::GtClassMap map({{"SM_Car_01", db::GtClassMap::Entry{2, "car"}}});
+    EXPECT_EQ(map.size(), 1U);
+    const auto hit = map.lookup("SM_Car_01");
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_EQ(hit->class_id, 2U);
+    EXPECT_EQ(hit->class_name, "car");
+    // Prefix of the exact pattern must NOT match (no wildcard).
+    EXPECT_FALSE(map.lookup("SM_Car_02").has_value());
+    EXPECT_FALSE(map.lookup("SM_Car").has_value());
+}
+
+TEST(GtClassMap, TrailingWildcardMatchesPrefixes) {
+    db::GtClassMap map({{"SK_Mannequin*", db::GtClassMap::Entry{0, "person"}}});
+    EXPECT_TRUE(map.lookup("SK_Mannequin").has_value());     // exactly the prefix
+    EXPECT_TRUE(map.lookup("SK_Mannequin_01").has_value());  // with suffix
+    EXPECT_TRUE(map.lookup("SK_MannequinFoo").has_value());  // no separator required
+    EXPECT_FALSE(map.lookup("Mannequin_01").has_value());    // prefix differs
+    EXPECT_FALSE(map.lookup("SK_Man").has_value());          // shorter than pattern prefix
+}
+
+TEST(GtClassMap, FirstMatchWins) {
+    db::GtClassMap map({
+        {"SM_*", db::GtClassMap::Entry{99, "generic"}},
+        {"SM_Car*", db::GtClassMap::Entry{2, "car"}},  // would also match "SM_Car_01"
+    });
+    const auto     hit = map.lookup("SM_Car_01");
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_EQ(hit->class_id, 99U) << "first-registered pattern should win";
+}
+
+TEST(GtClassMap, LoadFromConfigReadsGtClassMapSection) {
+    const auto map = load_map_from_json({
+        {"SK_Mannequin*", {{"class_id", 0}, {"class_name", "person"}}},
+        {"SM_Car*", {{"class_id", 2}, {"class_name", "car"}}},
+        {"SM_TrafficCone*", {{"class_id", 10}, {"class_name", "obstacle"}}},
+    });
+    EXPECT_EQ(map.size(), 3U);
+
+    const auto person = map.lookup("SK_Mannequin_01");
+    ASSERT_TRUE(person.has_value());
+    EXPECT_EQ(person->class_name, "person");
+
+    const auto car = map.lookup("SM_Car_42");
+    ASSERT_TRUE(car.has_value());
+    EXPECT_EQ(car->class_id, 2U);
+
+    EXPECT_FALSE(map.lookup("DroppedObject").has_value());
+}
+
+TEST(GtClassMap, LoadFromConfigReturnsEmptyWhenKeyAbsent) {
+    drone::Config cfg;
+    // No gt_class_map at all — load() should produce an empty map, not crash.
+    const auto map = db::GtClassMap::load(cfg);
+    EXPECT_TRUE(map.empty());
+}
+
+TEST(GtClassMap, LoadFromConfigSkipsMalformedEntries) {
+    const auto map = load_map_from_json({
+        {"Good*", {{"class_id", 7}, {"class_name", "thing"}}},
+        {"NoClass", nlohmann::json("not-an-object")},
+        {"MissingName", {{"class_id", 3}}},
+    });
+    EXPECT_EQ(map.size(), 1U);  // only "Good*" survives validation
+    EXPECT_TRUE(map.lookup("Good_01").has_value());
+}
+
+TEST(GtClassMap, PatternsAccessorReturnsRegisteredPatterns) {
+    db::GtClassMap map({
+        {"SK_Mannequin*", {0, "person"}},
+        {"SM_Car*", {2, "car"}},
+    });
+    const auto     patterns = map.patterns();
+    ASSERT_EQ(patterns.size(), 2U);
+    EXPECT_EQ(patterns[0], "SK_Mannequin*");
+    EXPECT_EQ(patterns[1], "SM_Car*");
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// JSONL serialisation
+// ────────────────────────────────────────────────────────────────────────────
+
+TEST(GtEmitterJson, SingleLineSerialisesAndParsesRoundTrip) {
+    db::FrameGroundTruth f;
+    f.timestamp_ns               = 1'700'000'000'000'000'000ULL;
+    f.frame_sequence             = 42;
+    f.camera_pose.translation[0] = 10.0F;
+    f.camera_pose.translation[1] = 20.0F;
+    f.camera_pose.translation[2] = 5.0F;
+    f.camera_pose.quaternion[0]  = 1.0F;
+    f.objects.push_back(
+        db::GtDetection{0, "person", db::BBox2D{100, 200, 50, 80}, 0xdeadbeefU, 0.1F, 12.5F});
+    f.objects.push_back(
+        db::GtDetection{2, "car", db::BBox2D{400, 300, 120, 60}, 0xabcd1234U, 0.0F, 8.2F});
+
+    const std::string line = db::to_json_line(f);
+
+    // Single-line JSON — no embedded newlines.
+    EXPECT_EQ(line.find('\n'), std::string::npos);
+
+    // Parses cleanly and preserves every field.
+    const auto j = nlohmann::json::parse(line);
+    EXPECT_EQ(j["timestamp_ns"].get<uint64_t>(), f.timestamp_ns);
+    EXPECT_EQ(j["frame_sequence"].get<uint64_t>(), 42U);
+    ASSERT_TRUE(j.contains("camera_pose"));
+    EXPECT_EQ(j["camera_pose"]["translation"][0].get<float>(), 10.0F);
+    ASSERT_EQ(j["objects"].size(), 2U);
+    EXPECT_EQ(j["objects"][0]["class_name"].get<std::string>(), "person");
+    EXPECT_EQ(j["objects"][0]["gt_track_id"].get<uint32_t>(), 0xdeadbeefU);
+    EXPECT_EQ(j["objects"][0]["bbox"]["x"].get<float>(), 100.0F);
+    EXPECT_FLOAT_EQ(j["objects"][0]["occlusion"].get<float>(), 0.1F);
+    EXPECT_FLOAT_EQ(j["objects"][1]["distance_m"].get<float>(), 8.2F);
+}
+
+TEST(GtEmitterJson, EmptyObjectsArraySerialisesCleanly) {
+    db::FrameGroundTruth f;
+    f.timestamp_ns = 1;
+    const auto j   = nlohmann::json::parse(db::to_json_line(f));
+    EXPECT_TRUE(j["objects"].is_array());
+    EXPECT_EQ(j["objects"].size(), 0U);
+}
+
+TEST(GtEmitterJson, EscapesQuotesAndBackslashesInClassName) {
+    // Defensive: class_name comes from scenario config. A tampered or
+    // typo'd config shouldn't produce malformed JSON.
+    db::FrameGroundTruth f;
+    f.objects.push_back(
+        db::GtDetection{0, "name with \"quotes\" and \\slash", db::BBox2D{0, 0, 1, 1}, 1, 0, 0});
+    const std::string line = db::to_json_line(f);
+    // Parser round-trips the escaped characters back to the original bytes.
+    const auto j = nlohmann::json::parse(line);
+    EXPECT_EQ(j["objects"][0]["class_name"].get<std::string>(), "name with \"quotes\" and \\slash");
+}


### PR DESCRIPTION
## Summary

- PR 1 of Issue #594 (GT emitter under Epic #523). Produces per-frame ground-truth bboxes for scenarios #29 + #30 via Cosys-AirSim's built-in detection API.
- Second prerequisite for #573 baseline capture (first was profiler wiring — PR #593 merged). After this lands + Gazebo GT lands (PR 2), #573 can compute real TP/FP/FN numbers.
- Pluggable interface (`IGroundTruthEmitter`) with Cosys backend today, Gazebo backend in the follow-up PR.

Closes #594

## Design decisions (documented in `docs/design/perception_v2_detailed_design.md` §13)

1. **Approach B — per-frame dynamic GT from the simulator**, not static-config GT. 3 of 5 target scenarios have dynamic content; static GT would produce misleading baselines.
2. **Stable `gt_track_id` across FoV exits.** The simulator has omniscient object identity, so re-entering objects emit the same track_id. No dormant-track guessing needed on the GT side (that's a detector-side approximation).
3. **Out-of-FoV / heavily-occluded objects not emitted** — AirSim's detection API filters visible-only.
4. **Per-scenario `gt_class_map`** in the scenario JSON file — self-contained, auditable.
5. **Occlusion as first-class field** with 0.0 placeholder; real score tracked in IMPROVEMENTS.md.

The user's insight about dormant tracks ("applicable here? won't work for dynamic objects") directly drove decision 2 — GT doesn't need the dormant-track approximation because the simulator has perfect identity information even when the detector doesn't.

## Implementation

Uses AirSim's built-in detection API — cleaner than parsing segmentation images ourselves:

```cpp
rpc.simAddDetectionFilterMeshName(camera, ImageType::Scene, "SK_Mannequin*");
rpc.simSetDetectionFilterRadius(camera, ImageType::Scene, 10000.0F);  // cm
auto detections = rpc.simGetDetections(camera, ImageType::Scene);
// vector<DetectionInfo>{ name, box2D, box3D, relative_pose, ... }
```

Each `DetectionInfo` maps to one `GtDetection` via the per-scenario class map. Stable `gt_track_id` is `std::hash<string_view>(name)` folded to 32 bits.

## Files

**New:**
- [tests/benchmark/gt_emitter.h](tests/benchmark/gt_emitter.h) — public interface (~160 lines)
- [tests/benchmark/gt_emitter.cpp](tests/benchmark/gt_emitter.cpp) — shared impl (GtClassMap, to_json_line)
- [tests/benchmark/cosys_gt_emitter.cpp](tests/benchmark/cosys_gt_emitter.cpp) — Cosys backend (HAVE_COSYS_AIRSIM-gated, ~220 lines)
- [tests/test_gt_emitter.cpp](tests/test_gt_emitter.cpp) — 11 unit tests

**Modified:**
- [config/scenarios/29_cosys_perception.json](config/scenarios/29_cosys_perception.json), [30_cosys_static.json](config/scenarios/30_cosys_static.json) — `gt_class_map` entries
- [docs/architecture/SIMULATION_ARCHITECTURE.md](docs/architecture/SIMULATION_ARCHITECTURE.md) — scope note clarifying the existing doc is Gazebo-only + pointers to Cosys references
- [docs/guides/CONFIG_GUIDE.md](docs/guides/CONFIG_GUIDE.md) — documented `gt_class_map` scenario-config key
- [docs/tracking/IMPROVEMENTS.md](docs/tracking/IMPROVEMENTS.md) — entry #10 for a future `COSYS_SIMULATION_ARCHITECTURE.md`
- [docs/tracking/PROGRESS.md](docs/tracking/PROGRESS.md) — Improvement #77
- [tests/CMakeLists.txt](tests/CMakeLists.txt), [tests/TESTS.md](tests/TESTS.md) — new target + totals
- `docs/design/perception_v2_detailed_design.md` — §13 GT emitter section (gitignored)

## Universal acceptance criteria (from #514)

- [x] Design doc §13 updated with beginner-friendly explainer + dormant-track rationale
- [x] No license obligations change — AirSim detection API is stock SDK

## Specific acceptance criteria (from #594)

- [x] Cosys emitter exists; scenarios #29 + #30 have `gt_class_map` entries
- [x] Output JSON parses cleanly via `nlohmann::json`; schema matches `drone::benchmark::FrameData`
- [x] Occlusion field present (0.0 placeholder for PR 1; real score follow-up)
- [x] GT track IDs stable (hash of object name; same name → same id across frames)
- [x] Out-of-FoV objects not emitted (AirSim detection API filters visible-only)
- [ ] Gazebo emitter (PR 2) — scenarios #02/#18/#21

## Test plan

- [x] `ninja test_gt_emitter && ./bin/test_gt_emitter` — 11/11 pass
- [x] `ctest --test-dir build -j$(nproc)` — 1651 → 1662, 100% pass
- [x] `clang-format-18 --dry-run --Werror` on modified files — clean
- [ ] **Scenario smoke (reviewer to confirm, needs live AirSim):** run scenario 30 with a GT-emitter-enabled harness, inspect `drone_logs/scenarios_cosys/cosys_static/latest/gt_*.jsonl` for non-empty records with person/chair/couch entries. Not automated in this PR because the scenario runner integration is #573's scope.

## Deferred

| # | Finding | Destination |
|---|---|---|
| Real occlusion score | IMPROVEMENTS.md | Segmentation-mask accounting follow-up |
| Gazebo GT emitter | Issue #594 PR 2 | Scenarios #02/#18/#21 |
| `COSYS_SIMULATION_ARCHITECTURE.md` | IMPROVEMENTS.md #10 | Document when patterns stabilise |

## Next after merge

- PR 2: Gazebo GT emitter (~400 LOC under the same issue #594).
- Then #573 baseline capture consumes both GT backends + the profiler JSONs and produces `benchmarks/baseline.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)