### PR TITLE
feat(#572): CI gating — baseline comparison tool + regression detection

### DIFF
--- a/.github/workflows/ci-perception.yml
+++ b/.github/workflows/ci-perception.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           # Compare structured baseline metrics if a current-run baseline exists.
           # The compare_to_baseline tool loads BaselineCapture JSON format.
+          #
+          # NOTE: baseline is read from the PR branch checkout. Before promoting
+          # this to a required check, pin the baseline to the default branch or
+          # an artifact store to prevent PR authors from weakening thresholds.
           if [[ -f /tmp/current-run-baseline.json ]]; then
             echo "Running baseline comparison..."
             ./build/bin/compare_to_baseline \
@@ -96,9 +100,10 @@ jobs:
               body += `| Metric | Baseline | Current | Delta | Status |\n`;
               body += `|--------|----------|---------|-------|--------|\n`;
               for (const [key, val] of Object.entries(results.metrics || {})) {
+                const safeKey = key.replace(/[|`<>\n\r]/g, '_');
                 const delta = (val.current - val.baseline).toFixed(3);
                 const status = val.passed ? '✅' : '⚠️';
-                body += `| ${key} | ${val.baseline} | ${val.current} | ${delta} | ${status} |\n`;
+                body += `| ${safeKey} | ${val.baseline} | ${val.current} | ${delta} | ${status} |\n`;
               }
               body += `\n**Cost:** $${results.cost || 'N/A'} | **Duration:** ${results.duration_min || 'N/A'} min`;
             } catch (e) {

--- a/.github/workflows/ci-perception.yml
+++ b/.github/workflows/ci-perception.yml
@@ -68,6 +68,22 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Baseline regression gate
+        id: baseline_gate
+        if: always() && steps.perception.conclusion == 'success'
+        run: |
+          # Compare structured baseline metrics if a current-run baseline exists.
+          # The compare_to_baseline tool loads BaselineCapture JSON format.
+          if [[ -f /tmp/current-run-baseline.json ]]; then
+            echo "Running baseline comparison..."
+            ./build/bin/compare_to_baseline \
+              --baseline benchmarks/baseline.json \
+              --current /tmp/current-run-baseline.json \
+              | tee /tmp/baseline-comparison.md
+          else
+            echo "No current-run baseline found — skipping structured comparison"
+          fi
+
       - name: Post results as PR comment
         if: always() && steps.perception.conclusion != 'skipped'
         uses: actions/github-script@v7

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3221,4 +3221,31 @@ Also cherry-picked review fixes from PR #595 (`fe2e84a`): GT emitter config key 
 
 ---
 
-_Last updated after Improvement #78 (baseline capture, #573). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._
+### Improvement #79 — CI gating: baseline comparison tool + regression detection (Issue #572, Epic #523)
+
+**Date:** 2026-04-20
+
+**What:** Baseline comparator that fails CI when a PR regresses perception quality beyond configurable thresholds. Compares a current benchmark run against `benchmarks/baseline.json` using percentage-based relative thresholds for detection (recall, precision, mAP), tracking (MOTA, MOTP), and latency (per-stage p95). Includes a CLI tool (`compare_to_baseline`) for local and CI use, and a CI workflow step in `ci-perception.yml`.
+
+**Files added:**
+
+- `tests/benchmark/baseline_comparator.h` — `ComparisonThresholds`, `MetricDelta`, `ScenarioComparison`, `ComparisonResult` types + `compare_baselines()` / `format_comparison()` APIs
+- `tests/benchmark/baseline_comparator.cpp` — comparison engine: higher-is-better (recall, precision, mAP, MOTA, MOTP), lower-is-better (latency p95), zero-baseline skip, Markdown table formatter
+- `tests/benchmark/compare_to_baseline_main.cpp` — CLI: `--baseline <path> --current <path>` with per-metric threshold overrides, exit 0/1
+- `tests/test_baseline_comparator.cpp` — 11 GTest cases: improvement, regression, within-threshold, missing scenario, zero baseline, latency regression, format output, extra scenario, custom thresholds, tracking regression, partial failure
+
+**Files modified:**
+
+- `tests/CMakeLists.txt` — `test_baseline_comparator` test target + `compare_to_baseline` executable target
+- `.github/workflows/ci-perception.yml` — baseline regression gate step between perception run and PR comment
+- `tests/TESTS.md` — suite entry + detailed section + total count update
+
+**Why:** Without automated regression detection, perception quality regressions can slip through code review. The comparator enforces that recall, precision, mAP, MOTA, MOTP, and latency don't degrade beyond thresholds (default 5% for accuracy, 20% for latency). Zero-baseline skip ensures the all-zeros seed baseline passes gracefully until real data is captured. Advisory in CI until baselines have real values.
+
+**Test count:** +11 in `test_baseline_comparator`. 1661 → 1672.
+
+**Universal acceptance criteria:** CI workflow updated; no license obligations change.
+
+---
+
+*Last updated after Improvement #79 (CI gating comparator, #572). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory.*

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3242,7 +3242,7 @@ Also cherry-picked review fixes from PR #595 (`fe2e84a`): GT emitter config key 
 
 **Why:** Without automated regression detection, perception quality regressions can slip through code review. The comparator enforces that recall, precision, mAP, MOTA, MOTP, and latency don't degrade beyond thresholds (default 5% for accuracy, 20% for latency). Zero-baseline skip ensures the all-zeros seed baseline passes gracefully until real data is captured. Advisory in CI until baselines have real values.
 
-**Test count:** +11 in `test_baseline_comparator`. 1661 → 1672.
+**Test count:** +21 in `test_baseline_comparator`. 1661 → 1682.
 
 **Universal acceptance criteria:** CI workflow updated; no license obligations change.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -466,3 +466,34 @@ target_include_directories(test_baseline_capture PRIVATE
 target_link_libraries(test_baseline_capture PRIVATE
     nlohmann_json::nlohmann_json
 )
+
+# ── Baseline comparator tests (Issue #572 — Epic #523) ──────────
+# Validates regression detection against configurable thresholds:
+# recall, precision, mAP, MOTA, latency p95.
+add_drone_test(test_baseline_comparator
+    test_baseline_comparator.cpp
+    benchmark/baseline_comparator.cpp
+    benchmark/baseline_capture.cpp
+    benchmark/perception_metrics.cpp
+)
+target_include_directories(test_baseline_comparator PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(test_baseline_comparator PRIVATE
+    nlohmann_json::nlohmann_json
+)
+
+# ── Baseline comparison CLI tool (Issue #572) ────────────────────
+# Standalone executable: compare current run against stored baseline.
+add_executable(compare_to_baseline
+    benchmark/compare_to_baseline_main.cpp
+    benchmark/baseline_comparator.cpp
+    benchmark/baseline_capture.cpp
+    benchmark/perception_metrics.cpp
+)
+target_include_directories(compare_to_baseline PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(compare_to_baseline PRIVATE
+    nlohmann_json::nlohmann_json
+)

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -135,8 +135,8 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — Profiler Dump Smoke](#test_latency_profiler_dumpcpp--3-tests) | 1 | 3 | Simulated P2/P4 wiring pattern — concurrent workers record via ScopedLatency, dump to JSON on disk, parse back, verify no lost records |
 | [Benchmark — GT Emitter](#test_gt_emittercpp--13-tests) | 1 | 13 | GtClassMap pattern match (exact / wildcard / first-wins); load-from-scenario-config (well-formed, missing, malformed); JSONL serialisation round-trip with quote-and-backslash escaping; review fixes: config key validation, error path coverage |
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
-| [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--11-tests) | 1 | 11 | Regression detection (recall/precision/mAP/MOTA/latency), configurable thresholds, zero-baseline skip, missing scenario detection, partial failure, Markdown table output |
-| **Total** | **77 C++ + 5 shell** | **1672 (no SDK) / 1713 (+SDK) + 42 + 250+** | |
+| [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--21-tests) | 1 | 21 | Regression detection (recall/precision/mAP/MOTA/MOTP/latency), configurable thresholds, zero-baseline skip, missing scenario detection, boundary tests, latency defensive paths, format rendering, partial failure |
+| **Total** | **77 C++ + 5 shell** | **1682 (no SDK) / 1723 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -1098,15 +1098,15 @@ expensive modulo operations.
 
 ---
 
-### test_baseline_comparator.cpp — 11 tests
+### test_baseline_comparator.cpp — 21 tests
 
 **What it tests:** `drone::benchmark::compare_baselines()` and `format_comparison()` — the regression detection engine that compares a current benchmark run against a stored baseline (#572 / Epic #523). Consumes `BaselineCapture` objects from #573 and enforces configurable percentage thresholds on detection, tracking, and latency metrics.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
-| `BaselineComparatorTest` | 11 | Improvement passes (higher metrics → pass); regression beyond threshold fails (10% recall drop exceeds 5% threshold); regression within threshold passes (3% drop within 5%); missing scenario in current run fails; zero-valued baseline metrics skipped (not yet captured → always pass); latency regression fails (30% p95 increase exceeds 20% threshold); format produces Markdown table with correct columns and summary; extra scenario in current ignored (only baseline scenarios checked); custom thresholds respected (strict 5% fails, relaxed 15% passes); tracking regression detected (MOTA 17.6% drop exceeds 5%); multiple scenarios with partial failure (one good, one regressed) |
+| `BaselineComparatorTest` | 21 | Improvement passes (higher metrics → pass, metrics_checked > 0); regression beyond threshold fails (10% recall drop exceeds 5% threshold); regression within threshold passes (3% drop within 5%); exact boundary passes (current = baseline × 0.95 → pass, >= inclusive); below boundary fails (current = 0.759 < 0.76 boundary); missing scenario in current run fails; zero-valued baseline metrics skipped (detection + latency with zero baselines → always pass); latency regression fails (30% p95 increase exceeds 20% threshold); latency improvement passes (20% decrease); latency within threshold passes (15% increase within 20%); latency missing stage silently skips (only present stages compared); latency malformed JSON safe (no crash or false fail); format produces Markdown table with correct columns and summary; format renders **MISSING** for absent scenarios; format renders **FAIL** for regressed metrics; extra scenario in current ignored; custom thresholds respected (strict 5% fails, relaxed 15% passes); MOTA regression detected (17.6% drop exceeds 5%); MOTP-only regression detected (MOTA stable, MOTP drops 18.75%); MOTP uses independent threshold from MOTA (relaxed motp_drop_pct passes); multiple scenarios with partial failure (one good, one regressed) |
 
-**Why these tests matter:** This is the CI gate — a bug here either lets regressions through silently or blocks valid PRs with false alarms. The zero-baseline skip is critical because `benchmarks/baseline.json` is currently all zeros; without it, every comparison would fail. The latency tests ensure pipeline performance regressions are caught alongside accuracy regressions.
+**Why these tests matter:** This is the CI gate — a bug here either lets regressions through silently or blocks valid PRs with false alarms. The zero-baseline skip is critical because `benchmarks/baseline.json` is currently all zeros; without it, every comparison would fail. The latency defensive path tests ensure malformed/missing data doesn't crash the tool. The MOTP-specific tests caught a copy-paste bug where MOTP silently shared MOTA's threshold.
 
 **Key files under test:** `tests/benchmark/baseline_comparator.h`, `tests/benchmark/baseline_comparator.cpp`. Also tests the CLI tool `compare_to_baseline_main.cpp` indirectly (same comparison logic). Depends on `baseline_capture.h/cpp` (#573) for `BaselineCapture` and `ScenarioBaseline` types.
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -135,7 +135,8 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — Profiler Dump Smoke](#test_latency_profiler_dumpcpp--3-tests) | 1 | 3 | Simulated P2/P4 wiring pattern — concurrent workers record via ScopedLatency, dump to JSON on disk, parse back, verify no lost records |
 | [Benchmark — GT Emitter](#test_gt_emittercpp--13-tests) | 1 | 13 | GtClassMap pattern match (exact / wildcard / first-wins); load-from-scenario-config (well-formed, missing, malformed); JSONL serialisation round-trip with quote-and-backslash escaping; review fixes: config key validation, error path coverage |
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
-| **Total** | **76 C++ + 5 shell** | **1661 (no SDK) / 1702 (+SDK) + 42 + 250+** | |
+| [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--11-tests) | 1 | 11 | Regression detection (recall/precision/mAP/MOTA/latency), configurable thresholds, zero-baseline skip, missing scenario detection, partial failure, Markdown table output |
+| **Total** | **77 C++ + 5 shell** | **1672 (no SDK) / 1713 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -1094,6 +1095,20 @@ expensive modulo operations.
 **Why these tests matter:** The baseline is the single reference point the entire perception v2 rewrite is measured against. A serialisation bug that silently drops a field, a finalise() that miscounts TP/FP, or a load() that corrupts the class breakdown would make every subsequent delta measurement wrong — and we wouldn't notice until live testing on hardware.
 
 **Key files under test:** `tests/benchmark/baseline_capture.h`, `tests/benchmark/baseline_capture.cpp`. Delegates to `perception_metrics.h/cpp` (#570) for the actual TP/FP/FN and MOTA/MOTP computation.
+
+---
+
+### test_baseline_comparator.cpp — 11 tests
+
+**What it tests:** `drone::benchmark::compare_baselines()` and `format_comparison()` — the regression detection engine that compares a current benchmark run against a stored baseline (#572 / Epic #523). Consumes `BaselineCapture` objects from #573 and enforces configurable percentage thresholds on detection, tracking, and latency metrics.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `BaselineComparatorTest` | 11 | Improvement passes (higher metrics → pass); regression beyond threshold fails (10% recall drop exceeds 5% threshold); regression within threshold passes (3% drop within 5%); missing scenario in current run fails; zero-valued baseline metrics skipped (not yet captured → always pass); latency regression fails (30% p95 increase exceeds 20% threshold); format produces Markdown table with correct columns and summary; extra scenario in current ignored (only baseline scenarios checked); custom thresholds respected (strict 5% fails, relaxed 15% passes); tracking regression detected (MOTA 17.6% drop exceeds 5%); multiple scenarios with partial failure (one good, one regressed) |
+
+**Why these tests matter:** This is the CI gate — a bug here either lets regressions through silently or blocks valid PRs with false alarms. The zero-baseline skip is critical because `benchmarks/baseline.json` is currently all zeros; without it, every comparison would fail. The latency tests ensure pipeline performance regressions are caught alongside accuracy regressions.
+
+**Key files under test:** `tests/benchmark/baseline_comparator.h`, `tests/benchmark/baseline_comparator.cpp`. Also tests the CLI tool `compare_to_baseline_main.cpp` indirectly (same comparison logic). Depends on `baseline_capture.h/cpp` (#573) for `BaselineCapture` and `ScenarioBaseline` types.
 
 ---
 

--- a/tests/benchmark/baseline_capture.cpp
+++ b/tests/benchmark/baseline_capture.cpp
@@ -93,6 +93,11 @@ const ScenarioBaseline* BaselineCapture::scenario(const std::string& name) const
     return it != scenarios_.end() ? &it->second : nullptr;
 }
 
+ScenarioBaseline* BaselineCapture::scenario(const std::string& name) {
+    auto it = scenarios_.find(name);
+    return it != scenarios_.end() ? &it->second : nullptr;
+}
+
 const std::vector<std::string>& BaselineCapture::scenario_names() const {
     return order_;
 }

--- a/tests/benchmark/baseline_capture.h
+++ b/tests/benchmark/baseline_capture.h
@@ -106,6 +106,7 @@ public:
 
     // Access a scenario baseline (returns nullptr if not found).
     [[nodiscard]] const ScenarioBaseline* scenario(const std::string& name) const;
+    [[nodiscard]] ScenarioBaseline*       scenario(const std::string& name);
 
     // All scenario names in insertion order.
     [[nodiscard]] const std::vector<std::string>& scenario_names() const;

--- a/tests/benchmark/baseline_comparator.cpp
+++ b/tests/benchmark/baseline_comparator.cpp
@@ -1,0 +1,187 @@
+// tests/benchmark/baseline_comparator.cpp
+
+#include "benchmark/baseline_comparator.h"
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+#include <nlohmann/json.hpp>
+
+namespace drone::benchmark {
+
+namespace {
+
+MetricDelta check_higher_is_better(const std::string& name, double baseline_val, double current_val,
+                                   double threshold_pct) {
+    MetricDelta d;
+    d.name          = name;
+    d.baseline      = baseline_val;
+    d.current       = current_val;
+    d.threshold_pct = threshold_pct * 100.0;
+    d.direction     = "higher_is_better";
+
+    if (baseline_val == 0.0) {
+        d.skipped   = true;
+        d.passed    = true;
+        d.delta_pct = 0.0;
+        return d;
+    }
+
+    d.delta_pct = (current_val - baseline_val) / baseline_val * 100.0;
+    d.passed    = current_val >= baseline_val * (1.0 - threshold_pct);
+    return d;
+}
+
+MetricDelta check_lower_is_better(const std::string& name, double baseline_val, double current_val,
+                                  double threshold_pct) {
+    MetricDelta d;
+    d.name          = name;
+    d.baseline      = baseline_val;
+    d.current       = current_val;
+    d.threshold_pct = threshold_pct * 100.0;
+    d.direction     = "lower_is_better";
+
+    if (baseline_val == 0.0) {
+        d.skipped   = true;
+        d.passed    = true;
+        d.delta_pct = 0.0;
+        return d;
+    }
+
+    d.delta_pct = (current_val - baseline_val) / baseline_val * 100.0;
+    d.passed    = current_val <= baseline_val * (1.0 + threshold_pct);
+    return d;
+}
+
+void compare_latency(const std::string& baseline_json, const std::string& current_json,
+                     double threshold_pct, ScenarioComparison& sc) {
+    if (baseline_json.empty() || current_json.empty()) {
+        return;
+    }
+
+    auto bl  = nlohmann::json::parse(baseline_json, nullptr, false);
+    auto cur = nlohmann::json::parse(current_json, nullptr, false);
+    if (bl.is_discarded() || cur.is_discarded()) {
+        return;
+    }
+
+    if (!bl.contains("stages") || !cur.contains("stages")) {
+        return;
+    }
+
+    for (auto it = bl["stages"].begin(); it != bl["stages"].end(); ++it) {
+        const auto& stage_name = it.key();
+        if (!cur["stages"].contains(stage_name)) {
+            continue;
+        }
+        const auto& bl_stage  = it.value();
+        const auto& cur_stage = cur["stages"][stage_name];
+
+        if (bl_stage.contains("p95_ns") && cur_stage.contains("p95_ns")) {
+            double bl_p95  = bl_stage["p95_ns"].get<double>();
+            double cur_p95 = cur_stage["p95_ns"].get<double>();
+            sc.metrics.push_back(check_lower_is_better("latency." + stage_name + ".p95_ns", bl_p95,
+                                                       cur_p95, threshold_pct));
+        }
+    }
+}
+
+}  // namespace
+
+ComparisonResult compare_baselines(const BaselineCapture& baseline, const BaselineCapture& current,
+                                   const ComparisonThresholds& thresholds) {
+    ComparisonResult result;
+    result.passed = true;
+
+    for (const auto& name : baseline.scenario_names()) {
+        ScenarioComparison sc;
+        sc.scenario_name = name;
+
+        const auto* bl  = baseline.scenario(name);
+        const auto* cur = current.scenario(name);
+
+        if (cur == nullptr) {
+            sc.found_in_current = false;
+            sc.passed           = false;
+            result.passed       = false;
+            result.scenarios.push_back(std::move(sc));
+            ++result.scenarios_checked;
+            continue;
+        }
+
+        sc.found_in_current = true;
+
+        // Detection metrics (higher is better).
+        sc.metrics.push_back(check_higher_is_better("micro_recall", bl->micro_recall,
+                                                    cur->micro_recall, thresholds.recall_drop_pct));
+        sc.metrics.push_back(check_higher_is_better("micro_precision", bl->micro_precision,
+                                                    cur->micro_precision,
+                                                    thresholds.precision_drop_pct));
+        sc.metrics.push_back(
+            check_higher_is_better("mean_ap", bl->mean_ap, cur->mean_ap, thresholds.ap_drop_pct));
+
+        // Tracking metrics (higher is better).
+        sc.metrics.push_back(
+            check_higher_is_better("mota", bl->mota, cur->mota, thresholds.mota_drop_pct));
+        sc.metrics.push_back(
+            check_higher_is_better("motp", bl->motp, cur->motp, thresholds.mota_drop_pct));
+
+        // Latency (lower is better).
+        compare_latency(bl->latency_json, cur->latency_json, thresholds.latency_rise_pct, sc);
+
+        // Roll up scenario pass/fail.
+        for (const auto& m : sc.metrics) {
+            if (!m.skipped) {
+                ++result.metrics_checked;
+            }
+            if (!m.passed) {
+                sc.passed = false;
+                ++result.metrics_failed;
+            }
+        }
+        if (!sc.passed) {
+            result.passed = false;
+        }
+
+        result.scenarios.push_back(std::move(sc));
+        ++result.scenarios_checked;
+    }
+
+    return result;
+}
+
+std::string format_comparison(const ComparisonResult& result) {
+    std::ostringstream os;
+
+    os << "## Baseline Comparison\n\n";
+    os << "| Scenario | Metric | Baseline | Current | Delta% | Threshold | Status |\n";
+    os << "|----------|--------|----------|---------|--------|-----------|--------|\n";
+
+    for (const auto& sc : result.scenarios) {
+        if (!sc.found_in_current) {
+            os << "| " << sc.scenario_name << " | — | — | — | — | — | MISSING |\n";
+            continue;
+        }
+        bool first = true;
+        for (const auto& m : sc.metrics) {
+            if (m.skipped) {
+                continue;
+            }
+            os << "| " << (first ? sc.scenario_name : "") << " | " << m.name << " | " << std::fixed
+               << std::setprecision(4) << m.baseline << " | " << m.current << " | " << std::showpos
+               << std::setprecision(1) << m.delta_pct << "%" << std::noshowpos << " | "
+               << std::setprecision(1) << m.threshold_pct << "% | "
+               << (m.passed ? "PASS" : "**FAIL**") << " |\n";
+            first = false;
+        }
+    }
+
+    os << "\n**Result:** " << result.scenarios_checked << " scenario(s), " << result.metrics_checked
+       << " metric(s) checked, " << result.metrics_failed << " failed — "
+       << (result.passed ? "**PASS**" : "**FAIL**") << "\n";
+
+    return os.str();
+}
+
+}  // namespace drone::benchmark

--- a/tests/benchmark/baseline_comparator.cpp
+++ b/tests/benchmark/baseline_comparator.cpp
@@ -2,6 +2,7 @@
 
 #include "benchmark/baseline_comparator.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <sstream>
@@ -12,14 +13,16 @@ namespace drone::benchmark {
 
 namespace {
 
-MetricDelta check_higher_is_better(const std::string& name, double baseline_val, double current_val,
-                                   double threshold_pct) {
+constexpr std::size_t kMaxLatencyJsonBytes = 1024 * 1024;
+
+MetricDelta make_delta(const std::string& name, double baseline_val, double current_val,
+                       double threshold_pct, const char* direction) {
     MetricDelta d;
     d.name          = name;
     d.baseline      = baseline_val;
     d.current       = current_val;
     d.threshold_pct = threshold_pct * 100.0;
-    d.direction     = "higher_is_better";
+    d.direction     = direction;
 
     if (baseline_val == 0.0) {
         d.skipped   = true;
@@ -29,34 +32,38 @@ MetricDelta check_higher_is_better(const std::string& name, double baseline_val,
     }
 
     d.delta_pct = (current_val - baseline_val) / baseline_val * 100.0;
-    d.passed    = current_val >= baseline_val * (1.0 - threshold_pct);
+    return d;
+}
+
+MetricDelta check_higher_is_better(const std::string& name, double baseline_val, double current_val,
+                                   double threshold_pct) {
+    auto d = make_delta(name, baseline_val, current_val, threshold_pct, "higher_is_better");
+    if (!d.skipped) {
+        d.passed = current_val >= baseline_val * (1.0 - threshold_pct);
+    }
     return d;
 }
 
 MetricDelta check_lower_is_better(const std::string& name, double baseline_val, double current_val,
                                   double threshold_pct) {
-    MetricDelta d;
-    d.name          = name;
-    d.baseline      = baseline_val;
-    d.current       = current_val;
-    d.threshold_pct = threshold_pct * 100.0;
-    d.direction     = "lower_is_better";
-
-    if (baseline_val == 0.0) {
-        d.skipped   = true;
-        d.passed    = true;
-        d.delta_pct = 0.0;
-        return d;
+    auto d = make_delta(name, baseline_val, current_val, threshold_pct, "lower_is_better");
+    if (!d.skipped) {
+        d.passed = current_val <= baseline_val * (1.0 + threshold_pct);
     }
-
-    d.delta_pct = (current_val - baseline_val) / baseline_val * 100.0;
-    d.passed    = current_val <= baseline_val * (1.0 + threshold_pct);
     return d;
+}
+
+bool is_valid_stage_name(const std::string& name) {
+    return std::all_of(name.begin(), name.end(),
+                       [](char c) { return std::isalnum(c) != 0 || c == '_'; });
 }
 
 void compare_latency(const std::string& baseline_json, const std::string& current_json,
                      double threshold_pct, ScenarioComparison& sc) {
     if (baseline_json.empty() || current_json.empty()) {
+        return;
+    }
+    if (baseline_json.size() > kMaxLatencyJsonBytes || current_json.size() > kMaxLatencyJsonBytes) {
         return;
     }
 
@@ -72,6 +79,9 @@ void compare_latency(const std::string& baseline_json, const std::string& curren
 
     for (auto it = bl["stages"].begin(); it != bl["stages"].end(); ++it) {
         const auto& stage_name = it.key();
+        if (!is_valid_stage_name(stage_name)) {
+            continue;
+        }
         if (!cur["stages"].contains(stage_name)) {
             continue;
         }
@@ -125,7 +135,7 @@ ComparisonResult compare_baselines(const BaselineCapture& baseline, const Baseli
         sc.metrics.push_back(
             check_higher_is_better("mota", bl->mota, cur->mota, thresholds.mota_drop_pct));
         sc.metrics.push_back(
-            check_higher_is_better("motp", bl->motp, cur->motp, thresholds.mota_drop_pct));
+            check_higher_is_better("motp", bl->motp, cur->motp, thresholds.motp_drop_pct));
 
         // Latency (lower is better).
         compare_latency(bl->latency_json, cur->latency_json, thresholds.latency_rise_pct, sc);
@@ -153,6 +163,7 @@ ComparisonResult compare_baselines(const BaselineCapture& baseline, const Baseli
 
 std::string format_comparison(const ComparisonResult& result) {
     std::ostringstream os;
+    os.str().reserve(512 * result.scenarios.size() + 256);
 
     os << "## Baseline Comparison\n\n";
     os << "| Scenario | Metric | Baseline | Current | Delta% | Threshold | Status |\n";
@@ -160,20 +171,18 @@ std::string format_comparison(const ComparisonResult& result) {
 
     for (const auto& sc : result.scenarios) {
         if (!sc.found_in_current) {
-            os << "| " << sc.scenario_name << " | — | — | — | — | — | MISSING |\n";
+            os << "| " << sc.scenario_name << " | — | — | — | — | — | **MISSING** |\n";
             continue;
         }
-        bool first = true;
         for (const auto& m : sc.metrics) {
             if (m.skipped) {
                 continue;
             }
-            os << "| " << (first ? sc.scenario_name : "") << " | " << m.name << " | " << std::fixed
+            os << "| " << sc.scenario_name << " | " << m.name << " | " << std::fixed
                << std::setprecision(4) << m.baseline << " | " << m.current << " | " << std::showpos
                << std::setprecision(1) << m.delta_pct << "%" << std::noshowpos << " | "
                << std::setprecision(1) << m.threshold_pct << "% | "
                << (m.passed ? "PASS" : "**FAIL**") << " |\n";
-            first = false;
         }
     }
 

--- a/tests/benchmark/baseline_comparator.h
+++ b/tests/benchmark/baseline_comparator.h
@@ -1,0 +1,60 @@
+// tests/benchmark/baseline_comparator.h
+//
+// Compares a current perception run against a stored baseline, detecting
+// regressions that exceed configurable thresholds (Issue #572, Epic #523).
+
+#pragma once
+
+#include "benchmark/baseline_capture.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drone::benchmark {
+
+struct ComparisonThresholds {
+    double recall_drop_pct    = 0.05;
+    double precision_drop_pct = 0.05;
+    double ap_drop_pct        = 0.05;
+    double mota_drop_pct      = 0.05;
+    double latency_rise_pct   = 0.20;
+};
+
+struct MetricDelta {
+    std::string name{};
+    double      baseline{0.0};
+    double      current{0.0};
+    double      delta_pct{0.0};
+    double      threshold_pct{0.0};
+    bool        passed{true};
+    bool        skipped{false};
+    std::string direction{};
+};
+
+struct ScenarioComparison {
+    std::string              scenario_name{};
+    bool                     passed{true};
+    bool                     found_in_current{false};
+    std::vector<MetricDelta> metrics{};
+};
+
+struct ComparisonResult {
+    bool                            passed{true};
+    uint32_t                        scenarios_checked{0};
+    uint32_t                        metrics_checked{0};
+    uint32_t                        metrics_failed{0};
+    std::vector<ScenarioComparison> scenarios{};
+};
+
+// Compare a current run against a baseline. Only scenarios present in the
+// baseline are checked — extra scenarios in current are ignored. Zero-valued
+// baseline metrics are skipped (not yet captured).
+[[nodiscard]] ComparisonResult compare_baselines(const BaselineCapture&      baseline,
+                                                 const BaselineCapture&      current,
+                                                 const ComparisonThresholds& thresholds = {});
+
+// Render the comparison result as a Markdown table suitable for CI output.
+[[nodiscard]] std::string format_comparison(const ComparisonResult& result);
+
+}  // namespace drone::benchmark

--- a/tests/benchmark/baseline_comparator.h
+++ b/tests/benchmark/baseline_comparator.h
@@ -18,9 +18,12 @@ struct ComparisonThresholds {
     double precision_drop_pct = 0.05;
     double ap_drop_pct        = 0.05;
     double mota_drop_pct      = 0.05;
+    double motp_drop_pct      = 0.05;
     double latency_rise_pct   = 0.20;
 };
 
+// Invariant: skipped == true implies passed == true (zero-valued baselines
+// are not-yet-captured and should never block a comparison).
 struct MetricDelta {
     std::string name{};
     double      baseline{0.0};
@@ -48,13 +51,15 @@ struct ComparisonResult {
 };
 
 // Compare a current run against a baseline. Only scenarios present in the
-// baseline are checked — extra scenarios in current are ignored. Zero-valued
+// baseline are checked — extra scenarios in current are ignored. Scenarios
+// present in baseline but absent in current cause a hard failure. Zero-valued
 // baseline metrics are skipped (not yet captured).
 [[nodiscard]] ComparisonResult compare_baselines(const BaselineCapture&      baseline,
                                                  const BaselineCapture&      current,
                                                  const ComparisonThresholds& thresholds = {});
 
 // Render the comparison result as a Markdown table suitable for CI output.
+// Missing scenarios produce a **MISSING** row; failed metrics show **FAIL**.
 [[nodiscard]] std::string format_comparison(const ComparisonResult& result);
 
 }  // namespace drone::benchmark

--- a/tests/benchmark/compare_to_baseline_main.cpp
+++ b/tests/benchmark/compare_to_baseline_main.cpp
@@ -1,0 +1,86 @@
+// tests/benchmark/compare_to_baseline_main.cpp
+//
+// CLI tool: compare current perception run metrics against a stored baseline.
+// Exits 0 if all metrics are within thresholds, 1 if any regression detected.
+//
+// Usage:
+//   compare_to_baseline --baseline benchmarks/baseline.json --current run.json
+//   compare_to_baseline --baseline bl.json --current run.json --recall-threshold 0.10
+
+#include "benchmark/baseline_capture.h"
+#include "benchmark/baseline_comparator.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void print_usage(const char* argv0) {
+    std::cerr << "Usage: " << argv0 << " --baseline <path> --current <path> [options]\n\n"
+              << "Options:\n"
+              << "  --recall-threshold <pct>     Max recall drop     (default: 0.05)\n"
+              << "  --precision-threshold <pct>  Max precision drop  (default: 0.05)\n"
+              << "  --ap-threshold <pct>         Max mAP drop        (default: 0.05)\n"
+              << "  --mota-threshold <pct>       Max MOTA drop       (default: 0.05)\n"
+              << "  --latency-threshold <pct>    Max latency p95 rise (default: 0.20)\n"
+              << "  --help                       Show this message\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    std::string                            baseline_path;
+    std::string                            current_path;
+    drone::benchmark::ComparisonThresholds thresholds;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--help" || arg == "-h") {
+            print_usage(argv[0]);
+            return 0;
+        }
+        if (arg == "--baseline" && i + 1 < argc) {
+            baseline_path = argv[++i];
+        } else if (arg == "--current" && i + 1 < argc) {
+            current_path = argv[++i];
+        } else if (arg == "--recall-threshold" && i + 1 < argc) {
+            thresholds.recall_drop_pct = std::stod(argv[++i]);
+        } else if (arg == "--precision-threshold" && i + 1 < argc) {
+            thresholds.precision_drop_pct = std::stod(argv[++i]);
+        } else if (arg == "--ap-threshold" && i + 1 < argc) {
+            thresholds.ap_drop_pct = std::stod(argv[++i]);
+        } else if (arg == "--mota-threshold" && i + 1 < argc) {
+            thresholds.mota_drop_pct = std::stod(argv[++i]);
+        } else if (arg == "--latency-threshold" && i + 1 < argc) {
+            thresholds.latency_rise_pct = std::stod(argv[++i]);
+        } else {
+            std::cerr << "Unknown option: " << arg << "\n";
+            print_usage(argv[0]);
+            return 2;
+        }
+    }
+
+    if (baseline_path.empty() || current_path.empty()) {
+        std::cerr << "Error: --baseline and --current are required\n\n";
+        print_usage(argv[0]);
+        return 2;
+    }
+
+    drone::benchmark::BaselineCapture baseline;
+    if (!baseline.load_json(baseline_path)) {
+        std::cerr << "Error: could not load baseline: " << baseline_path << "\n";
+        return 2;
+    }
+
+    drone::benchmark::BaselineCapture current;
+    if (!current.load_json(current_path)) {
+        std::cerr << "Error: could not load current run: " << current_path << "\n";
+        return 2;
+    }
+
+    const auto result = drone::benchmark::compare_baselines(baseline, current, thresholds);
+    std::cout << drone::benchmark::format_comparison(result);
+
+    return result.passed ? 0 : 1;
+}

--- a/tests/benchmark/compare_to_baseline_main.cpp
+++ b/tests/benchmark/compare_to_baseline_main.cpp
@@ -1,7 +1,8 @@
 // tests/benchmark/compare_to_baseline_main.cpp
 //
 // CLI tool: compare current perception run metrics against a stored baseline.
-// Exits 0 if all metrics are within thresholds, 1 if any regression detected.
+// Exits 0 if all metrics are within thresholds, 1 if any regression detected,
+// 2 on usage/parse error.
 //
 // Usage:
 //   compare_to_baseline --baseline benchmarks/baseline.json --current run.json
@@ -10,9 +11,11 @@
 #include "benchmark/baseline_capture.h"
 #include "benchmark/baseline_comparator.h"
 
+#include <charconv>
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -23,8 +26,23 @@ void print_usage(const char* argv0) {
               << "  --precision-threshold <pct>  Max precision drop  (default: 0.05)\n"
               << "  --ap-threshold <pct>         Max mAP drop        (default: 0.05)\n"
               << "  --mota-threshold <pct>       Max MOTA drop       (default: 0.05)\n"
+              << "  --motp-threshold <pct>       Max MOTP drop       (default: 0.05)\n"
               << "  --latency-threshold <pct>    Max latency p95 rise (default: 0.20)\n"
               << "  --help                       Show this message\n";
+}
+
+bool parse_threshold(const char* str, double& out) {
+    std::string_view sv(str);
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out);
+    if (ec != std::errc{} || ptr != sv.data() + sv.size()) {
+        std::cerr << "Error: invalid threshold value: " << str << "\n";
+        return false;
+    }
+    if (out <= 0.0 || out > 1.0) {
+        std::cerr << "Error: threshold must be in (0.0, 1.0]: " << str << "\n";
+        return false;
+    }
+    return true;
 }
 
 }  // namespace
@@ -35,7 +53,7 @@ int main(int argc, char* argv[]) {
     drone::benchmark::ComparisonThresholds thresholds;
 
     for (int i = 1; i < argc; ++i) {
-        std::string arg = argv[i];
+        std::string_view arg = argv[i];
         if (arg == "--help" || arg == "-h") {
             print_usage(argv[0]);
             return 0;
@@ -45,15 +63,17 @@ int main(int argc, char* argv[]) {
         } else if (arg == "--current" && i + 1 < argc) {
             current_path = argv[++i];
         } else if (arg == "--recall-threshold" && i + 1 < argc) {
-            thresholds.recall_drop_pct = std::stod(argv[++i]);
+            if (!parse_threshold(argv[++i], thresholds.recall_drop_pct)) return 2;
         } else if (arg == "--precision-threshold" && i + 1 < argc) {
-            thresholds.precision_drop_pct = std::stod(argv[++i]);
+            if (!parse_threshold(argv[++i], thresholds.precision_drop_pct)) return 2;
         } else if (arg == "--ap-threshold" && i + 1 < argc) {
-            thresholds.ap_drop_pct = std::stod(argv[++i]);
+            if (!parse_threshold(argv[++i], thresholds.ap_drop_pct)) return 2;
         } else if (arg == "--mota-threshold" && i + 1 < argc) {
-            thresholds.mota_drop_pct = std::stod(argv[++i]);
+            if (!parse_threshold(argv[++i], thresholds.mota_drop_pct)) return 2;
+        } else if (arg == "--motp-threshold" && i + 1 < argc) {
+            if (!parse_threshold(argv[++i], thresholds.motp_drop_pct)) return 2;
         } else if (arg == "--latency-threshold" && i + 1 < argc) {
-            thresholds.latency_rise_pct = std::stod(argv[++i]);
+            if (!parse_threshold(argv[++i], thresholds.latency_rise_pct)) return 2;
         } else {
             std::cerr << "Unknown option: " << arg << "\n";
             print_usage(argv[0]);

--- a/tests/test_baseline_comparator.cpp
+++ b/tests/test_baseline_comparator.cpp
@@ -33,13 +33,18 @@ void set_detection_metrics(BaselineCapture& capture, const std::string& name, do
 
 void set_tracking_metrics(BaselineCapture& capture, const std::string& name, double mota,
                           double motp, uint32_t id_switches) {
-    auto* s = const_cast<ScenarioBaseline*>(capture.scenario(name));
-    if (s == nullptr) {
-        return;
-    }
+    auto* s = capture.scenario(name);
+    ASSERT_NE(s, nullptr) << "Scenario '" << name << "' must be added before setting tracking";
     s->mota        = mota;
     s->motp        = motp;
     s->id_switches = id_switches;
+}
+
+void set_latency(BaselineCapture& capture, const std::string& name,
+                 const std::string& latency_json) {
+    auto* s = capture.scenario(name);
+    ASSERT_NE(s, nullptr) << "Scenario '" << name << "' must be added before setting latency";
+    s->latency_json = latency_json;
 }
 
 }  // namespace
@@ -56,6 +61,7 @@ TEST(BaselineComparatorTest, ImprovementPasses) {
     auto result = compare_baselines(baseline, current);
     EXPECT_TRUE(result.passed);
     EXPECT_EQ(result.metrics_failed, 0U);
+    EXPECT_GT(result.metrics_checked, 0U);
 }
 
 // -- Regression beyond threshold fails ----------------------------------------
@@ -65,14 +71,13 @@ TEST(BaselineComparatorTest, RegressionFails) {
     set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
 
     BaselineCapture current;
-    // 10% recall drop (0.80 → 0.70) exceeds 5% threshold.
+    // 10% recall drop (0.80 -> 0.70) exceeds 5% threshold.
     set_detection_metrics(current, "s1", 0.70, 0.85, 0.75, 70, 15, 30);
 
     auto result = compare_baselines(baseline, current);
     EXPECT_FALSE(result.passed);
     EXPECT_GE(result.metrics_failed, 1U);
 
-    // Find the recall metric.
     bool found_recall_fail = false;
     for (const auto& sc : result.scenarios) {
         for (const auto& m : sc.metrics) {
@@ -91,11 +96,56 @@ TEST(BaselineComparatorTest, WithinThresholdPasses) {
     set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
 
     BaselineCapture current;
-    // 3% recall drop (0.80 → 0.776) is within 5% threshold.
+    // 3% recall drop (0.80 -> 0.776) is within 5% threshold.
     set_detection_metrics(current, "s1", 0.776, 0.83, 0.73, 78, 17, 22);
 
     auto result = compare_baselines(baseline, current);
     EXPECT_TRUE(result.passed);
+}
+
+// -- Exact boundary passes (>= check) ----------------------------------------
+
+TEST(BaselineComparatorTest, ExactBoundaryPasses) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    // current = baseline * (1 - threshold) = 0.80 * 0.95 = 0.76 exactly.
+    set_detection_metrics(current, "s1", 0.76, 0.85, 0.75, 76, 15, 24);
+
+    auto result = compare_baselines(baseline, current);
+    // Should pass — >= boundary is inclusive.
+    bool recall_passed = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "micro_recall") {
+                recall_passed = m.passed;
+            }
+        }
+    }
+    EXPECT_TRUE(recall_passed);
+}
+
+// -- Just below boundary fails ------------------------------------------------
+
+TEST(BaselineComparatorTest, BelowBoundaryFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    // current = 0.759 < 0.76 boundary.
+    set_detection_metrics(current, "s1", 0.759, 0.85, 0.75, 76, 15, 24);
+
+    auto result        = compare_baselines(baseline, current);
+    bool recall_failed = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "micro_recall") {
+                recall_failed = !m.passed;
+            }
+        }
+    }
+    EXPECT_TRUE(recall_failed);
 }
 
 // -- Missing scenario in current run fails ------------------------------------
@@ -118,17 +168,19 @@ TEST(BaselineComparatorTest, MissingScenarioFails) {
 TEST(BaselineComparatorTest, ZeroBaselineSkipped) {
     BaselineCapture baseline;
     set_detection_metrics(baseline, "s1", 0.0, 0.0, 0.0, 0, 0, 0);
+    set_latency(baseline, "s1", R"({"stages":{"detector":{"p95_ns":0}}})");
 
     BaselineCapture current;
     set_detection_metrics(current, "s1", 0.5, 0.5, 0.5, 50, 50, 50);
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":1000000}}})");
 
     auto result = compare_baselines(baseline, current);
     EXPECT_TRUE(result.passed);
 
-    // All detection metrics should be skipped.
+    // All metrics (detection + latency) with zero baselines should be skipped.
     for (const auto& sc : result.scenarios) {
         for (const auto& m : sc.metrics) {
-            if (m.direction == "higher_is_better") {
+            if (m.baseline == 0.0) {
                 EXPECT_TRUE(m.skipped) << "Metric " << m.name << " should be skipped";
             }
         }
@@ -140,14 +192,12 @@ TEST(BaselineComparatorTest, ZeroBaselineSkipped) {
 TEST(BaselineComparatorTest, LatencyRegressionFails) {
     BaselineCapture baseline;
     set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
-    auto* bl_s         = const_cast<ScenarioBaseline*>(baseline.scenario("s1"));
-    bl_s->latency_json = R"({"stages":{"detector":{"p95_ns":5000000}}})";
+    set_latency(baseline, "s1", R"({"stages":{"detector":{"p95_ns":5000000}}})");
 
     BaselineCapture current;
     set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
-    auto* cur_s = const_cast<ScenarioBaseline*>(current.scenario("s1"));
     // 30% latency increase exceeds 20% threshold.
-    cur_s->latency_json = R"({"stages":{"detector":{"p95_ns":6500000}}})";
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":6500000}}})");
 
     auto result = compare_baselines(baseline, current);
     EXPECT_FALSE(result.passed);
@@ -161,6 +211,82 @@ TEST(BaselineComparatorTest, LatencyRegressionFails) {
         }
     }
     EXPECT_TRUE(found_latency_fail);
+}
+
+// -- Latency improvement passes -----------------------------------------------
+
+TEST(BaselineComparatorTest, LatencyImprovementPasses) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_latency(baseline, "s1", R"({"stages":{"detector":{"p95_ns":5000000}}})");
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // 20% latency decrease — improvement.
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":4000000}}})");
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+}
+
+// -- Latency within threshold passes ------------------------------------------
+
+TEST(BaselineComparatorTest, LatencyWithinThresholdPasses) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_latency(baseline, "s1", R"({"stages":{"detector":{"p95_ns":5000000}}})");
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // 15% latency increase within 20% threshold.
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":5750000}}})");
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+}
+
+// -- Latency stage absent in current silently skips ---------------------------
+
+TEST(BaselineComparatorTest, LatencyMissingStageSilentlySkips) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_latency(baseline, "s1",
+                R"({"stages":{"detector":{"p95_ns":5000000},"tracker":{"p95_ns":3000000}}})");
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // Current only has "detector" — "tracker" is absent.
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":5000000}}})");
+
+    auto result = compare_baselines(baseline, current);
+    // Missing stage is silently skipped — only "detector" is compared.
+    EXPECT_TRUE(result.passed);
+
+    uint32_t latency_metrics = 0;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name.find("latency") != std::string::npos) {
+                ++latency_metrics;
+            }
+        }
+    }
+    EXPECT_EQ(latency_metrics, 1U);
+}
+
+// -- Latency with malformed JSON does not crash or fail -----------------------
+
+TEST(BaselineComparatorTest, LatencyMalformedJsonSafe) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_latency(baseline, "s1", "{not valid json!!}");
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_latency(current, "s1", R"({"stages":{"detector":{"p95_ns":5000000}}})");
+
+    auto result = compare_baselines(baseline, current);
+    // Malformed baseline latency is silently ignored — detection metrics still checked.
+    EXPECT_TRUE(result.passed);
 }
 
 // -- Format produces Markdown table -------------------------------------------
@@ -178,8 +304,38 @@ TEST(BaselineComparatorTest, FormatTableOutput) {
     EXPECT_NE(table.find("## Baseline Comparison"), std::string::npos);
     EXPECT_NE(table.find("| Scenario"), std::string::npos);
     EXPECT_NE(table.find("micro_recall"), std::string::npos);
-    EXPECT_NE(table.find("PASS"), std::string::npos);
     EXPECT_NE(table.find("**PASS**"), std::string::npos);
+}
+
+// -- Format renders MISSING for absent scenarios ------------------------------
+
+TEST(BaselineComparatorTest, FormatMissingScenario) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "absent", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "other", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    auto result = compare_baselines(baseline, current);
+    auto table  = format_comparison(result);
+
+    EXPECT_NE(table.find("**MISSING**"), std::string::npos);
+    EXPECT_NE(table.find("absent"), std::string::npos);
+}
+
+// -- Format renders FAIL for regressed metrics --------------------------------
+
+TEST(BaselineComparatorTest, FormatFailRendered) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.60, 0.85, 0.75, 60, 15, 40);
+
+    auto result = compare_baselines(baseline, current);
+    auto table  = format_comparison(result);
+
+    EXPECT_NE(table.find("**FAIL**"), std::string::npos);
 }
 
 // -- Extra scenario in current is ignored -------------------------------------
@@ -216,9 +372,9 @@ TEST(BaselineComparatorTest, CustomThresholds) {
     EXPECT_TRUE(compare_baselines(baseline, current, relaxed).passed);
 }
 
-// -- Tracking regression detected ---------------------------------------------
+// -- Tracking MOTA regression detected ----------------------------------------
 
-TEST(BaselineComparatorTest, TrackingRegressionFails) {
+TEST(BaselineComparatorTest, TrackingMOTARegressionFails) {
     BaselineCapture baseline;
     set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
     set_tracking_metrics(baseline, "s1", 0.85, 0.78, 2);
@@ -230,6 +386,71 @@ TEST(BaselineComparatorTest, TrackingRegressionFails) {
 
     auto result = compare_baselines(baseline, current);
     EXPECT_FALSE(result.passed);
+
+    bool mota_failed = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "mota" && !m.passed) {
+                mota_failed = true;
+            }
+        }
+    }
+    EXPECT_TRUE(mota_failed);
+}
+
+// -- Tracking MOTP-only regression detected -----------------------------------
+
+TEST(BaselineComparatorTest, MOTPOnlyRegressionFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_tracking_metrics(baseline, "s1", 0.85, 0.80, 2);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // MOTA stays the same. MOTP drops from 0.80 to 0.65 — 18.75% drop, exceeds 5%.
+    set_tracking_metrics(current, "s1", 0.85, 0.65, 2);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+
+    bool motp_failed = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "motp" && !m.passed) {
+                motp_failed = true;
+            }
+        }
+    }
+    EXPECT_TRUE(motp_failed);
+}
+
+// -- MOTP uses independent threshold from MOTA --------------------------------
+
+TEST(BaselineComparatorTest, MOTPUsesOwnThreshold) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_tracking_metrics(baseline, "s1", 0.85, 0.80, 2);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // 10% MOTP drop — exceeds 5% but within 15%.
+    set_tracking_metrics(current, "s1", 0.85, 0.72, 2);
+
+    ComparisonThresholds t;
+    t.mota_drop_pct = 0.05;
+    t.motp_drop_pct = 0.15;
+    auto result     = compare_baselines(baseline, current, t);
+
+    // MOTP 10% drop within the relaxed 15% motp threshold — should pass.
+    bool motp_passed = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "motp") {
+                motp_passed = m.passed;
+            }
+        }
+    }
+    EXPECT_TRUE(motp_passed);
 }
 
 // -- Multiple scenarios — partial failure -------------------------------------

--- a/tests/test_baseline_comparator.cpp
+++ b/tests/test_baseline_comparator.cpp
@@ -1,0 +1,259 @@
+// tests/test_baseline_comparator.cpp
+//
+// Unit tests for BaselineComparator (Issue #572, Epic #523).
+// Verifies regression detection, threshold logic, and output formatting.
+
+#include "benchmark/baseline_capture.h"
+#include "benchmark/baseline_comparator.h"
+#include "benchmark/perception_metrics.h"
+
+#include <cstdint>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace drone::benchmark;
+
+namespace {
+
+// Populate a scenario with known detection metrics via raw struct fields
+// (bypasses finalise — we set metrics directly for deterministic testing).
+void set_detection_metrics(BaselineCapture& capture, const std::string& name, double recall,
+                           double precision, double mean_ap, uint32_t tp, uint32_t fp,
+                           uint32_t fn) {
+    auto& s           = capture.add_scenario(name);
+    s.micro_recall    = recall;
+    s.micro_precision = precision;
+    s.mean_ap         = mean_ap;
+    s.total_tp        = tp;
+    s.total_fp        = fp;
+    s.total_fn        = fn;
+    s.frame_count     = tp + fn;
+}
+
+void set_tracking_metrics(BaselineCapture& capture, const std::string& name, double mota,
+                          double motp, uint32_t id_switches) {
+    auto* s = const_cast<ScenarioBaseline*>(capture.scenario(name));
+    if (s == nullptr) {
+        return;
+    }
+    s->mota        = mota;
+    s->motp        = motp;
+    s->id_switches = id_switches;
+}
+
+}  // namespace
+
+// -- Improvement passes -------------------------------------------------------
+
+TEST(BaselineComparatorTest, ImprovementPasses) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.90, 0.90, 0.85, 90, 10, 10);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+    EXPECT_EQ(result.metrics_failed, 0U);
+}
+
+// -- Regression beyond threshold fails ----------------------------------------
+
+TEST(BaselineComparatorTest, RegressionFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    // 10% recall drop (0.80 → 0.70) exceeds 5% threshold.
+    set_detection_metrics(current, "s1", 0.70, 0.85, 0.75, 70, 15, 30);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+    EXPECT_GE(result.metrics_failed, 1U);
+
+    // Find the recall metric.
+    bool found_recall_fail = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name == "micro_recall" && !m.passed) {
+                found_recall_fail = true;
+            }
+        }
+    }
+    EXPECT_TRUE(found_recall_fail);
+}
+
+// -- Within threshold passes --------------------------------------------------
+
+TEST(BaselineComparatorTest, WithinThresholdPasses) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    // 3% recall drop (0.80 → 0.776) is within 5% threshold.
+    set_detection_metrics(current, "s1", 0.776, 0.83, 0.73, 78, 17, 22);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+}
+
+// -- Missing scenario in current run fails ------------------------------------
+
+TEST(BaselineComparatorTest, MissingScenarioFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "expected_scenario", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "different_scenario", 0.90, 0.90, 0.85, 90, 10, 10);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+    ASSERT_EQ(result.scenarios.size(), 1U);
+    EXPECT_FALSE(result.scenarios[0].found_in_current);
+}
+
+// -- Zero-valued baseline metrics are skipped ---------------------------------
+
+TEST(BaselineComparatorTest, ZeroBaselineSkipped) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.0, 0.0, 0.0, 0, 0, 0);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.5, 0.5, 0.5, 50, 50, 50);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+
+    // All detection metrics should be skipped.
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.direction == "higher_is_better") {
+                EXPECT_TRUE(m.skipped) << "Metric " << m.name << " should be skipped";
+            }
+        }
+    }
+}
+
+// -- Latency regression fails -------------------------------------------------
+
+TEST(BaselineComparatorTest, LatencyRegressionFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    auto* bl_s         = const_cast<ScenarioBaseline*>(baseline.scenario("s1"));
+    bl_s->latency_json = R"({"stages":{"detector":{"p95_ns":5000000}}})";
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    auto* cur_s = const_cast<ScenarioBaseline*>(current.scenario("s1"));
+    // 30% latency increase exceeds 20% threshold.
+    cur_s->latency_json = R"({"stages":{"detector":{"p95_ns":6500000}}})";
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+
+    bool found_latency_fail = false;
+    for (const auto& sc : result.scenarios) {
+        for (const auto& m : sc.metrics) {
+            if (m.name.find("latency") != std::string::npos && !m.passed) {
+                found_latency_fail = true;
+            }
+        }
+    }
+    EXPECT_TRUE(found_latency_fail);
+}
+
+// -- Format produces Markdown table -------------------------------------------
+
+TEST(BaselineComparatorTest, FormatTableOutput) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.82, 0.87, 0.77, 82, 13, 18);
+
+    auto result = compare_baselines(baseline, current);
+    auto table  = format_comparison(result);
+
+    EXPECT_NE(table.find("## Baseline Comparison"), std::string::npos);
+    EXPECT_NE(table.find("| Scenario"), std::string::npos);
+    EXPECT_NE(table.find("micro_recall"), std::string::npos);
+    EXPECT_NE(table.find("PASS"), std::string::npos);
+    EXPECT_NE(table.find("**PASS**"), std::string::npos);
+}
+
+// -- Extra scenario in current is ignored -------------------------------------
+
+TEST(BaselineComparatorTest, ExtraScenarioIgnored) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.82, 0.87, 0.77, 82, 13, 18);
+    set_detection_metrics(current, "s2_extra", 0.50, 0.50, 0.50, 50, 50, 50);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_TRUE(result.passed);
+    EXPECT_EQ(result.scenarios_checked, 1U);
+}
+
+// -- Custom thresholds respected ----------------------------------------------
+
+TEST(BaselineComparatorTest, CustomThresholds) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    // 10% recall drop — fails with default 5%, passes with 15%.
+    set_detection_metrics(current, "s1", 0.72, 0.85, 0.75, 72, 15, 28);
+
+    ComparisonThresholds strict;
+    strict.recall_drop_pct = 0.05;
+    EXPECT_FALSE(compare_baselines(baseline, current, strict).passed);
+
+    ComparisonThresholds relaxed;
+    relaxed.recall_drop_pct = 0.15;
+    EXPECT_TRUE(compare_baselines(baseline, current, relaxed).passed);
+}
+
+// -- Tracking regression detected ---------------------------------------------
+
+TEST(BaselineComparatorTest, TrackingRegressionFails) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_tracking_metrics(baseline, "s1", 0.85, 0.78, 2);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "s1", 0.80, 0.85, 0.75, 80, 15, 20);
+    // MOTA drops from 0.85 to 0.70 — 17.6% drop, exceeds 5% threshold.
+    set_tracking_metrics(current, "s1", 0.70, 0.78, 2);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+}
+
+// -- Multiple scenarios — partial failure -------------------------------------
+
+TEST(BaselineComparatorTest, MultipleScenarioPartialFailure) {
+    BaselineCapture baseline;
+    set_detection_metrics(baseline, "good", 0.80, 0.85, 0.75, 80, 15, 20);
+    set_detection_metrics(baseline, "bad", 0.80, 0.85, 0.75, 80, 15, 20);
+
+    BaselineCapture current;
+    set_detection_metrics(current, "good", 0.82, 0.87, 0.77, 82, 13, 18);
+    // "bad" scenario has severe recall regression.
+    set_detection_metrics(current, "bad", 0.50, 0.85, 0.75, 50, 15, 50);
+
+    auto result = compare_baselines(baseline, current);
+    EXPECT_FALSE(result.passed);
+    EXPECT_EQ(result.scenarios_checked, 2U);
+
+    bool good_passed = false;
+    bool bad_failed  = false;
+    for (const auto& sc : result.scenarios) {
+        if (sc.scenario_name == "good" && sc.passed) good_passed = true;
+        if (sc.scenario_name == "bad" && !sc.passed) bad_failed = true;
+    }
+    EXPECT_TRUE(good_passed);
+    EXPECT_TRUE(bad_failed);
+}


### PR DESCRIPTION
## Summary

- **BaselineComparator** (`baseline_comparator.h/cpp`) — compares current benchmark run against `benchmarks/baseline.json` with configurable percentage thresholds: 5% for detection (recall, precision, mAP) and tracking (MOTA, MOTP), 20% for latency (per-stage p95)
- **CLI tool** (`compare_to_baseline`) — `--baseline <path> --current <path>` with per-metric threshold overrides, exit 0 (pass) or 1 (fail)
- **CI integration** — advisory baseline regression gate step in `ci-perception.yml` between perception run and PR comment
- **11 GTest cases** covering regression detection, improvement pass-through, within-threshold, missing scenario, zero-baseline skip, latency regression, format output, custom thresholds, tracking regression, partial failure

### Design decisions

- **Percentage-based relative thresholds** — "recall dropped 5%" is more intuitive than absolute thresholds
- **Zero-baseline skip** — `benchmarks/baseline.json` is currently all zeros; comparisons pass until real data is captured from Tier 2/3 runs
- **No raw count comparisons** (FP, id_switches) — too sensitive with percentage thresholds on small counts; already captured by precision/recall/MOTA
- **Coexists with cloud workflow** — `tests/perception_baseline.json` (flat format) serves a different purpose; the two systems are complementary

Test count: 1661 → 1672 (+11)

Closes #572

## Test plan

- [x] `bash deploy/build.sh` — zero warnings
- [x] `./build/bin/test_baseline_comparator` — 11/11 pass
- [x] `./build/bin/compare_to_baseline --baseline benchmarks/baseline.json --current benchmarks/baseline.json` — self-compare passes (all zeros skipped)
- [x] `ctest -N --test-dir build | grep "Total Tests:"` — 1672
- [x] `clang-format-18 --dry-run --Werror` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)