### PR TITLE
feat(#574): dashboard renderer — HTML/MD benchmark report

### DIFF
--- a/.github/workflows/ci-perception.yml
+++ b/.github/workflows/ci-perception.yml
@@ -46,6 +46,11 @@ jobs:
       SPOT_MAX_PRICE: "0.50"
       ARTIFACT_STORE_URL: ${{ vars.ARTIFACT_STORE_URL }}
       RUN_ID: "pr-${{ github.event.pull_request.number }}-${{ github.run_number }}"
+      # Canonical baseline path — used by both compare_to_baseline and dashboard_renderer.
+      # NOTE: Currently read from the PR branch checkout. Before promoting to a
+      # required check, pin to origin/main or an artifact store to prevent
+      # PR authors from weakening thresholds.
+      BASELINE_PATH: benchmarks/baseline.json
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +66,7 @@ jobs:
             DRY_RUN_FLAG="--dry-run"
           fi
           bash tests/run_perception_ci.sh \
-            --baseline tests/perception_baseline.json \
+            --baseline "$BASELINE_PATH" \
             --output /tmp/perception-results.json \
             $DRY_RUN_FLAG
         env:
@@ -75,13 +80,10 @@ jobs:
           # Compare structured baseline metrics if a current-run baseline exists.
           # The compare_to_baseline tool loads BaselineCapture JSON format.
           #
-          # NOTE: baseline is read from the PR branch checkout. Before promoting
-          # this to a required check, pin the baseline to the default branch or
-          # an artifact store to prevent PR authors from weakening thresholds.
           if [[ -f /tmp/current-run-baseline.json ]]; then
             echo "Running baseline comparison..."
             ./build/bin/compare_to_baseline \
-              --baseline benchmarks/baseline.json \
+              --baseline "$BASELINE_PATH" \
               --current /tmp/current-run-baseline.json \
               | tee /tmp/baseline-comparison.md
           else
@@ -94,7 +96,7 @@ jobs:
         run: |
           if [[ -f /tmp/current-run-baseline.json ]]; then
             python3 tests/benchmark/dashboard_renderer.py \
-              --baseline benchmarks/baseline.json \
+              --baseline "$BASELINE_PATH" \
               --current /tmp/current-run-baseline.json \
               --mode pr-comment \
               > /tmp/dashboard-comment.md || true
@@ -128,8 +130,8 @@ jobs:
                 }
                 body += `\n**Cost:** $${results.cost || 'N/A'} | **Duration:** ${results.duration_min || 'N/A'} min`;
               } catch (e) {
+                core.warning(`Perception results parse error: ${e.message}`);
                 body += 'Could not parse perception results. Check workflow logs.\n';
-                body += `Error: ${e.message}`;
               }
               body += '\n\n> Advisory check — does not block merge.';
             }

--- a/.github/workflows/ci-perception.yml
+++ b/.github/workflows/ci-perception.yml
@@ -88,35 +88,60 @@ jobs:
             echo "No current-run baseline found — skipping structured comparison"
           fi
 
+      - name: Generate benchmark dashboard
+        id: dashboard
+        if: always() && steps.perception.conclusion == 'success'
+        run: |
+          if [[ -f /tmp/current-run-baseline.json ]]; then
+            python3 tests/benchmark/dashboard_renderer.py \
+              --baseline benchmarks/baseline.json \
+              --current /tmp/current-run-baseline.json \
+              --mode pr-comment \
+              > /tmp/dashboard-comment.md || true
+          fi
+
       - name: Post results as PR comment
         if: always() && steps.perception.conclusion != 'skipped'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            let body = '## Perception Regression Results\n\n';
+            let body = '';
+
+            // Prefer the Python dashboard report when available.
             try {
-              const results = JSON.parse(fs.readFileSync('/tmp/perception-results.json', 'utf8'));
-              body += `| Metric | Baseline | Current | Delta | Status |\n`;
-              body += `|--------|----------|---------|-------|--------|\n`;
-              for (const [key, val] of Object.entries(results.metrics || {})) {
-                const safeKey = key.replace(/[|`<>\n\r]/g, '_');
-                const delta = (val.current - val.baseline).toFixed(3);
-                const status = val.passed ? '✅' : '⚠️';
-                body += `| ${safeKey} | ${val.baseline} | ${val.current} | ${delta} | ${status} |\n`;
+              body = fs.readFileSync('/tmp/dashboard-comment.md', 'utf8');
+            } catch (_) {}
+
+            // Fall back to inline rendering from the cloud GPU results.
+            if (!body) {
+              body = '## Perception Regression Results\n\n';
+              try {
+                const results = JSON.parse(fs.readFileSync('/tmp/perception-results.json', 'utf8'));
+                body += `| Metric | Baseline | Current | Delta | Status |\n`;
+                body += `|--------|----------|---------|-------|--------|\n`;
+                for (const [key, val] of Object.entries(results.metrics || {})) {
+                  const safeKey = key.replace(/[|`<>\n\r]/g, '_');
+                  const delta = (val.current - val.baseline).toFixed(3);
+                  const status = val.passed ? '✅' : '⚠️';
+                  body += `| ${safeKey} | ${val.baseline} | ${val.current} | ${delta} | ${status} |\n`;
+                }
+                body += `\n**Cost:** $${results.cost || 'N/A'} | **Duration:** ${results.duration_min || 'N/A'} min`;
+              } catch (e) {
+                body += 'Could not parse perception results. Check workflow logs.\n';
+                body += `Error: ${e.message}`;
               }
-              body += `\n**Cost:** $${results.cost || 'N/A'} | **Duration:** ${results.duration_min || 'N/A'} min`;
-            } catch (e) {
-              body += 'Could not parse perception results. Check workflow logs.\n';
-              body += `Error: ${e.message}`;
+              body += '\n\n> Advisory check — does not block merge.';
             }
-            body += '\n\n> Advisory check — does not block merge.';
 
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner, repo: context.repo.repo,
               issue_number: context.issue.number
             });
-            const existing = comments.data.find(c => c.body.includes('Perception Regression Results'));
+            const existing = comments.data.find(c =>
+              c.body.includes('Perception Benchmark Report') ||
+              c.body.includes('Perception Regression Results')
+            );
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner, repo: context.repo.repo,

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3248,4 +3248,29 @@ Also cherry-picked review fixes from PR #595 (`fe2e84a`): GT emitter config key 
 
 ---
 
-*Last updated after Improvement #79 (CI gating comparator, #572). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory.*
+### Improvement #80 — Dashboard renderer: HTML/MD benchmark report (Issue #574, Epic #523)
+
+**Date:** 2026-04-21
+
+**What:** Python dashboard renderer that reads BaselineCapture JSON files (baseline + current run) and produces human-readable Markdown reports. Two output modes: condensed PR comment (~50 lines with summary table, top 3 regressions/improvements) and full report (per-class breakdowns, latency stage tables, threshold config). Zero-dependency — uses only Python stdlib (`json`, `argparse`, `dataclasses`).
+
+**Files added:**
+
+- `tests/benchmark/dashboard_renderer.py` — CLI tool + rendering engine: `load_baseline()`, `compare_scenarios()`, `render_pr_comment()`, `render_full_report()`, `_top_changes()`
+- `tests/benchmark/test_dashboard_renderer.py` — 14 unittest cases: loading (valid/missing/invalid), comparison (improvement/regression/zero-skip/missing/latency), rendering (PR comment sections, missing scenario, full report detail, skipped scenarios), top-changes (sorting, skip exclusion)
+
+**Files modified:**
+
+- `.github/workflows/ci-perception.yml` — added dashboard generation step, updated PR comment to prefer dashboard output with inline fallback
+- `tests/TESTS.md` — suite entry + total count update
+- `docs/design/perception_v2_detailed_design.md` — sample report snippet
+
+**Why:** Closes out Epic #523 (Perception Benchmark Harness). The C++ `compare_to_baseline` tool is the CI gate (exit code 0/1); the Python dashboard is the human-readable layer that makes results accessible to non-ML engineers. Top 3 highlights surface the most impactful changes without requiring engineers to parse full metric tables.
+
+**Test count:** +14 Python tests in `test_dashboard_renderer.py`.
+
+**Universal acceptance criteria:** design doc updated; no license obligations change.
+
+---
+
+*Last updated after Improvement #80 (dashboard renderer, #574). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory.*

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -136,8 +136,8 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — GT Emitter](#test_gt_emittercpp--13-tests) | 1 | 13 | GtClassMap pattern match (exact / wildcard / first-wins); load-from-scenario-config (well-formed, missing, malformed); JSONL serialisation round-trip with quote-and-backslash escaping; review fixes: config key validation, error path coverage |
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
 | [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--21-tests) | 1 | 21 | Regression detection (recall/precision/mAP/MOTA/MOTP/latency), configurable thresholds, zero-baseline skip, missing scenario detection, boundary tests, latency defensive paths, format rendering, partial failure |
-| Benchmark — Dashboard Renderer | 4 | 14 | Baseline loading, scenario comparison (improvement/regression/zero-skip/missing), PR comment rendering, full report rendering, top-changes ranking |
-| **Total** | **77 C++ + 5 shell + 1 Python** | **1682 (no SDK) / 1723 (+SDK) + 42 + 14 + 250+** | |
+| Benchmark — Dashboard Renderer | 7 | 29 | Baseline loading (valid/missing/invalid/no-scenarios), scenario comparison (improvement/regression/boundary/zero-skip/missing/latency-string), PR comment rendering (sections/vacuous-warning/missing), full report rendering (detail/missing/skipped), top-changes ranking (higher/lower-is-better/skipped), latency deserialization, CLI main |
+| **Total** | **77 C++ + 5 shell + 1 Python** | **1682 (no SDK) / 1723 (+SDK) + 42 + 29 + 250+** | |
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -136,7 +136,8 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — GT Emitter](#test_gt_emittercpp--13-tests) | 1 | 13 | GtClassMap pattern match (exact / wildcard / first-wins); load-from-scenario-config (well-formed, missing, malformed); JSONL serialisation round-trip with quote-and-backslash escaping; review fixes: config key validation, error path coverage |
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
 | [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--21-tests) | 1 | 21 | Regression detection (recall/precision/mAP/MOTA/MOTP/latency), configurable thresholds, zero-baseline skip, missing scenario detection, boundary tests, latency defensive paths, format rendering, partial failure |
-| **Total** | **77 C++ + 5 shell** | **1682 (no SDK) / 1723 (+SDK) + 42 + 250+** | |
+| Benchmark — Dashboard Renderer | 4 | 14 | Baseline loading, scenario comparison (improvement/regression/zero-skip/missing), PR comment rendering, full report rendering, top-changes ranking |
+| **Total** | **77 C++ + 5 shell + 1 Python** | **1682 (no SDK) / 1723 (+SDK) + 42 + 14 + 250+** | |
 
 ---
 

--- a/tests/benchmark/dashboard_renderer.py
+++ b/tests/benchmark/dashboard_renderer.py
@@ -81,17 +81,19 @@ def load_baseline(path: str) -> Optional[dict]:
     return data
 
 
+_METRIC_TO_THRESHOLD_KEY = {
+    "micro_recall": "recall",
+    "micro_precision": "precision",
+    "mean_ap": "ap",
+    "mota": "mota",
+    "motp": "motp",
+}
+
+
 def _threshold_for(metric_name: str, thresholds: dict) -> float:
-    if metric_name == "micro_recall":
-        return thresholds.get("recall", 0.05)
-    if metric_name == "micro_precision":
-        return thresholds.get("precision", 0.05)
-    if metric_name == "mean_ap":
-        return thresholds.get("ap", 0.05)
-    if metric_name == "mota":
-        return thresholds.get("mota", 0.05)
-    if metric_name == "motp":
-        return thresholds.get("motp", 0.05)
+    key = _METRIC_TO_THRESHOLD_KEY.get(metric_name)
+    if key:
+        return thresholds.get(key, 0.05)
     if "latency" in metric_name:
         return thresholds.get("latency", 0.20)
     return 0.05
@@ -175,23 +177,24 @@ def compare_scenarios(baseline: dict, current: dict,
     return result
 
 
+def _deserialize_latency(val) -> Optional[dict]:
+    """Deserialize a latency value that may be a dict or JSON string."""
+    if val is None:
+        return None
+    if isinstance(val, str):
+        try:
+            val = json.loads(val)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    return val if isinstance(val, dict) else None
+
+
 def _compare_latency(bl_s: dict, cur_s: dict, thresholds: dict,
                      sc: ScenarioResult) -> None:
-    bl_lat = bl_s.get("latency")
-    cur_lat = cur_s.get("latency")
+    bl_lat = _deserialize_latency(bl_s.get("latency"))
+    cur_lat = _deserialize_latency(cur_s.get("latency"))
     if not bl_lat or not cur_lat:
         return
-
-    if isinstance(bl_lat, str):
-        try:
-            bl_lat = json.loads(bl_lat)
-        except (json.JSONDecodeError, TypeError):
-            return
-    if isinstance(cur_lat, str):
-        try:
-            cur_lat = json.loads(cur_lat)
-        except (json.JSONDecodeError, TypeError):
-            return
 
     bl_stages = bl_lat.get("stages", {})
     cur_stages = cur_lat.get("stages", {})
@@ -234,6 +237,13 @@ def _top_changes(result: ComparisonResult, n: int = 3):
     return regressions[:n], improvements[:n]
 
 
+def _sanitize_md(text: str) -> str:
+    """Strip characters that break Markdown table cells or enable injection."""
+    for ch in ("|", "`", "<", ">", "\n", "\r"):
+        text = text.replace(ch, "_")
+    return text
+
+
 def _fmt_val(val: float, name: str) -> str:
     if "latency" in name:
         ms = val / 1_000_000
@@ -247,8 +257,9 @@ def _fmt_delta(delta_pct: float) -> str:
 
 def _scenario_summary_row(sc: ScenarioResult) -> str:
     """Render one row of the summary table."""
+    safe_name = _sanitize_md(sc.name)
     if not sc.found_in_current:
-        return f"| {sc.name} | — | — | — | — | — | **MISSING** |"
+        return f"| {safe_name} | — | — | — | — | — | **MISSING** |"
 
     by_name: Dict[str, MetricDelta] = {m.name: m for m in sc.metrics}
 
@@ -262,13 +273,13 @@ def _scenario_summary_row(sc: ScenarioResult) -> str:
     lat_cell = cell(lat_key) if lat_key else "—"
 
     status = "\u2705" if sc.passed else "\u274c"
-    return (f"| {sc.name} | {cell('micro_recall')} | {cell('micro_precision')} "
+    return (f"| {safe_name} | {cell('micro_recall')} | {cell('micro_precision')} "
             f"| {cell('mean_ap')} | {cell('mota')} | {lat_cell} | {status} |")
 
 
 def render_pr_comment(result: ComparisonResult,
                       thresholds: Optional[dict] = None) -> str:
-    """Render a condensed ~50-line Markdown report for PR comments."""
+    """Render a condensed Markdown report (~50-60 lines) for PR comments."""
     if thresholds is None:
         thresholds = DEFAULT_THRESHOLDS
 
@@ -289,6 +300,14 @@ def render_pr_comment(result: ComparisonResult,
     for sc in result.scenarios:
         lines.append(_scenario_summary_row(sc))
 
+    if result.scenarios_checked > 0 and result.metrics_checked == 0:
+        lines.extend([
+            "",
+            "> \u26a0\ufe0f **All baseline metrics are zero (placeholder).** "
+            "No real comparison was performed. Populate baselines to enable "
+            "regression detection.",
+        ])
+
     regressions, improvements = _top_changes(result)
 
     lines.extend(["", "### Top Changes", ""])
@@ -299,7 +318,7 @@ def render_pr_comment(result: ComparisonResult,
     else:
         for i, (sname, m) in enumerate(regressions, 1):
             lines.append(
-                f"{i}. {sname} / {m.name}: "
+                f"{i}. {_sanitize_md(sname)} / {_sanitize_md(m.name)}: "
                 f"{_fmt_val(m.baseline, m.name)} \u2192 "
                 f"{_fmt_val(m.current, m.name)} ({_fmt_delta(m.delta_pct)})"
             )
@@ -311,17 +330,17 @@ def render_pr_comment(result: ComparisonResult,
     else:
         for i, (sname, m) in enumerate(improvements, 1):
             lines.append(
-                f"{i}. {sname} / {m.name}: "
+                f"{i}. {_sanitize_md(sname)} / {_sanitize_md(m.name)}: "
                 f"{_fmt_val(m.baseline, m.name)} \u2192 "
                 f"{_fmt_val(m.current, m.name)} ({_fmt_delta(m.delta_pct)})"
             )
 
-    acc_t = int(thresholds.get("recall", 0.05) * 100)
+    recall_t = int(thresholds.get("recall", 0.05) * 100)
     lat_t = int(thresholds.get("latency", 0.20) * 100)
     lines.extend([
         "",
         f"> Advisory \u2014 does not block merge. "
-        f"Thresholds: {acc_t}% accuracy, {lat_t}% latency.",
+        f"Thresholds: {recall_t}% recall, {lat_t}% latency.",
     ])
 
     return "\n".join(lines) + "\n"
@@ -339,7 +358,8 @@ def render_full_report(result: ComparisonResult, baseline: dict,
     parts.append("\n---\n\n### Detailed Breakdown\n")
 
     for sc in result.scenarios:
-        parts.append(f"\n#### {sc.name}\n")
+        safe_sc = _sanitize_md(sc.name)
+        parts.append(f"\n#### {safe_sc}\n")
 
         if not sc.found_in_current:
             parts.append("**Status:** MISSING in current run\n")
@@ -348,15 +368,16 @@ def render_full_report(result: ComparisonResult, baseline: dict,
         parts.append("| Metric | Baseline | Current | Delta | Threshold | Status |")
         parts.append("|--------|----------|---------|-------|-----------|--------|")
         for m in sc.metrics:
+            safe_m = _sanitize_md(m.name)
             if m.skipped:
                 parts.append(
-                    f"| {m.name} | {_fmt_val(m.baseline, m.name)} | "
+                    f"| {safe_m} | {_fmt_val(m.baseline, m.name)} | "
                     f"{_fmt_val(m.current, m.name)} | — | — | skipped |"
                 )
                 continue
             status = "PASS" if m.passed else "**FAIL**"
             parts.append(
-                f"| {m.name} | {_fmt_val(m.baseline, m.name)} | "
+                f"| {safe_m} | {_fmt_val(m.baseline, m.name)} | "
                 f"{_fmt_val(m.current, m.name)} | {_fmt_delta(m.delta_pct)} "
                 f"| {m.threshold_pct:.0f}% | {status} |"
             )
@@ -364,12 +385,14 @@ def render_full_report(result: ComparisonResult, baseline: dict,
         cur_s = current.get("scenarios", {}).get(sc.name, {})
         per_class = cur_s.get("per_class", [])
         if per_class:
-            parts.append(f"\n**Per-class breakdown ({sc.name}):**\n")
+            parts.append(f"\n**Per-class breakdown ({safe_sc}):**\n")
             parts.append("| Class | Precision | Recall | F1 | AP | Count |")
             parts.append("|-------|-----------|--------|----|----|-------|")
             for pc in per_class:
+                cls_name = _sanitize_md(
+                    str(pc.get('class_name', pc.get('class_id', '?'))))
                 parts.append(
-                    f"| {pc.get('class_name', pc.get('class_id', '?'))} "
+                    f"| {cls_name} "
                     f"| {pc.get('precision', 0):.2f} "
                     f"| {pc.get('recall', 0):.2f} "
                     f"| {pc.get('f1', 0):.2f} "
@@ -377,24 +400,21 @@ def render_full_report(result: ComparisonResult, baseline: dict,
                     f"| {pc.get('detection_count', 0)} |"
                 )
 
-        cur_lat = cur_s.get("latency")
-        if cur_lat:
-            if isinstance(cur_lat, str):
-                try:
-                    cur_lat = json.loads(cur_lat)
-                except (json.JSONDecodeError, TypeError):
-                    cur_lat = None
-            if cur_lat and "stages" in cur_lat:
-                parts.append(f"\n**Latency stages ({sc.name}):**\n")
-                parts.append("| Stage | p50 | p95 | p99 |")
-                parts.append("|-------|-----|-----|-----|")
-                for stage, vals in cur_lat["stages"].items():
-                    p50 = vals.get("p50_ns", 0) / 1_000_000
-                    p95 = vals.get("p95_ns", 0) / 1_000_000
-                    p99 = vals.get("p99_ns", 0) / 1_000_000
-                    parts.append(f"| {stage} | {p50:.1f}ms | {p95:.1f}ms | {p99:.1f}ms |")
+        cur_lat = _deserialize_latency(cur_s.get("latency"))
+        if cur_lat and "stages" in cur_lat:
+            parts.append(f"\n**Latency stages ({safe_sc}):**\n")
+            parts.append("| Stage | p50 | p95 | p99 |")
+            parts.append("|-------|-----|-----|-----|")
+            for stage, vals in cur_lat["stages"].items():
+                safe_stage = _sanitize_md(stage)
+                p50 = vals.get("p50_ns", 0) / 1_000_000
+                p95 = vals.get("p95_ns", 0) / 1_000_000
+                p99 = vals.get("p99_ns", 0) / 1_000_000
+                parts.append(
+                    f"| {safe_stage} | {p50:.1f}ms | {p95:.1f}ms "
+                    f"| {p99:.1f}ms |")
 
-    parts.append(f"\n### Thresholds\n")
+    parts.append("\n### Thresholds\n")
     parts.append("| Metric | Threshold |")
     parts.append("|--------|-----------|")
     for k, v in thresholds.items():
@@ -428,10 +448,15 @@ def main():
     if args.thresholds:
         try:
             overrides = json.loads(args.thresholds)
-            thresholds.update(overrides)
         except json.JSONDecodeError as e:
             print(f"Error: invalid thresholds JSON: {e}", file=sys.stderr)
             return 2
+        for k, v in overrides.items():
+            if not isinstance(v, (int, float)) or v <= 0.0 or v > 1.0:
+                print(f"Error: threshold '{k}' must be in (0.0, 1.0], "
+                      f"got {v}", file=sys.stderr)
+                return 2
+        thresholds.update(overrides)
 
     result = compare_scenarios(baseline, current, thresholds)
 

--- a/tests/benchmark/dashboard_renderer.py
+++ b/tests/benchmark/dashboard_renderer.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Perception benchmark dashboard renderer.
+
+Reads BaselineCapture JSON files (baseline + current run) and produces a
+human-readable Markdown report for PR comments or standalone viewing.
+
+Usage:
+    python3 tests/benchmark/dashboard_renderer.py \\
+        --baseline benchmarks/baseline.json \\
+        --current /tmp/current-run-baseline.json \\
+        --mode pr-comment
+
+    python3 tests/benchmark/dashboard_renderer.py \\
+        --baseline benchmarks/baseline.json \\
+        --current /tmp/current-run-baseline.json \\
+        --mode full
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+DEFAULT_THRESHOLDS = {
+    "recall": 0.05,
+    "precision": 0.05,
+    "ap": 0.05,
+    "mota": 0.05,
+    "motp": 0.05,
+    "latency": 0.20,
+}
+
+HIGHER_IS_BETTER = {"micro_recall", "micro_precision", "mean_ap", "mota", "motp"}
+
+
+@dataclass
+class MetricDelta:
+    name: str
+    baseline: float
+    current: float
+    delta_pct: float = 0.0
+    threshold_pct: float = 0.0
+    passed: bool = True
+    skipped: bool = False
+    direction: str = "higher_is_better"
+
+
+@dataclass
+class ScenarioResult:
+    name: str
+    passed: bool = True
+    found_in_current: bool = True
+    metrics: List[MetricDelta] = field(default_factory=list)
+
+
+@dataclass
+class ComparisonResult:
+    passed: bool = True
+    scenarios: List[ScenarioResult] = field(default_factory=list)
+    scenarios_checked: int = 0
+    metrics_checked: int = 0
+    metrics_failed: int = 0
+
+
+def load_baseline(path: str) -> Optional[dict]:
+    """Load and validate a BaselineCapture JSON file."""
+    p = Path(path)
+    if not p.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        return None
+    try:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON in {path}: {e}", file=sys.stderr)
+        return None
+    if "scenarios" not in data:
+        print(f"Error: missing 'scenarios' key in {path}", file=sys.stderr)
+        return None
+    return data
+
+
+def _threshold_for(metric_name: str, thresholds: dict) -> float:
+    if metric_name == "micro_recall":
+        return thresholds.get("recall", 0.05)
+    if metric_name == "micro_precision":
+        return thresholds.get("precision", 0.05)
+    if metric_name == "mean_ap":
+        return thresholds.get("ap", 0.05)
+    if metric_name == "mota":
+        return thresholds.get("mota", 0.05)
+    if metric_name == "motp":
+        return thresholds.get("motp", 0.05)
+    if "latency" in metric_name:
+        return thresholds.get("latency", 0.20)
+    return 0.05
+
+
+def _check_metric(name: str, baseline_val: float, current_val: float,
+                  threshold: float) -> MetricDelta:
+    higher = name in HIGHER_IS_BETTER
+    direction = "higher_is_better" if higher else "lower_is_better"
+
+    if baseline_val == 0.0:
+        return MetricDelta(name=name, baseline=baseline_val, current=current_val,
+                           skipped=True, direction=direction,
+                           threshold_pct=threshold * 100.0)
+
+    delta_pct = (current_val - baseline_val) / baseline_val * 100.0
+    if higher:
+        passed = current_val >= baseline_val * (1.0 - threshold)
+    else:
+        passed = current_val <= baseline_val * (1.0 + threshold)
+
+    return MetricDelta(name=name, baseline=baseline_val, current=current_val,
+                       delta_pct=delta_pct, threshold_pct=threshold * 100.0,
+                       passed=passed, direction=direction)
+
+
+def compare_scenarios(baseline: dict, current: dict,
+                      thresholds: Optional[dict] = None) -> ComparisonResult:
+    """Compare baseline vs current run, producing per-scenario results."""
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS
+
+    result = ComparisonResult()
+    bl_scenarios = baseline.get("scenarios", {})
+    cur_scenarios = current.get("scenarios", {})
+
+    for name, bl_s in bl_scenarios.items():
+        sc = ScenarioResult(name=name)
+        result.scenarios_checked += 1
+
+        if name not in cur_scenarios:
+            sc.found_in_current = False
+            sc.passed = False
+            result.passed = False
+            result.scenarios.append(sc)
+            continue
+
+        cur_s = cur_scenarios[name]
+        sc.found_in_current = True
+
+        bl_det = bl_s.get("detection", {})
+        cur_det = cur_s.get("detection", {})
+        for metric in ["micro_recall", "micro_precision", "mean_ap"]:
+            t = _threshold_for(metric, thresholds)
+            m = _check_metric(metric, bl_det.get(metric, 0.0),
+                              cur_det.get(metric, 0.0), t)
+            sc.metrics.append(m)
+
+        bl_trk = bl_s.get("tracking", {})
+        cur_trk = cur_s.get("tracking", {})
+        for metric in ["mota", "motp"]:
+            t = _threshold_for(metric, thresholds)
+            m = _check_metric(metric, bl_trk.get(metric, 0.0),
+                              cur_trk.get(metric, 0.0), t)
+            sc.metrics.append(m)
+
+        _compare_latency(bl_s, cur_s, thresholds, sc)
+
+        for m in sc.metrics:
+            if not m.skipped:
+                result.metrics_checked += 1
+            if not m.passed:
+                sc.passed = False
+                result.metrics_failed += 1
+
+        if not sc.passed:
+            result.passed = False
+
+        result.scenarios.append(sc)
+
+    return result
+
+
+def _compare_latency(bl_s: dict, cur_s: dict, thresholds: dict,
+                     sc: ScenarioResult) -> None:
+    bl_lat = bl_s.get("latency")
+    cur_lat = cur_s.get("latency")
+    if not bl_lat or not cur_lat:
+        return
+
+    if isinstance(bl_lat, str):
+        try:
+            bl_lat = json.loads(bl_lat)
+        except (json.JSONDecodeError, TypeError):
+            return
+    if isinstance(cur_lat, str):
+        try:
+            cur_lat = json.loads(cur_lat)
+        except (json.JSONDecodeError, TypeError):
+            return
+
+    bl_stages = bl_lat.get("stages", {})
+    cur_stages = cur_lat.get("stages", {})
+    threshold = thresholds.get("latency", 0.20)
+
+    for stage_name, bl_stage in bl_stages.items():
+        if stage_name not in cur_stages:
+            continue
+        cur_stage = cur_stages[stage_name]
+        bl_p95 = bl_stage.get("p95_ns", 0.0)
+        cur_p95 = cur_stage.get("p95_ns", 0.0)
+        metric_name = f"latency.{stage_name}.p95_ns"
+        sc.metrics.append(_check_metric(metric_name, bl_p95, cur_p95, threshold))
+
+
+def _top_changes(result: ComparisonResult, n: int = 3):
+    """Extract top N regressions and improvements by absolute delta."""
+    regressions = []
+    improvements = []
+    for sc in result.scenarios:
+        if not sc.found_in_current:
+            continue
+        for m in sc.metrics:
+            if m.skipped:
+                continue
+            entry = (sc.name, m)
+            if m.direction == "higher_is_better":
+                if m.delta_pct < 0:
+                    regressions.append(entry)
+                elif m.delta_pct > 0:
+                    improvements.append(entry)
+            else:
+                if m.delta_pct > 0:
+                    regressions.append(entry)
+                elif m.delta_pct < 0:
+                    improvements.append(entry)
+
+    regressions.sort(key=lambda x: abs(x[1].delta_pct), reverse=True)
+    improvements.sort(key=lambda x: abs(x[1].delta_pct), reverse=True)
+    return regressions[:n], improvements[:n]
+
+
+def _fmt_val(val: float, name: str) -> str:
+    if "latency" in name:
+        ms = val / 1_000_000
+        return f"{ms:.1f}ms"
+    return f"{val:.2f}"
+
+
+def _fmt_delta(delta_pct: float) -> str:
+    return f"{delta_pct:+.1f}%"
+
+
+def _scenario_summary_row(sc: ScenarioResult) -> str:
+    """Render one row of the summary table."""
+    if not sc.found_in_current:
+        return f"| {sc.name} | — | — | — | — | — | **MISSING** |"
+
+    by_name: Dict[str, MetricDelta] = {m.name: m for m in sc.metrics}
+
+    def cell(metric_name: str) -> str:
+        m = by_name.get(metric_name)
+        if m is None or m.skipped:
+            return "—"
+        return f"{_fmt_val(m.current, metric_name)} ({_fmt_delta(m.delta_pct)})"
+
+    lat_key = next((k for k in by_name if k.startswith("latency.")), None)
+    lat_cell = cell(lat_key) if lat_key else "—"
+
+    status = "\u2705" if sc.passed else "\u274c"
+    return (f"| {sc.name} | {cell('micro_recall')} | {cell('micro_precision')} "
+            f"| {cell('mean_ap')} | {cell('mota')} | {lat_cell} | {status} |")
+
+
+def render_pr_comment(result: ComparisonResult,
+                      thresholds: Optional[dict] = None) -> str:
+    """Render a condensed ~50-line Markdown report for PR comments."""
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS
+
+    status = "PASS" if result.passed else "FAIL"
+    lines = [
+        "## Perception Benchmark Report",
+        "",
+        f"**Result: {status}** ({result.scenarios_checked} scenario(s), "
+        f"{result.metrics_checked} metric(s) checked, "
+        f"{result.metrics_failed} failed)",
+        "",
+        "### Summary",
+        "",
+        "| Scenario | Recall | Precision | mAP | MOTA | Latency p95 | Status |",
+        "|----------|--------|-----------|-----|------|-------------|--------|",
+    ]
+
+    for sc in result.scenarios:
+        lines.append(_scenario_summary_row(sc))
+
+    regressions, improvements = _top_changes(result)
+
+    lines.extend(["", "### Top Changes", ""])
+
+    lines.append(f"\U0001f534 **Regressions ({len(regressions)})**")
+    if not regressions:
+        lines.append("None")
+    else:
+        for i, (sname, m) in enumerate(regressions, 1):
+            lines.append(
+                f"{i}. {sname} / {m.name}: "
+                f"{_fmt_val(m.baseline, m.name)} \u2192 "
+                f"{_fmt_val(m.current, m.name)} ({_fmt_delta(m.delta_pct)})"
+            )
+
+    lines.append("")
+    lines.append(f"\U0001f7e2 **Improvements ({len(improvements)})**")
+    if not improvements:
+        lines.append("None")
+    else:
+        for i, (sname, m) in enumerate(improvements, 1):
+            lines.append(
+                f"{i}. {sname} / {m.name}: "
+                f"{_fmt_val(m.baseline, m.name)} \u2192 "
+                f"{_fmt_val(m.current, m.name)} ({_fmt_delta(m.delta_pct)})"
+            )
+
+    acc_t = int(thresholds.get("recall", 0.05) * 100)
+    lat_t = int(thresholds.get("latency", 0.20) * 100)
+    lines.extend([
+        "",
+        f"> Advisory \u2014 does not block merge. "
+        f"Thresholds: {acc_t}% accuracy, {lat_t}% latency.",
+    ])
+
+    return "\n".join(lines) + "\n"
+
+
+def render_full_report(result: ComparisonResult, baseline: dict,
+                       current: dict,
+                       thresholds: Optional[dict] = None) -> str:
+    """Render a detailed report with per-class and latency breakdowns."""
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS
+
+    parts = [render_pr_comment(result, thresholds)]
+
+    parts.append("\n---\n\n### Detailed Breakdown\n")
+
+    for sc in result.scenarios:
+        parts.append(f"\n#### {sc.name}\n")
+
+        if not sc.found_in_current:
+            parts.append("**Status:** MISSING in current run\n")
+            continue
+
+        parts.append("| Metric | Baseline | Current | Delta | Threshold | Status |")
+        parts.append("|--------|----------|---------|-------|-----------|--------|")
+        for m in sc.metrics:
+            if m.skipped:
+                parts.append(
+                    f"| {m.name} | {_fmt_val(m.baseline, m.name)} | "
+                    f"{_fmt_val(m.current, m.name)} | — | — | skipped |"
+                )
+                continue
+            status = "PASS" if m.passed else "**FAIL**"
+            parts.append(
+                f"| {m.name} | {_fmt_val(m.baseline, m.name)} | "
+                f"{_fmt_val(m.current, m.name)} | {_fmt_delta(m.delta_pct)} "
+                f"| {m.threshold_pct:.0f}% | {status} |"
+            )
+
+        cur_s = current.get("scenarios", {}).get(sc.name, {})
+        per_class = cur_s.get("per_class", [])
+        if per_class:
+            parts.append(f"\n**Per-class breakdown ({sc.name}):**\n")
+            parts.append("| Class | Precision | Recall | F1 | AP | Count |")
+            parts.append("|-------|-----------|--------|----|----|-------|")
+            for pc in per_class:
+                parts.append(
+                    f"| {pc.get('class_name', pc.get('class_id', '?'))} "
+                    f"| {pc.get('precision', 0):.2f} "
+                    f"| {pc.get('recall', 0):.2f} "
+                    f"| {pc.get('f1', 0):.2f} "
+                    f"| {pc.get('ap', 0):.2f} "
+                    f"| {pc.get('detection_count', 0)} |"
+                )
+
+        cur_lat = cur_s.get("latency")
+        if cur_lat:
+            if isinstance(cur_lat, str):
+                try:
+                    cur_lat = json.loads(cur_lat)
+                except (json.JSONDecodeError, TypeError):
+                    cur_lat = None
+            if cur_lat and "stages" in cur_lat:
+                parts.append(f"\n**Latency stages ({sc.name}):**\n")
+                parts.append("| Stage | p50 | p95 | p99 |")
+                parts.append("|-------|-----|-----|-----|")
+                for stage, vals in cur_lat["stages"].items():
+                    p50 = vals.get("p50_ns", 0) / 1_000_000
+                    p95 = vals.get("p95_ns", 0) / 1_000_000
+                    p99 = vals.get("p99_ns", 0) / 1_000_000
+                    parts.append(f"| {stage} | {p50:.1f}ms | {p95:.1f}ms | {p99:.1f}ms |")
+
+    parts.append(f"\n### Thresholds\n")
+    parts.append("| Metric | Threshold |")
+    parts.append("|--------|-----------|")
+    for k, v in thresholds.items():
+        parts.append(f"| {k} | {v * 100:.0f}% |")
+
+    return "\n".join(parts) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Perception benchmark dashboard renderer")
+    parser.add_argument("--baseline", required=True,
+                        help="Path to baseline JSON")
+    parser.add_argument("--current", required=True,
+                        help="Path to current run JSON")
+    parser.add_argument("--mode", choices=["pr-comment", "full"],
+                        default="pr-comment",
+                        help="Output mode (default: pr-comment)")
+    parser.add_argument("--thresholds", default=None,
+                        help="JSON string of threshold overrides")
+    args = parser.parse_args()
+
+    baseline = load_baseline(args.baseline)
+    if baseline is None:
+        return 2
+    current = load_baseline(args.current)
+    if current is None:
+        return 2
+
+    thresholds = dict(DEFAULT_THRESHOLDS)
+    if args.thresholds:
+        try:
+            overrides = json.loads(args.thresholds)
+            thresholds.update(overrides)
+        except json.JSONDecodeError as e:
+            print(f"Error: invalid thresholds JSON: {e}", file=sys.stderr)
+            return 2
+
+    result = compare_scenarios(baseline, current, thresholds)
+
+    if args.mode == "pr-comment":
+        print(render_pr_comment(result, thresholds), end="")
+    else:
+        print(render_full_report(result, baseline, current, thresholds), end="")
+
+    return 0 if result.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_dashboard_renderer.py
+++ b/tests/benchmark/test_dashboard_renderer.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Unit tests for dashboard_renderer.py (Issue #574, Epic #523)."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from dashboard_renderer import (
+    ComparisonResult,
+    MetricDelta,
+    ScenarioResult,
+    _top_changes,
+    compare_scenarios,
+    load_baseline,
+    render_full_report,
+    render_pr_comment,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+BASELINE_PATH = os.path.join(REPO_ROOT, "benchmarks", "baseline.json")
+
+
+def _make_scenario(name, recall=0.8, precision=0.85, mean_ap=0.75,
+                   mota=0.8, motp=0.75, tp=80, fp=15, fn=20,
+                   latency=None, per_class=None):
+    s = {
+        "frame_count": tp + fn,
+        "iou_threshold": 0.5,
+        "num_classes": 2,
+        "detection": {
+            "total_tp": tp, "total_fp": fp, "total_fn": fn,
+            "micro_recall": recall, "micro_precision": precision,
+            "mean_ap": mean_ap,
+        },
+        "per_class": per_class or [],
+        "tracking": {"mota": mota, "motp": motp, "id_switches": 0,
+                      "fragmentations": 0},
+    }
+    if latency is not None:
+        s["latency"] = latency
+    return s
+
+
+def _wrap(scenarios):
+    return {"version": 1, "scenarios": scenarios}
+
+
+class TestLoadBaseline(unittest.TestCase):
+
+    def test_load_valid_baseline(self):
+        if not os.path.exists(BASELINE_PATH):
+            self.skipTest("benchmarks/baseline.json not found")
+        data = load_baseline(BASELINE_PATH)
+        self.assertIsNotNone(data)
+        self.assertIn("scenarios", data)
+        self.assertIn("version", data)
+
+    def test_load_missing_file(self):
+        result = load_baseline("/nonexistent/path.json")
+        self.assertIsNone(result)
+
+    def test_load_invalid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
+                                         delete=False) as f:
+            f.write("{not valid json}")
+            f.flush()
+            result = load_baseline(f.name)
+        os.unlink(f.name)
+        self.assertIsNone(result)
+
+
+class TestCompareScenarios(unittest.TestCase):
+
+    def test_improvement_passes(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.80)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.90)})
+        result = compare_scenarios(baseline, current)
+        self.assertTrue(result.passed)
+        self.assertEqual(result.metrics_failed, 0)
+        self.assertGreater(result.metrics_checked, 0)
+
+    def test_regression_fails(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.80)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.70)})
+        result = compare_scenarios(baseline, current)
+        self.assertFalse(result.passed)
+        self.assertGreaterEqual(result.metrics_failed, 1)
+
+    def test_zero_baseline_skipped(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.0,
+                                                precision=0.0, mean_ap=0.0,
+                                                mota=0.0, motp=0.0)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.5)})
+        result = compare_scenarios(baseline, current)
+        self.assertTrue(result.passed)
+
+    def test_missing_scenario_fails(self):
+        baseline = _wrap({"expected": _make_scenario("expected")})
+        current = _wrap({"other": _make_scenario("other")})
+        result = compare_scenarios(baseline, current)
+        self.assertFalse(result.passed)
+        self.assertFalse(result.scenarios[0].found_in_current)
+
+    def test_latency_regression(self):
+        lat_bl = {"stages": {"detector": {"p95_ns": 5000000}}}
+        lat_cur = {"stages": {"detector": {"p95_ns": 6500000}}}
+        baseline = _wrap({"s1": _make_scenario("s1", latency=lat_bl)})
+        current = _wrap({"s1": _make_scenario("s1", latency=lat_cur)})
+        result = compare_scenarios(baseline, current)
+        latency_failed = any(
+            m.name.startswith("latency.") and not m.passed
+            for sc in result.scenarios for m in sc.metrics
+        )
+        self.assertTrue(latency_failed)
+
+
+class TestRender(unittest.TestCase):
+
+    def test_pr_comment_contains_sections(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.80)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.82)})
+        result = compare_scenarios(baseline, current)
+        output = render_pr_comment(result)
+        self.assertIn("## Perception Benchmark Report", output)
+        self.assertIn("### Summary", output)
+        self.assertIn("### Top Changes", output)
+        self.assertIn("Advisory", output)
+        line_count = len(output.strip().split("\n"))
+        self.assertLessEqual(line_count, 60)
+
+    def test_pr_comment_missing_scenario(self):
+        baseline = _wrap({"absent": _make_scenario("absent")})
+        current = _wrap({"other": _make_scenario("other")})
+        result = compare_scenarios(baseline, current)
+        output = render_pr_comment(result)
+        self.assertIn("**MISSING**", output)
+        self.assertIn("FAIL", output)
+
+    def test_full_report_has_detail(self):
+        per_class = [{"class_id": 0, "class_name": "drone",
+                      "precision": 0.9, "recall": 0.85, "f1": 0.87,
+                      "ap": 0.82, "detection_count": 50, "tp": 42,
+                      "fp": 5, "fn": 8}]
+        lat = {"stages": {"detector": {"p50_ns": 3e6, "p95_ns": 5e6,
+                                        "p99_ns": 7e6}}}
+        baseline = _wrap({"s1": _make_scenario("s1", latency=lat,
+                                                per_class=per_class)})
+        current = _wrap({"s1": _make_scenario("s1", latency=lat,
+                                               per_class=per_class)})
+        result = compare_scenarios(baseline, current)
+        output = render_full_report(result, baseline, current)
+        self.assertIn("### Detailed Breakdown", output)
+        self.assertIn("Per-class breakdown", output)
+        self.assertIn("Latency stages", output)
+        self.assertIn("### Thresholds", output)
+        self.assertIn("drone", output)
+
+    def test_full_report_skipped_scenarios(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.0,
+                                                precision=0.0, mean_ap=0.0,
+                                                mota=0.0, motp=0.0)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.5)})
+        result = compare_scenarios(baseline, current)
+        output = render_full_report(result, baseline, current)
+        self.assertIn("skipped", output)
+
+
+class TestTopChanges(unittest.TestCase):
+
+    def test_top_changes_sorted(self):
+        result = ComparisonResult(scenarios=[
+            ScenarioResult(name="s1", metrics=[
+                MetricDelta(name="micro_recall", baseline=0.80, current=0.90,
+                            delta_pct=12.5, direction="higher_is_better"),
+                MetricDelta(name="micro_precision", baseline=0.85,
+                            current=0.87, delta_pct=2.4,
+                            direction="higher_is_better"),
+                MetricDelta(name="mean_ap", baseline=0.75, current=0.70,
+                            delta_pct=-6.7, direction="higher_is_better"),
+            ])
+        ])
+        regressions, improvements = _top_changes(result, n=3)
+        self.assertEqual(len(regressions), 1)
+        self.assertEqual(regressions[0][1].name, "mean_ap")
+        self.assertEqual(len(improvements), 2)
+        self.assertEqual(improvements[0][1].name, "micro_recall")
+
+    def test_top_changes_skipped_excluded(self):
+        result = ComparisonResult(scenarios=[
+            ScenarioResult(name="s1", metrics=[
+                MetricDelta(name="micro_recall", baseline=0.0, current=0.5,
+                            delta_pct=0.0, skipped=True,
+                            direction="higher_is_better"),
+            ])
+        ])
+        regressions, improvements = _top_changes(result)
+        self.assertEqual(len(regressions), 0)
+        self.assertEqual(len(improvements), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/benchmark/test_dashboard_renderer.py
+++ b/tests/benchmark/test_dashboard_renderer.py
@@ -12,6 +12,7 @@ from dashboard_renderer import (
     ComparisonResult,
     MetricDelta,
     ScenarioResult,
+    _deserialize_latency,
     _top_changes,
     compare_scenarios,
     load_baseline,
@@ -51,12 +52,22 @@ def _wrap(scenarios):
 class TestLoadBaseline(unittest.TestCase):
 
     def test_load_valid_baseline(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
+                                         delete=False) as f:
+            json.dump({"version": 1, "scenarios": {"s1": {}}}, f)
+            f.flush()
+            data = load_baseline(f.name)
+        os.unlink(f.name)
+        self.assertIsNotNone(data)
+        self.assertIn("scenarios", data)
+        self.assertIn("version", data)
+
+    def test_load_real_baseline(self):
         if not os.path.exists(BASELINE_PATH):
             self.skipTest("benchmarks/baseline.json not found")
         data = load_baseline(BASELINE_PATH)
         self.assertIsNotNone(data)
         self.assertIn("scenarios", data)
-        self.assertIn("version", data)
 
     def test_load_missing_file(self):
         result = load_baseline("/nonexistent/path.json")
@@ -66,6 +77,15 @@ class TestLoadBaseline(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
                                          delete=False) as f:
             f.write("{not valid json}")
+            f.flush()
+            result = load_baseline(f.name)
+        os.unlink(f.name)
+        self.assertIsNone(result)
+
+    def test_load_missing_scenarios_key(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
+                                         delete=False) as f:
+            json.dump({"version": 1}, f)
             f.flush()
             result = load_baseline(f.name)
         os.unlink(f.name)
@@ -104,17 +124,47 @@ class TestCompareScenarios(unittest.TestCase):
         self.assertFalse(result.passed)
         self.assertFalse(result.scenarios[0].found_in_current)
 
+    def test_exact_boundary_passes(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.80)})
+        boundary = 0.80 * (1.0 - 0.05)  # exactly at threshold
+        current = _wrap({"s1": _make_scenario("s1", recall=boundary)})
+        result = compare_scenarios(baseline, current)
+        self.assertTrue(result.passed)
+
+    def test_below_boundary_fails(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.80)})
+        below = 0.80 * (1.0 - 0.05) - 0.0001
+        current = _wrap({"s1": _make_scenario("s1", recall=below)})
+        result = compare_scenarios(baseline, current)
+        self.assertFalse(result.passed)
+        self.assertGreaterEqual(result.metrics_failed, 1)
+
     def test_latency_regression(self):
         lat_bl = {"stages": {"detector": {"p95_ns": 5000000}}}
         lat_cur = {"stages": {"detector": {"p95_ns": 6500000}}}
         baseline = _wrap({"s1": _make_scenario("s1", latency=lat_bl)})
         current = _wrap({"s1": _make_scenario("s1", latency=lat_cur)})
         result = compare_scenarios(baseline, current)
+        self.assertFalse(result.passed)
+        self.assertGreaterEqual(result.metrics_failed, 1)
         latency_failed = any(
             m.name.startswith("latency.") and not m.passed
             for sc in result.scenarios for m in sc.metrics
         )
         self.assertTrue(latency_failed)
+
+    def test_latency_as_json_string(self):
+        lat_bl = json.dumps({"stages": {"detector": {"p95_ns": 5000000}}})
+        lat_cur = json.dumps({"stages": {"detector": {"p95_ns": 6500000}}})
+        baseline = _wrap({"s1": _make_scenario("s1", latency=lat_bl)})
+        current = _wrap({"s1": _make_scenario("s1", latency=lat_cur)})
+        result = compare_scenarios(baseline, current)
+        self.assertFalse(result.passed)
+        latency_metrics = [
+            m for sc in result.scenarios for m in sc.metrics
+            if m.name.startswith("latency.")
+        ]
+        self.assertGreater(len(latency_metrics), 0)
 
 
 class TestRender(unittest.TestCase):
@@ -130,6 +180,15 @@ class TestRender(unittest.TestCase):
         self.assertIn("Advisory", output)
         line_count = len(output.strip().split("\n"))
         self.assertLessEqual(line_count, 60)
+
+    def test_pr_comment_vacuous_pass_warning(self):
+        baseline = _wrap({"s1": _make_scenario("s1", recall=0.0,
+                                                precision=0.0, mean_ap=0.0,
+                                                mota=0.0, motp=0.0)})
+        current = _wrap({"s1": _make_scenario("s1", recall=0.5)})
+        result = compare_scenarios(baseline, current)
+        output = render_pr_comment(result)
+        self.assertIn("All baseline metrics are zero", output)
 
     def test_pr_comment_missing_scenario(self):
         baseline = _wrap({"absent": _make_scenario("absent")})
@@ -157,6 +216,14 @@ class TestRender(unittest.TestCase):
         self.assertIn("Latency stages", output)
         self.assertIn("### Thresholds", output)
         self.assertIn("drone", output)
+
+    def test_full_report_missing_scenario(self):
+        baseline = _wrap({"absent": _make_scenario("absent")})
+        current = _wrap({"other": _make_scenario("other")})
+        result = compare_scenarios(baseline, current)
+        output = render_full_report(result, baseline, current)
+        self.assertIn("MISSING", output)
+        self.assertIn("absent", output)
 
     def test_full_report_skipped_scenarios(self):
         baseline = _wrap({"s1": _make_scenario("s1", recall=0.0,
@@ -188,6 +255,23 @@ class TestTopChanges(unittest.TestCase):
         self.assertEqual(len(improvements), 2)
         self.assertEqual(improvements[0][1].name, "micro_recall")
 
+    def test_top_changes_lower_is_better(self):
+        result = ComparisonResult(scenarios=[
+            ScenarioResult(name="s1", metrics=[
+                MetricDelta(name="latency.detector.p95_ns", baseline=5e6,
+                            current=6.5e6, delta_pct=30.0,
+                            direction="lower_is_better"),
+                MetricDelta(name="latency.tracker.p95_ns", baseline=3e6,
+                            current=2e6, delta_pct=-33.3,
+                            direction="lower_is_better"),
+            ])
+        ])
+        regressions, improvements = _top_changes(result, n=3)
+        self.assertEqual(len(regressions), 1)
+        self.assertEqual(regressions[0][1].name, "latency.detector.p95_ns")
+        self.assertEqual(len(improvements), 1)
+        self.assertEqual(improvements[0][1].name, "latency.tracker.p95_ns")
+
     def test_top_changes_skipped_excluded(self):
         result = ComparisonResult(scenarios=[
             ScenarioResult(name="s1", metrics=[
@@ -199,6 +283,58 @@ class TestTopChanges(unittest.TestCase):
         regressions, improvements = _top_changes(result)
         self.assertEqual(len(regressions), 0)
         self.assertEqual(len(improvements), 0)
+
+
+class TestDeserializeLatency(unittest.TestCase):
+
+    def test_dict_passthrough(self):
+        val = {"stages": {"det": {"p95_ns": 5e6}}}
+        self.assertEqual(_deserialize_latency(val), val)
+
+    def test_json_string(self):
+        val = json.dumps({"stages": {"det": {"p95_ns": 5e6}}})
+        result = _deserialize_latency(val)
+        self.assertIsNotNone(result)
+        self.assertIn("stages", result)
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_deserialize_latency(None))
+
+    def test_invalid_string_returns_none(self):
+        self.assertIsNone(_deserialize_latency("{bad json"))
+
+    def test_non_dict_returns_none(self):
+        self.assertIsNone(_deserialize_latency(42))
+
+
+class TestMain(unittest.TestCase):
+
+    def test_missing_baseline_returns_2(self):
+        import subprocess
+        script = os.path.join(os.path.dirname(__file__), "dashboard_renderer.py")
+        proc = subprocess.run(
+            [sys.executable, script, "--baseline", "/nonexistent",
+             "--current", "/nonexistent"],
+            capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 2)
+
+    def test_invalid_threshold_returns_2(self):
+        import subprocess
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
+                                         delete=False) as bl:
+            json.dump(_wrap({"s1": _make_scenario("s1")}), bl)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json",
+                                         delete=False) as cur:
+            json.dump(_wrap({"s1": _make_scenario("s1")}), cur)
+        script = os.path.join(os.path.dirname(__file__), "dashboard_renderer.py")
+        proc = subprocess.run(
+            [sys.executable, script, "--baseline", bl.name,
+             "--current", cur.name,
+             "--thresholds", '{"recall": -5.0}'],
+            capture_output=True, text=True)
+        os.unlink(bl.name)
+        os.unlink(cur.name)
+        self.assertEqual(proc.returncode, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Zero-dependency Python dashboard renderer (`tests/benchmark/dashboard_renderer.py`) that produces human-readable benchmark reports from BaselineCapture JSON — completes Epic #523 (Perception Benchmark Harness)
- Two output modes: `--mode pr-comment` (~50 lines for GitHub PR comments with summary table + top-3 changes) and `--mode full` (per-class breakdowns, latency stage tables, threshold config)
- CI integration: new "Generate benchmark dashboard" step in `ci-perception.yml` with graceful fallback to existing inline JS renderer

## Details

Mirrors the C++ `compare_to_baseline` comparison logic (same threshold rules, zero-skip, missing-scenario detection) but adds:
- Top-3 regression and improvement highlights sorted by absolute delta %
- Per-class breakdown tables (class_name, precision, recall, AP)
- Latency stage breakdown (p50/p95/p99 per stage)
- Configurable thresholds via `--thresholds` JSON override

**Design choice:** Zero external dependencies — stdlib only (`json`, `argparse`, `dataclasses`). No Jinja2, no pandas. Keeps CI fast with no pip install.

## Test plan

- [x] 14 unit tests (4 suites): load, compare, render, top-changes — all passing
- [x] Self-compare verified: baseline vs itself produces all-skipped (zero baselines)
- [x] PR comment output fits within ~50 line target
- [x] Full report includes per-class and latency stage tables
- [x] CI workflow: dashboard step added, fallback to inline JS if Python fails
- [ ] Verify CI workflow runs on next perception-touching PR

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)