### PR TITLE
feat(#519): per-class config schema + avoider/tracker integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ ctest --test-dir build --output-on-failure -j$(nproc)
 
 **Before reporting "all tests pass" — verify:**
 - [ ] Correct branch? (`git branch --show-current`)
-- [ ] Test count matches baseline? (currently **1479** — see [tests/TESTS.md](tests/TESTS.md))
+- [ ] Test count matches baseline? (currently **1707** — see [tests/TESTS.md](tests/TESTS.md))
 - [ ] Zero compiler warnings? (build uses `-Werror -Wall -Wextra`)
 - [ ] clang-format clean? (`git diff --name-only | xargs clang-format-18 --dry-run --Werror`)
 

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -91,6 +91,8 @@ inline constexpr const char* MAX_ASSOCIATION_COST = "perception.tracker.max_asso
 inline constexpr const char* HIGH_CONF_THRESHOLD  = "perception.tracker.high_conf_threshold";
 inline constexpr const char* LOW_CONF_THRESHOLD   = "perception.tracker.low_conf_threshold";
 inline constexpr const char* MAX_IOU_COST         = "perception.tracker.max_iou_cost";
+// Per-class motion model (Epic #519)
+inline constexpr const char* PER_CLASS_MOTION_MODEL = "perception.tracker.per_class.motion_model";
 }  // namespace tracker
 
 namespace radar {
@@ -258,6 +260,17 @@ inline constexpr const char* PATH_AWARE      = "mission_planner.obstacle_avoidan
 inline constexpr const char* PATH_AWARE_BYPASS_HYSTERESIS_M =
     "mission_planner.obstacle_avoidance.path_aware_bypass_hysteresis_m";
 inline constexpr const char* LOG_CORRECTIONS = "mission_planner.obstacle_avoidance.log_corrections";
+// Per-class overrides (Epic #519 — per-class config schema)
+inline constexpr const char* PER_CLASS_INFLUENCE_RADIUS_M =
+    "mission_planner.obstacle_avoidance.per_class.influence_radius_m";
+inline constexpr const char* PER_CLASS_REPULSIVE_GAIN =
+    "mission_planner.obstacle_avoidance.per_class.repulsive_gain";
+inline constexpr const char* PER_CLASS_MIN_DISTANCE_M =
+    "mission_planner.obstacle_avoidance.per_class.min_distance_m";
+inline constexpr const char* PER_CLASS_PREDICTION_DT_S =
+    "mission_planner.obstacle_avoidance.per_class.prediction_dt_s";
+inline constexpr const char* PER_CLASS_MIN_CONFIDENCE =
+    "mission_planner.obstacle_avoidance.per_class.min_confidence";
 }  // namespace obstacle_avoidance
 
 namespace obstacle_avoider {

--- a/common/util/include/util/config_validator.h
+++ b/common/util/include/util/config_validator.h
@@ -17,6 +17,7 @@
 #pragma once
 #include "util/config.h"
 #include "util/config_keys.h"
+#include "util/per_class_config.h"
 #include "util/result.h"
 
 #include <cmath>
@@ -227,6 +228,16 @@ public:
         return *this;
     }
 
+    /// Validate a per-class config section for unknown class names (Epic #519).
+    ConfigSchema& per_class_section(const std::string& key) {
+        auto k = key;
+        extra_rules_.emplace_back([k](const Config& cfg, std::vector<std::string>& errors) {
+            auto section_errors = validate_per_class_section(cfg, k);
+            errors.insert(errors.end(), section_errors.begin(), section_errors.end());
+        });
+        return *this;
+    }
+
     /// Build all rules into a flat list.
     [[nodiscard]] std::vector<ValidationRule> build() const {
         std::vector<ValidationRule> rules;
@@ -335,6 +346,8 @@ inline ConfigSchema perception_schema() {
     s.optional<int>(cfg_key::perception::radar::UPDATE_RATE_HZ).range(1, 1000);
     // Fusion
     s.optional<int>(cfg_key::perception::fusion::RATE_HZ).range(1, 1000);
+    // Per-class motion model section (Epic #519)
+    s.per_class_section(cfg_key::perception::tracker::PER_CLASS_MOTION_MODEL);
     return s;
 }
 
@@ -398,6 +411,13 @@ inline ConfigSchema mission_planner_schema() {
     s.optional<double>(cfg_key::mission_planner::obstacle_avoidance::PATH_AWARE_BYPASS_HYSTERESIS_M)
         .range(0.0, 10.0);
     s.optional<bool>(cfg_key::mission_planner::obstacle_avoidance::LOG_CORRECTIONS);
+    // Per-class obstacle avoidance sections (Epic #519)
+    namespace oa = cfg_key::mission_planner::obstacle_avoidance;
+    s.per_class_section(oa::PER_CLASS_INFLUENCE_RADIUS_M);
+    s.per_class_section(oa::PER_CLASS_REPULSIVE_GAIN);
+    s.per_class_section(oa::PER_CLASS_MIN_DISTANCE_M);
+    s.per_class_section(oa::PER_CLASS_PREDICTION_DT_S);
+    s.per_class_section(oa::PER_CLASS_MIN_CONFIDENCE);
     // Geofence
     s.optional<double>(cfg_key::mission_planner::geofence::ALTITUDE_FLOOR_M).range(-1000.0, 10000.0);
     s.optional<double>(cfg_key::mission_planner::geofence::ALTITUDE_CEILING_M).range(0.0, 10000.0);

--- a/common/util/include/util/per_class_config.h
+++ b/common/util/include/util/per_class_config.h
@@ -1,0 +1,101 @@
+// common/util/include/util/per_class_config.h
+// Per-class config lookup utility — loads JSON sections like
+//   { "default": 5.0, "person": 2.0, "drone": 4.0 }
+// into std::array<T, 8> indexed by ObjectClass enum values.
+#pragma once
+
+#include "util/config.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drone::util {
+
+inline constexpr uint8_t kPerClassCount = 8;
+
+inline constexpr std::array<const char*, kPerClassCount> kClassName = {
+    "unknown", "person", "vehicle_car", "vehicle_truck", "drone", "animal", "building", "tree",
+};
+
+/// Map a JSON class name to its index (0-7), or -1 if unrecognized.
+inline int class_name_to_index(const std::string& name) {
+    for (uint8_t i = 0; i < kPerClassCount; ++i) {
+        if (name == kClassName[i]) return static_cast<int>(i);
+    }
+    return -1;
+}
+
+/// Load a per-class array from a config section.
+///
+/// The section at `section_key` should be a JSON object with class name keys
+/// and a "default" fallback.  Unspecified classes get the "default" value;
+/// if "default" is absent, they get `fallback`.
+///
+/// Keys prefixed with "_comment" are silently skipped (convention for JSON
+/// comments).  Unrecognized class names are collected into `unknown_keys`
+/// if non-null.
+template<typename T>
+std::array<T, kPerClassCount> load_per_class(const Config& cfg, const std::string& section_key,
+                                             const T&                  fallback,
+                                             std::vector<std::string>* unknown_keys = nullptr) {
+    std::array<T, kPerClassCount> result;
+    result.fill(fallback);
+
+    auto section = cfg.section(section_key);
+    if (!section.is_object() || section.empty()) return result;
+
+    // Read "default" first — overrides the compiled fallback for all classes.
+    T base = fallback;
+    if (section.contains("default")) {
+        try {
+            base = section["default"].get<T>();
+        } catch (...) {
+            // Type mismatch — stick with compiled fallback.
+        }
+    }
+    result.fill(base);
+
+    // Per-class overrides.
+    for (auto it = section.begin(); it != section.end(); ++it) {
+        const auto& key = it.key();
+        if (key == "default") continue;
+        if (key.rfind("_comment", 0) == 0) continue;
+
+        int idx = class_name_to_index(key);
+        if (idx < 0) {
+            if (unknown_keys) unknown_keys->push_back(key);
+            continue;
+        }
+        try {
+            result[static_cast<uint8_t>(idx)] = it.value().get<T>();
+        } catch (...) {
+            // Type mismatch for this class — keep the default.
+        }
+    }
+
+    return result;
+}
+
+/// Validate that a per-class config section contains only recognized keys.
+/// Returns a list of error messages for unrecognized keys (empty = valid).
+inline std::vector<std::string> validate_per_class_section(const Config&      cfg,
+                                                           const std::string& section_key) {
+    std::vector<std::string> errors;
+    auto                     section = cfg.section(section_key);
+    if (!section.is_object()) return errors;
+
+    for (auto it = section.begin(); it != section.end(); ++it) {
+        const auto& key = it.key();
+        if (key == "default") continue;
+        if (key.rfind("_comment", 0) == 0) continue;
+        if (class_name_to_index(key) < 0) {
+            errors.push_back("Unknown class name '" + key + "' in config section '" + section_key +
+                             "'");
+        }
+    }
+    return errors;
+}
+
+}  // namespace drone::util

--- a/common/util/include/util/per_class_config.h
+++ b/common/util/include/util/per_class_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "util/config.h"
+#include "util/ilogger.h"
 
 #include <array>
 #include <cstdint>
@@ -52,7 +53,8 @@ std::array<T, kPerClassCount> load_per_class(const Config& cfg, const std::strin
         try {
             base = section["default"].get<T>();
         } catch (...) {
-            // Type mismatch — stick with compiled fallback.
+            DRONE_LOG_WARN("[per_class_config] Type mismatch for 'default' in section '{}'",
+                           section_key);
         }
     }
     result.fill(base);
@@ -71,7 +73,8 @@ std::array<T, kPerClassCount> load_per_class(const Config& cfg, const std::strin
         try {
             result[static_cast<uint8_t>(idx)] = it.value().get<T>();
         } catch (...) {
-            // Type mismatch for this class — keep the default.
+            DRONE_LOG_WARN("[per_class_config] Type mismatch for '{}' in section '{}'", key,
+                           section_key);
         }
     }
 

--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,10 @@
             "max_association_cost": 100.0,
             "high_conf_threshold": 0.5,
             "low_conf_threshold": 0.1,
-            "max_iou_cost": 0.7
+            "max_iou_cost": 0.7,
+            "per_class": {
+                "motion_model": { "default": "constant_velocity" }
+            }
         },
         "depth_estimator": {
             "backend": "simulated",
@@ -203,7 +206,15 @@
             "max_correction_mps": 3.0,
             "min_confidence": 0.3,
             "prediction_dt_s": 0.5,
-            "max_age_ms": 500
+            "max_age_ms": 500,
+            "per_class": {
+                "_comment": "Per-class overrides (Epic #519). Unspecified classes use 'default'.",
+                "influence_radius_m": { "default": 5.0, "person": 3.0, "vehicle_truck": 8.0, "building": 2.0, "tree": 2.0 },
+                "repulsive_gain": { "default": 2.0, "vehicle_truck": 3.0 },
+                "min_distance_m": { "default": 2.0, "person": 3.0, "vehicle_truck": 4.0 },
+                "prediction_dt_s": { "default": 0.5, "building": 0.0, "tree": 0.0, "drone": 1.0 },
+                "min_confidence": { "default": 0.3 }
+            }
         },
         "geofence": {
             "polygon": [

--- a/docs/tracking/CI_ISSUES.md
+++ b/docs/tracking/CI_ISSUES.md
@@ -650,3 +650,61 @@ Tests now run and validate in CI — no skipping, actual coverage.
 - Tests that load project files must use `PROJECT_CONFIG_DIR` (or similar CMake compile definition) to construct absolute paths — never rely on CWD being the repo root
 - `GTEST_SKIP()` is only appropriate for **genuinely optional** capabilities (e.g., Zenoh SHM where the library feature isn't compiled in). Don't use it to paper over path resolution issues
 - Check existing test targets for established patterns before inventing a new approach
+
+---
+
+## CI-012: `perception-check` dry-run `KeyError: 'metrics'` — baseline format mismatch
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-04-21 |
+| **Branch** | `feature/epic-519-per-class-config` |
+| **PR** | #599 |
+| **Affected step** | "Run perception CI" (dry-run mode) |
+| **CI job** | `perception-check` (advisory, `continue-on-error: true`) |
+
+### Symptoms
+
+```
+KeyError: 'metrics'
+```
+
+The `perception-check` CI job failed at the "Run perception CI" step in dry-run mode. The job is advisory (`continue-on-error: true`) so it didn't block merge, but it showed as a red X on every PR touching perception code.
+
+### Root Cause
+
+PR #596 (`feat(#573): baseline capture infrastructure`) changed `benchmarks/baseline.json` from a flat metrics format to the `BaselineCapture` format with nested `scenarios → detection/tracking` structure:
+
+```json
+// Old format (expected by CI script):
+{ "metrics": { "recall": { "value": 0.9, "threshold": 0.05 } } }
+
+// New format (BaselineCapture, PR #596):
+{ "version": 1, "scenarios": { "obstacle_avoidance": { "detection": { "micro_precision": 0.0 } } } }
+```
+
+Both the dry-run and live-compare Python snippets in `tests/run_perception_ci.sh` read `bl['metrics']` which no longer exists. The dry-run snippet (line 55) hit the `KeyError` immediately because there are no cloud credentials in CI, so every run goes through the dry-run path.
+
+### Fix Applied
+
+**Commit:** `b100d16`
+
+Updated both Python snippets in `tests/run_perception_ci.sh` to flatten the `BaselineCapture` `scenarios` structure into the flat `metrics` dict that the PR comment renderer (JavaScript in `ci-perception.yml`) expects:
+
+```python
+# Flatten BaselineCapture scenarios into flat metrics dict
+flat = {}
+for scenario, data in bl.get('scenarios', {}).items():
+    for section in ('detection', 'tracking'):
+        for metric, value in data.get(section, {}).items():
+            key = f'{scenario}.{section}.{metric}'
+            flat[key] = {'value': value, 'threshold': 0.05, ...}
+```
+
+Verified locally: dry-run now produces 50/50 metrics passing from the 5-scenario baseline.
+
+### Prevention
+
+- When changing a data format (like baseline JSON), search for all consumers of that format — not just the tool that writes it. `git grep 'metrics' -- '*.sh' '*.yml' '*.py'` would have caught the CI script.
+- The CI workflow's JS renderer already handled missing `metrics` with `results.metrics || {}`, but the Python snippets upstream didn't. Both layers should be defensive.
+- Consider adding a schema version check: if `bl.get('version')` exists, use the new flattening path; otherwise fall back to the legacy `bl['metrics']` path.

--- a/docs/tracking/IMPROVEMENTS.md
+++ b/docs/tracking/IMPROVEMENTS.md
@@ -16,6 +16,26 @@ Running list of improvements noticed in passing while doing other work. Not urge
 
 ## Open
 
+### 2026-04-21
+
+#### 12. HAL factory functions use `throw` instead of `Result<T,E>`
+
+- **Priority:** P2
+- **Category:** architecture
+- **Noticed while:** PR #599 review (Epic #519 per-class config). P4 planner/avoider factories converted in this PR; HAL factories remain.
+- **Current state:** All 7 factory functions in `common/hal/include/hal/hal_factory.h` (create_camera, create_fc_link, create_gcs_link, create_gimbal, create_imu_source, create_radar, create_depth_estimator) throw `std::runtime_error` on unknown backend strings. This is startup-only code but violates the project's `Result<T,E>` error-handling pattern.
+- **Proposed fix:** Convert all HAL factories to return `Result<std::unique_ptr<Interface>>`. Update callers in all 7 process main.cpp files and tests.
+- **When worth doing:** Standalone refactor PR — touches many files across the whole stack.
+
+#### 13. No IPC-boundary validation of `class_id` before `avoid()`
+
+- **Priority:** P3
+- **Category:** architecture (defense-in-depth)
+- **Noticed while:** PR #599 review — OOB array access via `class_id` as index into `std::array<T, 8>`.
+- **Current state:** `mission_state_tick.h` passes `DetectedObjectList` from IPC directly to `avoider.avoid()` without validating `class_id` bounds. The avoider now has an in-loop guard (`if (ci >= kPerClassCount) continue`), but defense-in-depth says validate at the system boundary too.
+- **Proposed fix:** Add a `validate()` method to `DetectedObjectList` or a free function that clamps/filters invalid class IDs before passing to downstream consumers. Log a warning when invalid IDs are received from IPC.
+- **When worth doing:** When touching IPC types or adding new consumers of DetectedObjectList.
+
 ### 2026-04-20
 
 #### 10. `COSYS_SIMULATION_ARCHITECTURE.md` — parallel to the existing Gazebo doc

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3273,4 +3273,35 @@ Also cherry-picked review fixes from PR #595 (`fe2e84a`): GT emitter config key 
 
 ---
 
-*Last updated after Improvement #80 (dashboard renderer, #574). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory.*
+### Improvement #81 — Per-Class Config Schema (Epic #519)
+
+**Date:** 2026-04-21
+
+**What:** Reusable per-class config infrastructure — `load_per_class<T>()` template reads JSON sections like `{ "default": 5.0, "person": 2.0 }` into `std::array<T, 8>` indexed by ObjectClass enum. Applied across obstacle avoidance (5 parameters: influence radius, repulsive gain, min distance, prediction horizon, confidence threshold) and tracker motion model (constant_velocity vs constant_acceleration per class). Startup validation rejects typo class names. Two-phase initialization: constructors sync per-class arrays from global scalars (backward compat), then Config-driven constructors overwrite from JSON.
+
+**Files added:**
+- `common/util/include/util/per_class_config.h` — header-only utility: `kClassName[]`, `class_name_to_index()`, `load_per_class<T>()`, `validate_per_class_section()`
+- `tests/test_per_class_config.cpp` — 12 tests for class name mapping, load variants, validation
+
+**Files modified:**
+- `common/util/include/util/config_keys.h` — 6 new per-class config key constants
+- `common/util/include/util/config_validator.h` — `per_class_section()` method, schema updates for mission_planner + perception
+- `process4_mission_planner/include/planner/obstacle_avoider_3d.h` — 5 per-class arrays, `sync_per_class_from_globals()`, `mutable_config()`, per-class lookups in `avoid()` loop
+- `process2_perception/include/perception/kalman_tracker.h` — `MotionModel` enum, `motion_model_from_string()`
+- `process2_perception/include/perception/bytetrack_tracker.h` — per-class motion model array in `ByteTrackParams`
+- `process2_perception/src/kalman_tracker.cpp` — motion-model-aware velocity noise, per-class load from config
+- `process2_perception/src/bytetrack_tracker.cpp` — per-class motion model at track creation
+- `config/default.json` — per-class sections for obstacle_avoidance and tracker
+- `tests/test_obstacle_avoider_3d.cpp` — +3 per-class tests (influence radius, confidence, prediction dt)
+- `tests/test_kalman_tracker.cpp` — +3 tests (motion model mapping, noise, default)
+- `tests/test_config_validator.cpp` — +4 tests (per-class section validation)
+
+**Why:** Per-class tuning enables different avoidance margins for people vs trucks vs buildings, different motion models for fast-moving drones vs stationary structures, and per-class confidence gating. All driven from JSON config — no code changes needed to tune per-class behavior.
+
+**Test count:** +22 (12 per_class_config + 3 avoider + 3 kalman + 4 validator). Total: 1704.
+
+**Universal acceptance criteria:** design doc updated; no license obligations change.
+
+---
+
+*Last updated after Improvement #81 (per-class config, Epic #519). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory.*

--- a/process2_perception/include/perception/bytetrack_tracker.h
+++ b/process2_perception/include/perception/bytetrack_tracker.h
@@ -7,7 +7,9 @@
 
 #include "perception/itracker.h"
 #include "perception/kalman_tracker.h"
+#include "util/per_class_config.h"
 
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -21,6 +23,8 @@ struct ByteTrackParams {
     double   max_iou_cost        = 0.7;
     uint32_t max_age             = 10;
     uint32_t min_hits            = 3;
+    // Per-class motion model (Epic #519).  Indexed by ObjectClass value.
+    std::array<MotionModel, drone::util::kPerClassCount> motion_models{};
 };
 
 /// ByteTrack tracker: two-stage Hungarian association on IoU cost.

--- a/process2_perception/include/perception/kalman_tracker.h
+++ b/process2_perception/include/perception/kalman_tracker.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "perception/itracker.h"
 #include "perception/types.h"
+#include "util/ilogger.h"
 
 #include <vector>
 
@@ -20,6 +21,10 @@ enum class MotionModel : uint8_t {
 
 inline MotionModel motion_model_from_string(const std::string& s) {
     if (s == "constant_acceleration") return MotionModel::CONSTANT_ACCELERATION;
+    if (s != "constant_velocity") {
+        DRONE_LOG_WARN("[MotionModel] Unknown motion model '{}', defaulting to constant_velocity",
+                       s);
+    }
     return MotionModel::CONSTANT_VELOCITY;
 }
 
@@ -47,8 +52,9 @@ public:
     uint32_t    hits               = 0;
     uint32_t    consecutive_misses = 0;
 
-    [[nodiscard]] bool is_confirmed() const { return hits >= 3; }
-    [[nodiscard]] bool is_stale() const { return consecutive_misses > 10; }
+    [[nodiscard]] bool  is_confirmed() const { return hits >= 3; }
+    [[nodiscard]] bool  is_stale() const { return consecutive_misses > 10; }
+    [[nodiscard]] float process_noise_velocity() const { return Q_(4, 4); }
 
 private:
     StateVec x_ = StateVec::Zero();

--- a/process2_perception/include/perception/kalman_tracker.h
+++ b/process2_perception/include/perception/kalman_tracker.h
@@ -12,6 +12,17 @@
 
 namespace drone::perception {
 
+/// Per-class motion model for Kalman process noise tuning (Epic #519).
+enum class MotionModel : uint8_t {
+    CONSTANT_VELOCITY     = 0,
+    CONSTANT_ACCELERATION = 1,
+};
+
+inline MotionModel motion_model_from_string(const std::string& s) {
+    if (s == "constant_acceleration") return MotionModel::CONSTANT_ACCELERATION;
+    return MotionModel::CONSTANT_VELOCITY;
+}
+
 class KalmanBoxTracker {
 public:
     static constexpr int STATE_DIM = 8;  // [x, y, w, h, vx, vy, vw, vh]
@@ -22,7 +33,8 @@ public:
     using MeasVec  = Eigen::Matrix<float, MEAS_DIM, 1>;
     using MeasMat  = Eigen::Matrix<float, MEAS_DIM, STATE_DIM>;
 
-    KalmanBoxTracker(const Detection2D& initial_det, uint32_t id);
+    KalmanBoxTracker(const Detection2D& initial_det, uint32_t id,
+                     MotionModel model = MotionModel::CONSTANT_VELOCITY);
     void                          predict(float dt = 1.0f / 30.0f);
     void                          update(const Detection2D& det);
     [[nodiscard]] Detection2D     predicted_bbox() const;

--- a/process2_perception/src/bytetrack_tracker.cpp
+++ b/process2_perception/src/bytetrack_tracker.cpp
@@ -6,6 +6,10 @@
 #include <algorithm>
 #include <cmath>
 
+static_assert(drone::util::kPerClassCount ==
+                  static_cast<uint8_t>(drone::perception::ObjectClass::TREE) + 1,
+              "kPerClassCount must match ObjectClass enum size");
+
 namespace drone::perception {
 
 ByteTrackTracker::ByteTrackTracker(Params params) : params_(params) {}
@@ -73,6 +77,8 @@ TrackedObjectList ByteTrackTracker::update(const Detection2DList& det_list) {
     // ── Step 2: Split detections by confidence ──────────────
     std::vector<Detection2D> high_dets;
     std::vector<Detection2D> low_dets;
+    high_dets.reserve(det_list.detections.size());
+    low_dets.reserve(det_list.detections.size());
 
     for (const auto& det : det_list.detections) {
         if (det.confidence >= params_.high_conf_threshold) {
@@ -137,7 +143,8 @@ TrackedObjectList ByteTrackTracker::update(const Detection2DList& det_list) {
     // Low-conf detections never create new tracks.
     for (size_t d = 0; d < high_dets.size(); ++d) {
         if (!high_det_matched[d]) {
-            auto ci    = static_cast<uint8_t>(high_dets[d].class_id);
+            auto ci = static_cast<uint8_t>(high_dets[d].class_id);
+            if (ci >= drone::util::kPerClassCount) ci = 0;
             auto model = params_.motion_models[ci];
             tracks_.emplace_back(high_dets[d], next_id_++, model);
         }
@@ -155,6 +162,7 @@ TrackedObjectList ByteTrackTracker::update(const Detection2DList& det_list) {
     output.timestamp_ns   = det_list.timestamp_ns;
     output.frame_sequence = det_list.frame_sequence;
 
+    output.objects.reserve(tracks_.size());
     for (const auto& track : tracks_) {
         if (track.hits < params_.min_hits) continue;
 

--- a/process2_perception/src/bytetrack_tracker.cpp
+++ b/process2_perception/src/bytetrack_tracker.cpp
@@ -137,7 +137,9 @@ TrackedObjectList ByteTrackTracker::update(const Detection2DList& det_list) {
     // Low-conf detections never create new tracks.
     for (size_t d = 0; d < high_dets.size(); ++d) {
         if (!high_det_matched[d]) {
-            tracks_.emplace_back(high_dets[d], next_id_++);
+            auto ci    = static_cast<uint8_t>(high_dets[d].class_id);
+            auto model = params_.motion_models[ci];
+            tracks_.emplace_back(high_dets[d], next_id_++, model);
         }
     }
 

--- a/process2_perception/src/kalman_tracker.cpp
+++ b/process2_perception/src/kalman_tracker.cpp
@@ -5,6 +5,8 @@
 
 #include "perception/bytetrack_tracker.h"
 #include "util/config.h"
+#include "util/config_keys.h"
+#include "util/per_class_config.h"
 
 #include <algorithm>
 #include <cmath>
@@ -20,7 +22,7 @@ namespace drone::perception {
 // ═══════════════════════════════════════════════════════════
 // KalmanBoxTracker
 // ═══════════════════════════════════════════════════════════
-KalmanBoxTracker::KalmanBoxTracker(const Detection2D& det, uint32_t id)
+KalmanBoxTracker::KalmanBoxTracker(const Detection2D& det, uint32_t id, MotionModel model)
     : track_id(id)
     , class_id(det.class_id)
     , confidence(det.confidence)
@@ -51,12 +53,15 @@ KalmanBoxTracker::KalmanBoxTracker(const Detection2D& det, uint32_t id)
     P_(6, 6) = 1000.0f;
     P_(7, 7) = 1000.0f;
 
-    // Process noise
-    Q_       = StateMat::Identity() * 1.0f;
-    Q_(4, 4) = 0.01f;
-    Q_(5, 5) = 0.01f;
-    Q_(6, 6) = 0.0001f;
-    Q_(7, 7) = 0.0001f;
+    // Process noise — tuned by motion model (Epic #519).
+    // CONSTANT_ACCELERATION uses higher velocity noise to accommodate
+    // rapid speed changes (manoeuvring targets like drones/animals).
+    const float vel_noise = (model == MotionModel::CONSTANT_ACCELERATION) ? 0.1f : 0.01f;
+    Q_                    = StateMat::Identity() * 1.0f;
+    Q_(4, 4)              = vel_noise;
+    Q_(5, 5)              = vel_noise;
+    Q_(6, 6)              = 0.0001f;
+    Q_(7, 7)              = 0.0001f;
 
     // Measurement noise
     R_ = Eigen::Matrix<float, MEAS_DIM, MEAS_DIM>::Identity() * 1.0f;
@@ -230,13 +235,18 @@ TrackerResult create_tracker(const std::string&                    backend,
     auto make_bytetrack = [&]() -> std::unique_ptr<ITracker> {
         ByteTrackTracker::Params params;
         if (cfg) {
-            params.high_conf_threshold = cfg->get<float>("perception.tracker.high_conf_threshold",
-                                                         0.5f);
-            params.low_conf_threshold  = cfg->get<float>("perception.tracker.low_conf_threshold",
-                                                         0.1f);
-            params.max_iou_cost        = cfg->get<double>("perception.tracker.max_iou_cost", 0.7);
-            params.max_age             = cfg->get<uint32_t>("perception.tracker.max_age", 10);
-            params.min_hits            = cfg->get<uint32_t>("perception.tracker.min_hits", 3);
+            namespace tk               = drone::cfg_key::perception::tracker;
+            params.high_conf_threshold = cfg->get<float>(tk::HIGH_CONF_THRESHOLD, 0.5f);
+            params.low_conf_threshold  = cfg->get<float>(tk::LOW_CONF_THRESHOLD, 0.1f);
+            params.max_iou_cost        = cfg->get<double>(tk::MAX_IOU_COST, 0.7);
+            params.max_age             = cfg->get<uint32_t>(tk::MAX_AGE, 10);
+            params.min_hits            = cfg->get<uint32_t>(tk::MIN_HITS, 3);
+            // Per-class motion models (Epic #519).
+            auto model_strings = drone::util::load_per_class<std::string>(
+                *cfg, tk::PER_CLASS_MOTION_MODEL, "constant_velocity");
+            for (uint8_t i = 0; i < drone::util::kPerClassCount; ++i) {
+                params.motion_models[i] = motion_model_from_string(model_strings[i]);
+            }
         }
         return std::make_unique<ByteTrackTracker>(params);
     };

--- a/process4_mission_planner/include/planner/obstacle_avoider_3d.h
+++ b/process4_mission_planner/include/planner/obstacle_avoider_3d.h
@@ -19,6 +19,7 @@
 #include "util/config_keys.h"
 #include "util/ilogger.h"
 #include "util/per_class_config.h"
+#include "util/result.h"
 
 #include <algorithm>
 #include <array>
@@ -28,6 +29,10 @@
 #include <string>
 
 namespace drone::planner {
+
+static_assert(drone::util::kPerClassCount ==
+                  static_cast<uint8_t>(drone::ipc::ObjectClass::TREE) + 1,
+              "kPerClassCount must match ObjectClass enum size");
 
 /// Configuration for the 3D obstacle avoider.
 struct ObstacleAvoider3DConfig {
@@ -168,6 +173,7 @@ public:
         for (uint32_t i = 0; i < objects.num_objects; ++i) {
             const auto& obj = objects.objects[i];
             const auto  ci  = static_cast<uint8_t>(obj.class_id);
+            if (ci >= drone::util::kPerClassCount) continue;
 
             if (obj.confidence < config_.min_confidence_per_class[ci]) continue;
             ++considered;
@@ -211,9 +217,9 @@ public:
                 if (config_.log_corrections) {
                     const float cmag = std::sqrt(cx * cx + cy * cy + cz * cz);
                     if (cmag > 0.5f) {
-                        DRONE_LOG_INFO("[Avoider] obstacle d={:.1f}m rep={:.2f} |c|={:.2f}m/s at "
-                                       "({:.1f},{:.1f},{:.1f})",
-                                       dist, repulsion, cmag, ox, oy, oz);
+                        DRONE_LOG_DEBUG("[Avoider] obstacle d={:.1f}m rep={:.2f} |c|={:.2f}m/s "
+                                        "at ({:.1f},{:.1f},{:.1f})",
+                                        dist, repulsion, cmag, ox, oy, oz);
                     }
                 }
             }
@@ -362,16 +368,18 @@ private:
 // is fully visible — avoids circular-include issues.
 namespace drone::planner {
 
-inline std::unique_ptr<IObstacleAvoider> create_obstacle_avoider(
+[[nodiscard]] inline drone::util::Result<std::unique_ptr<IObstacleAvoider>> create_obstacle_avoider(
     const std::string& backend = "potential_field_3d", float influence_radius = 5.0f,
     float repulsive_gain = 2.0f, const drone::Config* cfg = nullptr) {
+    using R = drone::util::Result<std::unique_ptr<IObstacleAvoider>>;
     if (backend == "3d" || backend == "obstacle_avoider_3d" || backend == "potential_field_3d") {
         if (cfg) {
-            return std::make_unique<ObstacleAvoider3D>(*cfg);
+            return R::ok(std::make_unique<ObstacleAvoider3D>(*cfg));
         }
-        return std::make_unique<ObstacleAvoider3D>(influence_radius, repulsive_gain);
+        return R::ok(std::make_unique<ObstacleAvoider3D>(influence_radius, repulsive_gain));
     }
-    throw std::runtime_error("Unknown obstacle avoider: " + backend);
+    return R::err(drone::util::Error(drone::util::ErrorCode::InvalidValue,
+                                     "Unknown obstacle avoider: " + backend));
 }
 
 }  // namespace drone::planner

--- a/process4_mission_planner/include/planner/obstacle_avoider_3d.h
+++ b/process4_mission_planner/include/planner/obstacle_avoider_3d.h
@@ -18,8 +18,10 @@
 #include "util/config.h"
 #include "util/config_keys.h"
 #include "util/ilogger.h"
+#include "util/per_class_config.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -46,15 +48,29 @@ struct ObstacleAvoider3DConfig {
     // Per-obstacle INFO log when its contribution exceeds ~0.5 m/s.  Gated so
     // scenarios that want quiet avoider output can disable it (Issue #503).
     bool log_corrections = true;
+
+    // Per-class overrides (Epic #519).  Indexed by ObjectClass enum value (0-7).
+    // Zero-initialized here; the ObstacleAvoider3D constructor fills them
+    // from the global scalars above, then the Config-driven constructor
+    // overwrites with per-class values from JSON.
+    std::array<float, drone::util::kPerClassCount> influence_radius_per_class{};
+    std::array<float, drone::util::kPerClassCount> repulsive_gain_per_class{};
+    std::array<float, drone::util::kPerClassCount> min_distance_per_class{};
+    std::array<float, drone::util::kPerClassCount> prediction_dt_per_class{};
+    std::array<float, drone::util::kPerClassCount> min_confidence_per_class{};
 };
 
 class ObstacleAvoider3D final : public IObstacleAvoider {
 public:
-    explicit ObstacleAvoider3D(const ObstacleAvoider3DConfig& config = {}) : config_(config) {}
+    explicit ObstacleAvoider3D(const ObstacleAvoider3DConfig& config = {}) : config_(config) {
+        sync_per_class_from_globals();
+    }
 
     /// Convenience constructor with influence radius and repulsive gain.
     ObstacleAvoider3D(float influence_radius, float repulsive_gain)
-        : config_{influence_radius, repulsive_gain} {}
+        : config_{influence_radius, repulsive_gain} {
+        sync_per_class_from_globals();
+    }
 
     /// Config-driven constructor — reads all avoider params from drone::Config.
     explicit ObstacleAvoider3D(const drone::Config& cfg) {
@@ -100,6 +116,19 @@ public:
         config_.log_corrections =
             cfg.get<bool>(drone::cfg_key::mission_planner::obstacle_avoidance::LOG_CORRECTIONS,
                           config_.log_corrections);
+
+        // Per-class overrides — fall back to the global scalar loaded above.
+        namespace oa                       = drone::cfg_key::mission_planner::obstacle_avoidance;
+        config_.influence_radius_per_class = drone::util::load_per_class<float>(
+            cfg, oa::PER_CLASS_INFLUENCE_RADIUS_M, config_.influence_radius_m);
+        config_.repulsive_gain_per_class = drone::util::load_per_class<float>(
+            cfg, oa::PER_CLASS_REPULSIVE_GAIN, config_.repulsive_gain);
+        config_.min_distance_per_class = drone::util::load_per_class<float>(
+            cfg, oa::PER_CLASS_MIN_DISTANCE_M, config_.min_distance_m);
+        config_.prediction_dt_per_class = drone::util::load_per_class<float>(
+            cfg, oa::PER_CLASS_PREDICTION_DT_S, config_.prediction_dt_s);
+        config_.min_confidence_per_class = drone::util::load_per_class<float>(
+            cfg, oa::PER_CLASS_MIN_CONFIDENCE, config_.min_confidence);
     }
 
     drone::ipc::TrajectoryCmd avoid(const drone::ipc::TrajectoryCmd&      planned,
@@ -138,13 +167,16 @@ public:
 
         for (uint32_t i = 0; i < objects.num_objects; ++i) {
             const auto& obj = objects.objects[i];
-            if (obj.confidence < config_.min_confidence) continue;
+            const auto  ci  = static_cast<uint8_t>(obj.class_id);
+
+            if (obj.confidence < config_.min_confidence_per_class[ci]) continue;
             ++considered;
 
             // Predicted object position (if velocity is available)
-            float ox = obj.position_x + obj.velocity_x * config_.prediction_dt_s;
-            float oy = obj.position_y + obj.velocity_y * config_.prediction_dt_s;
-            float oz = obj.position_z + obj.velocity_z * config_.prediction_dt_s;
+            const float pred_dt = config_.prediction_dt_per_class[ci];
+            float       ox      = obj.position_x + obj.velocity_x * pred_dt;
+            float       oy      = obj.position_y + obj.velocity_y * pred_dt;
+            float       oz      = obj.position_z + obj.velocity_z * pred_dt;
 
             // Relative position from drone to obstacle
             float dx = ox - drone_x;
@@ -153,11 +185,11 @@ public:
 
             float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
 
-            if (dist < config_.influence_radius_m && dist > 0.01f) {
+            if (dist < config_.influence_radius_per_class[ci] && dist > 0.01f) {
                 ++active;
                 if (dist < min_active_dist) min_active_dist = dist;
                 // Inverse-square repulsive force (decays with distance)
-                float repulsion = config_.repulsive_gain / (dist * dist);
+                float repulsion = config_.repulsive_gain_per_class[ci] / (dist * dist);
 
                 // Per-obstacle contribution vector (so we can log its magnitude).
                 const float cx = -(dx / dist) * repulsion;
@@ -299,7 +331,23 @@ public:
     /// Exposed for tests and diagnostics.
     [[nodiscard]] bool close_regime_active() const { return close_regime_active_; }
 
+    /// Mutable config access — for tests that need per-class overrides
+    /// after construction (the constructor fills per-class arrays from
+    /// the global scalars, so tests must override after).
+    ObstacleAvoider3DConfig& mutable_config() { return config_; }
+
 private:
+    // Fill all per-class arrays from their corresponding global scalar.
+    // Called once at construction so legacy configs that only set globals
+    // propagate correctly to the per-class arrays.
+    void sync_per_class_from_globals() {
+        config_.influence_radius_per_class.fill(config_.influence_radius_m);
+        config_.repulsive_gain_per_class.fill(config_.repulsive_gain);
+        config_.min_distance_per_class.fill(config_.min_distance_m);
+        config_.prediction_dt_per_class.fill(config_.prediction_dt_s);
+        config_.min_confidence_per_class.fill(config_.min_confidence);
+    }
+
     ObstacleAvoider3DConfig config_;
     // Path-aware bypass hysteresis state (Issue #503).
     // Enters when closest obstacle < min_distance_m; exits when it rises

--- a/process4_mission_planner/include/planner/planner_factory.h
+++ b/process4_mission_planner/include/planner/planner_factory.h
@@ -9,21 +9,23 @@
 #include "planner/dstar_lite_planner.h"
 #include "planner/grid_planner_base.h"
 #include "planner/ipath_planner.h"
+#include "util/result.h"
 
 #include <memory>
-#include <stdexcept>
 #include <string>
 
 namespace drone::planner {
 
 /// Create a path planner by backend name.
 /// D* Lite accepts a GridPlannerConfig.
-inline std::unique_ptr<IPathPlanner> create_path_planner(const std::string& backend = "dstar_lite",
-                                                         const GridPlannerConfig& config = {}) {
+[[nodiscard]] inline drone::util::Result<std::unique_ptr<IPathPlanner>> create_path_planner(
+    const std::string& backend = "dstar_lite", const GridPlannerConfig& config = {}) {
+    using R = drone::util::Result<std::unique_ptr<IPathPlanner>>;
     if (backend == "dstar_lite") {
-        return std::make_unique<DStarLitePlanner>(config);
+        return R::ok(std::make_unique<DStarLitePlanner>(config));
     }
-    throw std::runtime_error("Unknown path planner: " + backend);
+    return R::err(drone::util::Error(drone::util::ErrorCode::InvalidValue,
+                                     "Unknown path planner: " + backend));
 }
 
 }  // namespace drone::planner

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -229,7 +229,12 @@ int main(int argc, char* argv[]) {
         ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SNAP_APPROACH_BIAS,
                            planner_cfg.snap_approach_bias);
 
-    auto path_planner = drone::planner::create_path_planner(planner_backend, planner_cfg);
+    auto planner_result = drone::planner::create_path_planner(planner_backend, planner_cfg);
+    if (planner_result.is_err()) {
+        DRONE_LOG_ERROR("[P4] {}", planner_result.error().message());
+        return EXIT_FAILURE;
+    }
+    auto path_planner = std::move(planner_result).value();
     DRONE_LOG_INFO("Path planner: {}", path_planner->name());
     auto* grid_planner = dynamic_cast<drone::planner::IGridPlanner*>(path_planner.get());
 
@@ -239,8 +244,13 @@ int main(int argc, char* argv[]) {
 
     auto avoider_backend = ctx.cfg.get<std::string>(
         drone::cfg_key::mission_planner::obstacle_avoider::BACKEND, "potential_field");
-    auto avoider = drone::planner::create_obstacle_avoider(avoider_backend, influence_radius,
-                                                           repulsive_gain, &ctx.cfg);
+    auto avoider_result = drone::planner::create_obstacle_avoider(avoider_backend, influence_radius,
+                                                                  repulsive_gain, &ctx.cfg);
+    if (avoider_result.is_err()) {
+        DRONE_LOG_ERROR("[P4] {}", avoider_result.error().message());
+        return EXIT_FAILURE;
+    }
+    auto avoider = std::move(avoider_result).value();
     DRONE_LOG_INFO("Obstacle avoider: {}", avoider->name());
 
     // ── Geofence setup ─────────────────────────────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -62,6 +62,9 @@ add_drone_test(test_fault_manager   test_fault_manager.cpp)
 # ── Geofence tests ──────────────────────────────────────────
 add_drone_test(test_geofence        test_geofence.cpp)
 
+# ── Per-class config utility tests (Epic #519) ─────────────
+add_drone_test(test_per_class_config test_per_class_config.cpp)
+
 # ── 3D Obstacle Avoider tests ───────────────────────────────
 add_drone_test(test_obstacle_avoider_3d test_obstacle_avoider_3d.cpp)
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -100,8 +100,8 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — Gazebo](#hal--gazebo) | 2 | 25 | Gazebo camera and IMU backends |
 | [HAL — MAVLink](#hal--mavlink) | 1 | 14 | MavlinkFCLink (MAVSDK-based flight controller) |
 | [HAL — Radar](#hal--radar) | 1 | 29 | IRadar interface, SimulatedRadar, factory, config, topic |
-| [P2 — Perception](#p2--perception) | 6 | 216 | Kalman filter + Hungarian solver, ByteTrack (two-stage IoU), fusion (UKF+camera+radar+dormant re-ID+covariance depth+height priors+radar-learned heights), color contour, YOLOv8, world transform |
-| [P4 — Mission Planner](#p4--mission-planner) | 8 | 220 | Mission FSM, FaultManager, StaticObstacleLayer, GCSCommandHandler, FaultResponseExecutor, MissionStateTick, D* Lite planner, ObstacleAvoider3D |
+| [P2 — Perception](#p2--perception) | 6 | 219 | Kalman filter + Hungarian solver + per-class motion model, ByteTrack (two-stage IoU), fusion (UKF+camera+radar+dormant re-ID+covariance depth+height priors+radar-learned heights), color contour, YOLOv8, world transform |
+| [P4 — Mission Planner](#p4--mission-planner) | 8 | 224 | Mission FSM, FaultManager, StaticObstacleLayer, GCSCommandHandler, FaultResponseExecutor, MissionStateTick, D* Lite planner, ObstacleAvoider3D (+ per-class overrides) |
 | [P5 — Comms](#p5--comms) | 1 | 13 | MavlinkSim and GCSLink |
 | [P6 — Payload Manager](#p6--payload-manager) | 1 | 9 | GimbalController servo simulation |
 | [P7 — System Monitor](#p7--system-monitor) | 2 | 53 | CPU/memory/thermal monitoring, ISysInfo abstraction, ProcessManager supervisor |
@@ -109,7 +109,7 @@ bash deploy/build.sh --test-filter watchdog
 | [Watchdog — Thread Health Publisher](#watchdog--thread-health-publisher) | 1 | 15 | ShmThreadHealth struct, ThreadHealthPublisher bridge |
 | [Watchdog — Restart Policy](#watchdog--restart-policy) | 1 | 17 | RestartPolicy backoff/thermal, StackStatus, ProcessConfig from_json |
 | [Watchdog — Process Graph](#watchdog--process-graph) | 1 | 27 | Dual-edge dependency graph, topo sort, cascade targets, cycle detection |
-| [Utility](#utility) | 5 | 147 | Config, Result<T,E>, config validator, JSON log sink, latency tracker |
+| [Utility](#utility) | 6 | 163 | Config, Result<T,E>, config validator, per-class config, JSON log sink, latency tracker |
 | [P3 — SLAM / VIO](#p3--slam--vio) | 3 | 49 | Feature extractor, stereo matcher, IMU pre-integrator, VIO backend (covariance quality) |
 | [Utility — Diagnostics](#utility--diagnostics) | 1 | 12 | FrameDiagnostics collector, ScopedDiagTimer, merge, severity |
 | [P4 — Collision Recovery](#p4--collision-recovery) | 1 | 14 | Post-collision FSM state, waypoint skip, recovery logic |
@@ -137,7 +137,7 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
 | [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--21-tests) | 1 | 21 | Regression detection (recall/precision/mAP/MOTA/MOTP/latency), configurable thresholds, zero-baseline skip, missing scenario detection, boundary tests, latency defensive paths, format rendering, partial failure |
 | Benchmark — Dashboard Renderer | 7 | 29 | Baseline loading (valid/missing/invalid/no-scenarios), scenario comparison (improvement/regression/boundary/zero-skip/missing/latency-string), PR comment rendering (sections/vacuous-warning/missing), full report rendering (detail/missing/skipped), top-changes ranking (higher/lower-is-better/skipped), latency deserialization, CLI main |
-| **Total** | **77 C++ + 5 shell + 1 Python** | **1682 (no SDK) / 1723 (+SDK) + 42 + 29 + 250+** | |
+| **Total** | **78 C++ + 5 shell + 1 Python** | **1704 (no SDK) / 1745 (+SDK) + 42 + 29 + 250+** | |
 
 ---
 
@@ -439,16 +439,17 @@ Compiled with `HAVE_MAVSDK`.  Tests gracefully handle missing PX4 SITL.
 
 ## P2 — Perception
 
-### test_kalman_tracker.cpp — 15 tests
+### test_kalman_tracker.cpp — 18 tests
 
 **What it tests:** Tracking building blocks — Kalman filter (8D state, constant
-velocity model) and O(n³) Munkres Hungarian assignment solver. These are shared
-infrastructure used by ByteTrackTracker.
+velocity model, per-class motion model) and O(n³) Munkres Hungarian assignment
+solver. These are shared infrastructure used by ByteTrackTracker.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
 | `KalmanBoxTrackerTest` | 7 | Init from detection, predict step, update step, age increment, `is_confirmed()` after N updates, `is_stale()` after M misses, velocity initially zero |
 | `HungarianSolverTest` | 8 | Empty input, single match, perfect diagonal, max-cost gating, all-too-expensive, rectangular matrices, Munkres optimality (greedy-beats cases) |
+| `MotionModelTest` | 3 | `motion_model_from_string()` mapping, CONSTANT_ACCELERATION higher velocity noise than CONSTANT_VELOCITY, default model is CONSTANT_VELOCITY |
 
 **Key files under test:** `perception/kalman_tracker.h`
 
@@ -634,11 +635,12 @@ tracking variables.
 
 ---
 
-### test_obstacle_avoider_3d.cpp — 24 tests
+### test_obstacle_avoider_3d.cpp — 27 tests
 
 **What it tests:** ObstacleAvoider3D — 3D repulsive field with velocity prediction,
 factory registration (including `"potential_field_3d"` alias), name accessor, vertical gain,
-path-aware mode, Euclidean-magnitude clamp and close-regime path-aware bypass (Issue #503).
+path-aware mode, Euclidean-magnitude clamp, close-regime path-aware bypass (Issue #503),
+and per-class config overrides (Epic #519).
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
@@ -649,6 +651,8 @@ path-aware mode, Euclidean-magnitude clamp and close-regime path-aware bypass (I
 | `ObstacleAvoider3DTest` | 2 | `vertical_gain=0` eliminates Z repulsion, `vertical_gain=1` produces Z repulsion |
 | `ObstacleAvoider3DTest` | 4 | Path-aware mode: strips backward repulsion, preserves lateral, preserves same-direction, disabled fallback |
 | `ObstacleAvoider3DTest` | 3 | Euclidean-magnitude clamp (not per-axis), close-regime bypass pushes opposite planner, bypass hysteresis prevents flip-flop (Issue #503) |
+| `ObstacleAvoider3DTest` | 3 | Per-class influence radius (PERSON vs TRUCK at same distance), per-class confidence threshold (DRONE filtered at 0.5 when threshold=0.8), per-class prediction dt (BUILDING stationary vs DRONE aggressive prediction) (Epic #519) |
+| `ObstacleAvoider3DTest` | 1 | Config-driven constructor loads per-class from JSON |
 
 **Key files under test:** `planner/obstacle_avoider_3d.h`, `planner/iobstacle_avoider.h`
 
@@ -980,17 +984,35 @@ graph where:
 
 ---
 
-### test_config_validator.cpp — 22 tests
+### test_config_validator.cpp — 26 tests
 
 **What it tests:** `ConfigSchema` startup-time config validation with
 builder-pattern constraints. Includes real config validation test
-(`DefaultConfigPassesAllSchemas`) using absolute path resolution.
+(`DefaultConfigPassesAllSchemas`) using absolute path resolution, and
+per-class section validation (Epic #519).
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
 | `ConfigValidatorTest` | 22 | Required field missing → error, type mismatch → error, range constraint (`.range()`), one-of constraint (`.one_of()`), custom predicate (`.satisfies()`), optional fields, required sections, **default.json validates against all schemas** (absolute path via PROJECT_CONFIG_DIR), multiple errors collected in single pass, pre-built process schemas |
+| `ConfigValidatorTest` | 4 | Per-class section validation: valid section passes, typo class name ("personn") rejected, missing section OK, `_comment` keys allowed (Epic #519) |
 
-**Key files under test:** `util/config_validator.h`
+**Key files under test:** `util/config_validator.h`, `util/per_class_config.h`
+
+---
+
+### test_per_class_config.cpp — 12 tests
+
+**What it tests:** `per_class_config.h` — per-class config lookup utility (Epic #519).
+Maps JSON sections like `{ "default": 5.0, "person": 2.0 }` into `std::array<T, 8>`
+indexed by `ObjectClass` enum values.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `PerClassConfig` | 2 | `class_name_to_index()` — all 8 valid class names, invalid name returns -1 |
+| `PerClassConfig` | 7 | `load_per_class<T>()` — all classes specified, default fallback for unspecified, no default uses fallback, missing section, unknown keys collected, `_comment` keys ignored, string type support |
+| `PerClassConfig` | 3 | `validate_per_class_section()` — valid section clean, unknown class name detected, missing section returns empty |
+
+**Key files under test:** `util/per_class_config.h`
 
 ---
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -137,7 +137,7 @@ bash deploy/build.sh --test-filter watchdog
 | [Benchmark — Baseline Capture](#test_baseline_capturecpp--17-tests) | 1 | 17 | Metric accumulation, per-class breakdown with class names, multi-scenario insertion order, JSON round-trip (write + load + full field verification), latency content fidelity, tracking metrics (MOTP bounds, ID switches, fragmentations), empty/nonexistent/duplicate scenarios, malformed/wrong-schema JSON, state preservation on load failure |
 | [Benchmark — Baseline Comparator](#test_baseline_comparatorcpp--21-tests) | 1 | 21 | Regression detection (recall/precision/mAP/MOTA/MOTP/latency), configurable thresholds, zero-baseline skip, missing scenario detection, boundary tests, latency defensive paths, format rendering, partial failure |
 | Benchmark — Dashboard Renderer | 7 | 29 | Baseline loading (valid/missing/invalid/no-scenarios), scenario comparison (improvement/regression/boundary/zero-skip/missing/latency-string), PR comment rendering (sections/vacuous-warning/missing), full report rendering (detail/missing/skipped), top-changes ranking (higher/lower-is-better/skipped), latency deserialization, CLI main |
-| **Total** | **78 C++ + 5 shell + 1 Python** | **1704 (no SDK) / 1745 (+SDK) + 42 + 29 + 250+** | |
+| **Total** | **78 C++ + 5 shell + 1 Python** | **1707 (no SDK) / 1748 (+SDK) + 42 + 29 + 250+** | |
 
 ---
 
@@ -635,17 +635,17 @@ tracking variables.
 
 ---
 
-### test_obstacle_avoider_3d.cpp — 27 tests
+### test_obstacle_avoider_3d.cpp — 29 tests
 
 **What it tests:** ObstacleAvoider3D — 3D repulsive field with velocity prediction,
 factory registration (including `"potential_field_3d"` alias), name accessor, vertical gain,
 path-aware mode, Euclidean-magnitude clamp, close-regime path-aware bypass (Issue #503),
-and per-class config overrides (Epic #519).
+per-class config overrides (Epic #519), OOB class_id safety, and Result<>-based factory errors.
 
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
 | `ObstacleAvoider3DTest` | 7 | No objects pass-through, stale objects ignored, close object repels in XYZ, low confidence ignored, correction clamped, prediction shifts repulsion, NaN pose pass-through |
-| `ObstacleAvoiderFactory` | 4 | `"3d"` registered, `"obstacle_avoider_3d"` registered, `"potential_field_3d"` registered, unknown throws |
+| `ObstacleAvoiderFactory` | 4 | `"3d"` registered, `"obstacle_avoider_3d"` registered, `"potential_field_3d"` registered, unknown returns Result error |
 | `ObstacleAvoider3DTest` | 2 | Name is correct, convenience constructor |
 | `ObstacleAvoider3DTest` | 1 | Very close object (< 0.1m) produces maximum repulsion (dead zone fix) |
 | `ObstacleAvoider3DTest` | 2 | `vertical_gain=0` eliminates Z repulsion, `vertical_gain=1` produces Z repulsion |
@@ -653,6 +653,8 @@ and per-class config overrides (Epic #519).
 | `ObstacleAvoider3DTest` | 3 | Euclidean-magnitude clamp (not per-axis), close-regime bypass pushes opposite planner, bypass hysteresis prevents flip-flop (Issue #503) |
 | `ObstacleAvoider3DTest` | 3 | Per-class influence radius (PERSON vs TRUCK at same distance), per-class confidence threshold (DRONE filtered at 0.5 when threshold=0.8), per-class prediction dt (BUILDING stationary vs DRONE aggressive prediction) (Epic #519) |
 | `ObstacleAvoider3DTest` | 1 | Config-driven constructor loads per-class from JSON |
+| `ObstacleAvoider3DTest` | 1 | OOB class_id (255) is safely skipped — no repulsion applied |
+| `ObstacleAvoider3DTest` | 1 | Config-driven per-class loading from JSON (PERSON influence=3.0, default=5.0) |
 
 **Key files under test:** `planner/obstacle_avoider_3d.h`, `planner/iobstacle_avoider.h`
 
@@ -1000,7 +1002,7 @@ per-class section validation (Epic #519).
 
 ---
 
-### test_per_class_config.cpp — 12 tests
+### test_per_class_config.cpp — 13 tests
 
 **What it tests:** `per_class_config.h` — per-class config lookup utility (Epic #519).
 Maps JSON sections like `{ "default": 5.0, "person": 2.0 }` into `std::array<T, 8>`
@@ -1009,7 +1011,7 @@ indexed by `ObjectClass` enum values.
 | Suite | Tests | What is validated |
 |-------|-------|-------------------|
 | `PerClassConfig` | 2 | `class_name_to_index()` — all 8 valid class names, invalid name returns -1 |
-| `PerClassConfig` | 7 | `load_per_class<T>()` — all classes specified, default fallback for unspecified, no default uses fallback, missing section, unknown keys collected, `_comment` keys ignored, string type support |
+| `PerClassConfig` | 8 | `load_per_class<T>()` — all classes specified, default fallback for unspecified, no default uses fallback, missing section, unknown keys collected, `_comment` keys ignored, type mismatch falls back to compiled default, string type support |
 | `PerClassConfig` | 3 | `validate_per_class_section()` — valid section clean, unknown class name detected, missing section returns empty |
 
 **Key files under test:** `util/per_class_config.h`

--- a/tests/run_perception_ci.sh
+++ b/tests/run_perception_ci.sh
@@ -48,16 +48,31 @@ import json, sys
 baseline_path = '$BASELINE'
 output_path = '$OUTPUT'
 
+LOWER_IS_BETTER = {'id_switches', 'fragmentations', 'total_fp', 'total_fn'}
+
 with open(baseline_path) as f:
     bl = json.load(f)
 
+# BaselineCapture format: { scenarios: { name: { detection: {...}, tracking: {...} } } }
+# Flatten into metrics dict for the PR comment renderer.
+flat = {}
+for scenario, data in bl.get('scenarios', {}).items():
+    for section in ('detection', 'tracking'):
+        for metric, value in data.get(section, {}).items():
+            key = f'{scenario}.{section}.{metric}'
+            flat[key] = {
+                'value': value,
+                'threshold': 0.05,
+                'direction': 'lower_is_better' if metric in LOWER_IS_BETTER else 'higher_is_better',
+            }
+
 results = {'metrics': {}, 'cost': 0, 'duration_min': 0, 'dry_run': True}
-for key, val in bl['metrics'].items():
+for key, val in flat.items():
     results['metrics'][key] = {
         'baseline': val['value'],
         'current': val['value'],
         'threshold': val['threshold'],
-        'passed': True
+        'passed': True,
     }
 
 with open(output_path, 'w') as f:
@@ -142,8 +157,22 @@ echo "--- Step 5: Comparing against baseline ---"
 python3 << COMPARE_EOF
 import json
 
+LOWER_IS_BETTER = {'id_switches', 'fragmentations', 'total_fp', 'total_fn'}
+
 with open('$BASELINE') as f:
     bl = json.load(f)
+
+# Flatten BaselineCapture scenarios into a flat metrics dict.
+flat = {}
+for scenario, data in bl.get('scenarios', {}).items():
+    for section in ('detection', 'tracking'):
+        for metric, value in data.get(section, {}).items():
+            key = f'{scenario}.{section}.{metric}'
+            flat[key] = {
+                'value': value,
+                'threshold': 0.05,
+                'direction': 'lower_is_better' if metric in LOWER_IS_BETTER else 'higher_is_better',
+            }
 
 # Load raw metrics (may be empty if scenarios failed)
 try:
@@ -161,12 +190,11 @@ except (FileNotFoundError, json.JSONDecodeError):
     pass
 
 results = {'metrics': {}, 'cost': 0.25, 'duration_min': 30}
-for key, val in bl['metrics'].items():
+for key, val in flat.items():
     baseline_val = val['value']
     threshold = val['threshold']
 
     if key not in raw:
-        # Missing metric = fail (don't silently fall back to baseline)
         results['metrics'][key] = {
             'baseline': baseline_val,
             'current': None,
@@ -178,11 +206,9 @@ for key, val in bl['metrics'].items():
 
     current = raw[key]
 
-    if val.get('direction') == 'lower_is_better':
-        # Current should not exceed baseline + threshold
+    if val['direction'] == 'lower_is_better':
         passed = current <= baseline_val + threshold
     else:
-        # Current should not fall below baseline - threshold
         passed = current >= baseline_val - threshold
 
     results['metrics'][key] = {

--- a/tests/test_collision_recovery.cpp
+++ b/tests/test_collision_recovery.cpp
@@ -147,9 +147,9 @@ protected:
         fsm.on_arm();
     }
 
-    std::unique_ptr<IPathPlanner>     planner_ = create_path_planner("dstar_lite");
-    std::unique_ptr<IObstacleAvoider> avoider_ = create_obstacle_avoider("potential_field_3d", 5.0f,
-                                                                         2.0f);
+    std::unique_ptr<IPathPlanner>     planner_ = create_path_planner("dstar_lite").value();
+    std::unique_ptr<IObstacleAvoider> avoider_ =
+        create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f).value();
 
     void do_tick(const Pose& pose, const FCState& fc_state) {
         DetectedObjectList            objects{};

--- a/tests/test_config_validator.cpp
+++ b/tests/test_config_validator.cpp
@@ -339,3 +339,51 @@ TEST_F(ConfigValidatorTest, CustomRuleFails) {
     EXPECT_EQ(r.error().size(), 1u);
     EXPECT_NE(r.error()[0].find("battery_crit must be less than battery_warn"), std::string::npos);
 }
+
+// ═══════════════════════════════════════════════════════════
+// Per-class section validation (Epic #519)
+// ���═══��══════════════════════════════════════════════════════
+
+TEST_F(ConfigValidatorTest, PerClassSectionValidPasses) {
+    load_json(R"({
+        "per_class": {
+            "influence": { "default": 5.0, "person": 3.0, "drone": 4.0, "_comment": "test" }
+        }
+    })");
+    ConfigSchema s;
+    s.per_class_section("per_class.influence");
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, PerClassSectionTypoRejected) {
+    load_json(R"({
+        "per_class": {
+            "influence": { "default": 5.0, "personn": 3.0 }
+        }
+    })");
+    ConfigSchema s;
+    s.per_class_section("per_class.influence");
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_err());
+    ASSERT_EQ(r.error().size(), 1u);
+    EXPECT_NE(r.error()[0].find("personn"), std::string::npos);
+}
+
+TEST_F(ConfigValidatorTest, PerClassSectionMissingIsOk) {
+    load_json(R"({ "other": 1 })");
+    ConfigSchema s;
+    s.per_class_section("per_class.influence");
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}
+
+TEST_F(ConfigValidatorTest, PerClassSectionCommentKeysAllowed) {
+    load_json(R"({
+        "sec": { "_comment_why": "explanation", "default": 1.0, "tree": 2.0 }
+    })");
+    ConfigSchema s;
+    s.per_class_section("sec");
+    auto r = validate(cfg_, s);
+    EXPECT_TRUE(r.is_ok());
+}

--- a/tests/test_dstar_lite_planner.cpp
+++ b/tests/test_dstar_lite_planner.cpp
@@ -368,13 +368,15 @@ TEST(GridCellHashTest, SameCellSameHash) {
 }
 
 TEST(PathPlannerFactory, FactoryCreatesDStarLite) {
-    auto planner = create_path_planner("dstar_lite");
-    EXPECT_NE(planner, nullptr);
-    EXPECT_EQ(planner->name(), "DStarLitePlanner");
+    auto result = create_path_planner("dstar_lite");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_NE(result.value(), nullptr);
+    EXPECT_EQ(result.value()->name(), "DStarLitePlanner");
 }
 
-TEST(PathPlannerFactory, UnknownThrows) {
-    EXPECT_THROW(create_path_planner("nonexistent"), std::runtime_error);
+TEST(PathPlannerFactory, UnknownReturnsError) {
+    auto result = create_path_planner("nonexistent");
+    EXPECT_TRUE(result.is_err());
 }
 
 // ═════════════════════════════════════════════════════════════
@@ -945,9 +947,9 @@ TEST(DStarLiteIntegrationTest, UpdateObstaclesIntegration) {
 }
 
 TEST(DStarLiteIntegrationTest, FactoryRegistered) {
-    auto planner = create_path_planner("dstar_lite");
-    EXPECT_NE(planner, nullptr);
-    EXPECT_EQ(planner->name(), "DStarLitePlanner");
+    auto result = create_path_planner("dstar_lite");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value()->name(), "DStarLitePlanner");
 }
 
 // ═════════════════════════════════════════════════════════════

--- a/tests/test_kalman_tracker.cpp
+++ b/tests/test_kalman_tracker.cpp
@@ -222,37 +222,20 @@ TEST(KalmanBoxTrackerTest, MotionModelFromString) {
 }
 
 TEST(KalmanBoxTrackerTest, ConstantAccelerationHigherVelocityNoise) {
-    // CONSTANT_ACCELERATION should produce higher process noise on velocity
-    // states, making the filter more responsive to speed changes.
     Detection2D det{100, 200, 50, 80, 0.9f, ObjectClass::DRONE, 0, 0};
 
     KalmanBoxTracker cv_tracker(det, 1, MotionModel::CONSTANT_VELOCITY);
     KalmanBoxTracker ca_tracker(det, 2, MotionModel::CONSTANT_ACCELERATION);
 
-    // Both start at the same position.  After several predictions with no
-    // updates, the CA tracker should have more uncertainty (larger P matrix
-    // diagonal for velocity states) because its process noise is higher.
-    for (int i = 0; i < 10; ++i) {
-        cv_tracker.predict();
-        ca_tracker.predict();
-    }
-
-    // The CA tracker's velocity should diverge more from zero because
-    // higher Q allows the state to move faster.  We verify indirectly:
-    // both trackers predicted the same initial bbox, but after 10 unupdated
-    // predictions, the CA tracker's predicted bbox should be at least as
-    // uncertain (wider predicted position spread is hard to test directly
-    // without exposing P).  Instead, verify the predicted bboxes differ.
-    auto cv_pred = cv_tracker.predicted_bbox();
-    auto ca_pred = ca_tracker.predicted_bbox();
-    // Both should be similar (same initial state, just noise differs),
-    // but the key invariant is that the construction succeeded.
-    EXPECT_FLOAT_EQ(cv_pred.confidence, ca_pred.confidence);
+    // CA model uses 10x higher velocity process noise (0.1 vs 0.01).
+    EXPECT_FLOAT_EQ(cv_tracker.process_noise_velocity(), 0.01f);
+    EXPECT_FLOAT_EQ(ca_tracker.process_noise_velocity(), 0.1f);
+    EXPECT_GT(ca_tracker.process_noise_velocity(), cv_tracker.process_noise_velocity());
 }
 
 TEST(KalmanBoxTrackerTest, DefaultMotionModelIsConstantVelocity) {
     Detection2D      det{100, 200, 50, 80, 0.9f, ObjectClass::PERSON, 0, 0};
     KalmanBoxTracker tracker(det, 1);
-    // Default construction should work (constant_velocity).
-    EXPECT_EQ(tracker.track_id, 1u);
+    // Default model is CONSTANT_VELOCITY — verify via process noise.
+    EXPECT_FLOAT_EQ(tracker.process_noise_velocity(), 0.01f);
 }

--- a/tests/test_kalman_tracker.cpp
+++ b/tests/test_kalman_tracker.cpp
@@ -208,3 +208,51 @@ TEST(HungarianSolverTest, MoreColsThanRows) {
     EXPECT_DOUBLE_EQ(result.total_cost, 3.0);
     EXPECT_EQ(result.unmatched_cols.size(), 1u);  // col 0 unmatched
 }
+
+// ═══════════════════════════════════════════════════════════
+// Motion model tests (Epic #519)
+// ═══════════════════════════════════════════════════════════
+
+TEST(KalmanBoxTrackerTest, MotionModelFromString) {
+    EXPECT_EQ(motion_model_from_string("constant_velocity"), MotionModel::CONSTANT_VELOCITY);
+    EXPECT_EQ(motion_model_from_string("constant_acceleration"),
+              MotionModel::CONSTANT_ACCELERATION);
+    EXPECT_EQ(motion_model_from_string("unknown_model"), MotionModel::CONSTANT_VELOCITY);
+    EXPECT_EQ(motion_model_from_string(""), MotionModel::CONSTANT_VELOCITY);
+}
+
+TEST(KalmanBoxTrackerTest, ConstantAccelerationHigherVelocityNoise) {
+    // CONSTANT_ACCELERATION should produce higher process noise on velocity
+    // states, making the filter more responsive to speed changes.
+    Detection2D det{100, 200, 50, 80, 0.9f, ObjectClass::DRONE, 0, 0};
+
+    KalmanBoxTracker cv_tracker(det, 1, MotionModel::CONSTANT_VELOCITY);
+    KalmanBoxTracker ca_tracker(det, 2, MotionModel::CONSTANT_ACCELERATION);
+
+    // Both start at the same position.  After several predictions with no
+    // updates, the CA tracker should have more uncertainty (larger P matrix
+    // diagonal for velocity states) because its process noise is higher.
+    for (int i = 0; i < 10; ++i) {
+        cv_tracker.predict();
+        ca_tracker.predict();
+    }
+
+    // The CA tracker's velocity should diverge more from zero because
+    // higher Q allows the state to move faster.  We verify indirectly:
+    // both trackers predicted the same initial bbox, but after 10 unupdated
+    // predictions, the CA tracker's predicted bbox should be at least as
+    // uncertain (wider predicted position spread is hard to test directly
+    // without exposing P).  Instead, verify the predicted bboxes differ.
+    auto cv_pred = cv_tracker.predicted_bbox();
+    auto ca_pred = ca_tracker.predicted_bbox();
+    // Both should be similar (same initial state, just noise differs),
+    // but the key invariant is that the construction succeeded.
+    EXPECT_FLOAT_EQ(cv_pred.confidence, ca_pred.confidence);
+}
+
+TEST(KalmanBoxTrackerTest, DefaultMotionModelIsConstantVelocity) {
+    Detection2D      det{100, 200, 50, 80, 0.9f, ObjectClass::PERSON, 0, 0};
+    KalmanBoxTracker tracker(det, 1);
+    // Default construction should work (constant_velocity).
+    EXPECT_EQ(tracker.track_id, 1u);
+}

--- a/tests/test_mission_state_tick.cpp
+++ b/tests/test_mission_state_tick.cpp
@@ -75,9 +75,9 @@ protected:
         fsm.on_arm();  // → PREFLIGHT
     }
 
-    std::unique_ptr<IPathPlanner>     planner_ = create_path_planner("dstar_lite");
-    std::unique_ptr<IObstacleAvoider> avoider_ = create_obstacle_avoider("potential_field_3d", 5.0f,
-                                                                         2.0f);
+    std::unique_ptr<IPathPlanner>     planner_ = create_path_planner("dstar_lite").value();
+    std::unique_ptr<IObstacleAvoider> avoider_ =
+        create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f).value();
 
     void do_tick(const Pose& pose, const FCState& fc_state) {
         DetectedObjectList            objects{};
@@ -336,8 +336,8 @@ TEST(MissionStateTickUnstuckTest, ExitsOnTimerExpiry) {
     local_fsm.on_stuck();
     ASSERT_EQ(local_fsm.state(), MissionState::NAVIGATE_UNSTUCK);
 
-    auto                local_planner = create_path_planner("dstar_lite");
-    auto                local_avoider = create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f);
+    auto local_planner = create_path_planner("dstar_lite").value();
+    auto local_avoider = create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f).value();
     StaticObstacleLayer local_layer;
 
     Pose                          pose = make_pose(5, 5, 5);
@@ -386,8 +386,8 @@ TEST(MissionStateTickUnstuckTest, NavigateTickDetectsStuckAndTransitions) {
     local_fsm.on_navigate();
     ASSERT_EQ(local_fsm.state(), MissionState::NAVIGATE);
 
-    auto                local_planner = create_path_planner("dstar_lite");
-    auto                local_avoider = create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f);
+    auto local_planner = create_path_planner("dstar_lite").value();
+    auto local_avoider = create_obstacle_avoider("potential_field_3d", 5.0f, 2.0f).value();
     StaticObstacleLayer local_layer;
 
     Pose                          pose = make_pose(5, 5, 5);

--- a/tests/test_obstacle_avoider_3d.cpp
+++ b/tests/test_obstacle_avoider_3d.cpp
@@ -212,25 +212,27 @@ TEST(ObstacleAvoider3DTest, NaNPosePassesThrough) {
 // ═════════════════════════════════════════════════════════════
 
 TEST(ObstacleAvoiderFactory, ThreeDBackendRegistered) {
-    auto avoider = create_obstacle_avoider("3d");
-    EXPECT_NE(avoider, nullptr);
-    EXPECT_EQ(avoider->name(), "ObstacleAvoider3D");
+    auto result = create_obstacle_avoider("3d");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_NE(result.value(), nullptr);
+    EXPECT_EQ(result.value()->name(), "ObstacleAvoider3D");
 }
 
 TEST(ObstacleAvoiderFactory, AlternateNameRegistered) {
-    auto avoider = create_obstacle_avoider("obstacle_avoider_3d");
-    EXPECT_NE(avoider, nullptr);
-    EXPECT_EQ(avoider->name(), "ObstacleAvoider3D");
+    auto result = create_obstacle_avoider("obstacle_avoider_3d");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value()->name(), "ObstacleAvoider3D");
 }
 
 TEST(ObstacleAvoiderFactory, PotentialField3DRegistered) {
-    auto avoider = create_obstacle_avoider("potential_field_3d");
-    EXPECT_NE(avoider, nullptr);
-    EXPECT_EQ(avoider->name(), "ObstacleAvoider3D");
+    auto result = create_obstacle_avoider("potential_field_3d");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value()->name(), "ObstacleAvoider3D");
 }
 
-TEST(ObstacleAvoiderFactory, UnknownThrows) {
-    EXPECT_THROW(create_obstacle_avoider("nonexistent"), std::runtime_error);
+TEST(ObstacleAvoiderFactory, UnknownReturnsError) {
+    auto result = create_obstacle_avoider("nonexistent");
+    EXPECT_TRUE(result.is_err());
 }
 
 // ═════════════════════════════════════════════════════════════
@@ -689,6 +691,82 @@ TEST(ObstacleAvoider3DTest, PerClassPredictionDt) {
 
     // DRONE should get stronger repulsion (predicted closer).
     EXPECT_LT(result_drone.velocity_x, result_building.velocity_x);
+}
+
+TEST(ObstacleAvoider3DTest, OobClassIdSkipped) {
+    // An IPC message with class_id >= 8 must not cause OOB array access.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m = 10.0f;
+    config.repulsive_gain     = 2.0f;
+    config.path_aware         = false;
+    config.log_corrections    = false;
+
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 3.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.objects[0].class_id   = static_cast<drone::ipc::ObjectClass>(255);
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+    // Object with invalid class_id should be skipped — no repulsion.
+    EXPECT_FLOAT_EQ(result.velocity_x, cmd.velocity_x);
+    EXPECT_FLOAT_EQ(result.velocity_y, cmd.velocity_y);
+    EXPECT_FLOAT_EQ(result.velocity_z, cmd.velocity_z);
+}
+
+TEST(ObstacleAvoider3DTest, ConfigDrivenPerClassLoading) {
+    // Verify the Config-driven constructor loads per-class overrides from JSON.
+    std::string tmp = "/tmp/drone_test_avoider_cfg_" + std::to_string(::getpid()) + ".json";
+    {
+        std::ofstream ofs(tmp);
+        ofs << R"({
+            "mission_planner": {
+                "obstacle_avoidance": {
+                    "influence_radius_m": 5.0,
+                    "repulsive_gain": 2.0,
+                    "path_aware": false,
+                    "log_corrections": false,
+                    "per_class": {
+                        "influence_radius_m": { "default": 5.0, "person": 3.0 }
+                    }
+                }
+            }
+        })";
+    }
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(tmp));
+    std::remove(tmp.c_str());
+
+    ObstacleAvoider3D avoider(cfg);
+    // PERSON (idx 1) should have influence_radius=3.0, others 5.0.
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 4.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    // PERSON at 4m — outside per-class radius (3.0), no repulsion.
+    objects.objects[0].class_id = drone::ipc::ObjectClass::PERSON;
+    auto result_person          = avoider.avoid(cmd, pose, objects);
+    EXPECT_FLOAT_EQ(result_person.velocity_x, cmd.velocity_x);
+
+    // UNKNOWN at 4m — inside default radius (5.0), gets repulsion.
+    objects.objects[0].class_id = drone::ipc::ObjectClass::UNKNOWN;
+    auto result_unknown         = avoider.avoid(cmd, pose, objects);
+    EXPECT_LT(result_unknown.velocity_x, cmd.velocity_x);
 }
 
 TEST(ObstacleAvoider3DTest, PathAwareDisabledFallback) {

--- a/tests/test_obstacle_avoider_3d.cpp
+++ b/tests/test_obstacle_avoider_3d.cpp
@@ -582,6 +582,115 @@ TEST(ObstacleAvoider3DTest, BypassHysteresisPreventsFlipFlop) {
     EXPECT_FALSE(avoider.close_regime_active());
 }
 
+// ═════════════════════════════════════════════════════════════
+// Per-class config (Epic #519)
+// ═════════════════════════════════════════════════════════════
+
+TEST(ObstacleAvoider3DTest, PerClassInfluenceRadius) {
+    // PERSON (idx 1) with influence_radius=3.0 gets no avoidance at 4m,
+    // but VEHICLE_TRUCK (idx 3) with influence_radius=8.0 does.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m = 5.0f;
+    config.repulsive_gain     = 2.0f;
+    config.path_aware         = false;
+    config.log_corrections    = false;
+
+    ObstacleAvoider3D avoider(config);
+    // Set per-class overrides after construction (constructor syncs from globals).
+    avoider.mutable_config().influence_radius_per_class[1] = 3.0f;  // PERSON
+    avoider.mutable_config().influence_radius_per_class[3] = 8.0f;  // VEHICLE_TRUCK
+
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Object at 4m — outside PERSON radius (3.0) but inside TRUCK radius (8.0).
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 4.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    // As PERSON — no repulsion (outside influence radius).
+    objects.objects[0].class_id = drone::ipc::ObjectClass::PERSON;
+    auto result_person          = avoider.avoid(cmd, pose, objects);
+    EXPECT_FLOAT_EQ(result_person.velocity_x, cmd.velocity_x);
+
+    // As VEHICLE_TRUCK — gets repulsion.
+    objects.objects[0].class_id = drone::ipc::ObjectClass::VEHICLE_TRUCK;
+    auto result_truck           = avoider.avoid(cmd, pose, objects);
+    EXPECT_LT(result_truck.velocity_x, cmd.velocity_x);
+}
+
+TEST(ObstacleAvoider3DTest, PerClassConfidenceThreshold) {
+    // DRONE (idx 4) has min_confidence=0.8, so a 0.5-confidence drone is filtered.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m = 10.0f;
+    config.repulsive_gain     = 2.0f;
+    config.path_aware         = false;
+    config.log_corrections    = false;
+
+    ObstacleAvoider3D avoider(config);
+    // Set per-class override after construction (constructor syncs from globals).
+    avoider.mutable_config().min_confidence_per_class[4] = 0.8f;  // DRONE
+
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 3.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.5f;
+    objects.objects[0].class_id   = drone::ipc::ObjectClass::DRONE;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+    // Filtered out — no repulsion.
+    EXPECT_FLOAT_EQ(result.velocity_x, cmd.velocity_x);
+}
+
+TEST(ObstacleAvoider3DTest, PerClassPredictionDt) {
+    // BUILDING (idx 6) with prediction_dt=0.0 ignores velocity.
+    // DRONE (idx 4) with prediction_dt=1.0 predicts forward.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m = 10.0f;
+    config.repulsive_gain     = 2.0f;
+    config.path_aware         = false;
+    config.log_corrections    = false;
+
+    ObstacleAvoider3D avoider(config);
+    // Set per-class overrides after construction (constructor syncs from globals).
+    avoider.mutable_config().prediction_dt_per_class[6] = 0.0f;  // BUILDING — stationary
+    avoider.mutable_config().prediction_dt_per_class[4] = 1.0f;  // DRONE — aggressive prediction
+
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Object at 8m, approaching at 6 m/s.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 8.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].velocity_x = -6.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    // As BUILDING (prediction_dt=0): predicted pos = 8m, within influence.
+    objects.objects[0].class_id = drone::ipc::ObjectClass::BUILDING;
+    auto result_building        = avoider.avoid(cmd, pose, objects);
+
+    // As DRONE (prediction_dt=1.0): predicted pos = 8+(-6)*1 = 2m, much closer.
+    objects.objects[0].class_id = drone::ipc::ObjectClass::DRONE;
+    auto result_drone           = avoider.avoid(cmd, pose, objects);
+
+    // DRONE should get stronger repulsion (predicted closer).
+    EXPECT_LT(result_drone.velocity_x, result_building.velocity_x);
+}
+
 TEST(ObstacleAvoider3DTest, PathAwareDisabledFallback) {
     // path_aware=false → old isotropic behavior (obstacle ahead reduces vx).
     ObstacleAvoider3DConfig config;

--- a/tests/test_per_class_config.cpp
+++ b/tests/test_per_class_config.cpp
@@ -126,6 +126,17 @@ TEST(PerClassConfig, LoadPerClass_CommentKeysIgnored) {
     EXPECT_FLOAT_EQ(result[1], 2.0f);
 }
 
+TEST(PerClassConfig, LoadPerClass_TypeMismatchUsesFallback) {
+    // "default" is a string but we load as float → type mismatch, should use compiled fallback.
+    nlohmann::json data   = {{"sec", {{"default", "not_a_number"}, {"person", "also_not"}}}};
+    auto           cfg    = make_config(data);
+    auto           result = load_per_class<float>(cfg, "sec", 42.0f);
+
+    for (uint8_t i = 0; i < kPerClassCount; ++i) {
+        EXPECT_FLOAT_EQ(result[i], 42.0f);
+    }
+}
+
 TEST(PerClassConfig, LoadPerClass_StringType) {
     nlohmann::json data = {
         {"sec", {{"default", "constant_velocity"}, {"drone", "constant_acceleration"}}}};

--- a/tests/test_per_class_config.cpp
+++ b/tests/test_per_class_config.cpp
@@ -1,0 +1,164 @@
+// tests/test_per_class_config.cpp
+// Unit tests for drone::util per-class config utility (Epic #519).
+#include "util/per_class_config.h"
+
+#include <fstream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using namespace drone::util;
+
+// ── Helpers ─────────────────────────────────────────────────
+
+static drone::Config make_config(const nlohmann::json& data) {
+    // Write to temp file and load — Config requires a file path.
+    const std::string path = "/tmp/test_per_class_config_" +
+                             std::to_string(reinterpret_cast<uintptr_t>(&data)) + ".json";
+    std::ofstream ofs(path);
+    ofs << data.dump();
+    ofs.close();
+    drone::Config cfg;
+    cfg.load(path);
+    std::remove(path.c_str());
+    return cfg;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// class_name_to_index
+// ═══════════════════════════════════════════════════════════════
+
+TEST(PerClassConfig, ClassNameToIndex_AllValid) {
+    EXPECT_EQ(class_name_to_index("unknown"), 0);
+    EXPECT_EQ(class_name_to_index("person"), 1);
+    EXPECT_EQ(class_name_to_index("vehicle_car"), 2);
+    EXPECT_EQ(class_name_to_index("vehicle_truck"), 3);
+    EXPECT_EQ(class_name_to_index("drone"), 4);
+    EXPECT_EQ(class_name_to_index("animal"), 5);
+    EXPECT_EQ(class_name_to_index("building"), 6);
+    EXPECT_EQ(class_name_to_index("tree"), 7);
+}
+
+TEST(PerClassConfig, ClassNameToIndex_InvalidReturnsNeg1) {
+    EXPECT_EQ(class_name_to_index("personn"), -1);
+    EXPECT_EQ(class_name_to_index(""), -1);
+    EXPECT_EQ(class_name_to_index("PERSON"), -1);
+}
+
+// ═══════════════════════════════════════════════════════════════
+// load_per_class
+// ═══════════════════════════════════════════════════════════════
+
+TEST(PerClassConfig, LoadPerClass_AllClassesSpecified) {
+    nlohmann::json data   = {{"test_section",
+                              {{"unknown", 1.0},
+                               {"person", 2.0},
+                               {"vehicle_car", 3.0},
+                               {"vehicle_truck", 4.0},
+                               {"drone", 5.0},
+                               {"animal", 6.0},
+                               {"building", 7.0},
+                               {"tree", 8.0}}}};
+    auto           cfg    = make_config(data);
+    auto           result = load_per_class<float>(cfg, "test_section", 0.0f);
+
+    EXPECT_FLOAT_EQ(result[0], 1.0f);
+    EXPECT_FLOAT_EQ(result[1], 2.0f);
+    EXPECT_FLOAT_EQ(result[2], 3.0f);
+    EXPECT_FLOAT_EQ(result[3], 4.0f);
+    EXPECT_FLOAT_EQ(result[4], 5.0f);
+    EXPECT_FLOAT_EQ(result[5], 6.0f);
+    EXPECT_FLOAT_EQ(result[6], 7.0f);
+    EXPECT_FLOAT_EQ(result[7], 8.0f);
+}
+
+TEST(PerClassConfig, LoadPerClass_DefaultFallback) {
+    nlohmann::json data   = {{"test_section", {{"default", 5.0}, {"person", 2.0}}}};
+    auto           cfg    = make_config(data);
+    auto           result = load_per_class<float>(cfg, "test_section", 99.0f);
+
+    EXPECT_FLOAT_EQ(result[0], 5.0f);  // unknown → default
+    EXPECT_FLOAT_EQ(result[1], 2.0f);  // person → override
+    EXPECT_FLOAT_EQ(result[4], 5.0f);  // drone → default
+    EXPECT_FLOAT_EQ(result[7], 5.0f);  // tree → default
+}
+
+TEST(PerClassConfig, LoadPerClass_NoDefault_UsesFallback) {
+    nlohmann::json data   = {{"test_section", {{"person", 2.0}}}};
+    auto           cfg    = make_config(data);
+    auto           result = load_per_class<float>(cfg, "test_section", 99.0f);
+
+    EXPECT_FLOAT_EQ(result[0], 99.0f);  // fallback
+    EXPECT_FLOAT_EQ(result[1], 2.0f);   // person override
+    EXPECT_FLOAT_EQ(result[4], 99.0f);  // fallback
+}
+
+TEST(PerClassConfig, LoadPerClass_MissingSection) {
+    nlohmann::json data   = {{"other_section", 42}};
+    auto           cfg    = make_config(data);
+    auto           result = load_per_class<float>(cfg, "test_section", 7.0f);
+
+    for (uint8_t i = 0; i < kPerClassCount; ++i) {
+        EXPECT_FLOAT_EQ(result[i], 7.0f);
+    }
+}
+
+TEST(PerClassConfig, LoadPerClass_UnknownKeysCollected) {
+    nlohmann::json           data = {{"sec", {{"default", 1.0}, {"personn", 2.0}, {"cat", 3.0}}}};
+    auto                     cfg  = make_config(data);
+    std::vector<std::string> unknown;
+    auto                     result = load_per_class<float>(cfg, "sec", 0.0f, &unknown);
+
+    EXPECT_EQ(unknown.size(), 2u);
+    // All values should be the default since the keys were unrecognized.
+    EXPECT_FLOAT_EQ(result[1], 1.0f);
+}
+
+TEST(PerClassConfig, LoadPerClass_CommentKeysIgnored) {
+    nlohmann::json data = {
+        {"sec", {{"default", 1.0}, {"_comment", "this is a comment"}, {"person", 2.0}}}};
+    auto                     cfg = make_config(data);
+    std::vector<std::string> unknown;
+    auto                     result = load_per_class<float>(cfg, "sec", 0.0f, &unknown);
+
+    EXPECT_TRUE(unknown.empty());
+    EXPECT_FLOAT_EQ(result[1], 2.0f);
+}
+
+TEST(PerClassConfig, LoadPerClass_StringType) {
+    nlohmann::json data = {
+        {"sec", {{"default", "constant_velocity"}, {"drone", "constant_acceleration"}}}};
+    auto cfg    = make_config(data);
+    auto result = load_per_class<std::string>(cfg, "sec", "constant_velocity");
+
+    EXPECT_EQ(result[0], "constant_velocity");
+    EXPECT_EQ(result[4], "constant_acceleration");
+}
+
+// ═══════════════════════════════════════════════════════════════
+// validate_per_class_section
+// ═══════════════════════════════════════════════════════════════
+
+TEST(PerClassConfig, Validate_AllValid) {
+    nlohmann::json data = {
+        {"sec", {{"default", 1.0}, {"person", 2.0}, {"drone", 3.0}, {"_comment_x", "ok"}}}};
+    auto cfg    = make_config(data);
+    auto errors = validate_per_class_section(cfg, "sec");
+    EXPECT_TRUE(errors.empty());
+}
+
+TEST(PerClassConfig, Validate_UnknownClassName) {
+    nlohmann::json data   = {{"sec", {{"personn", 2.0}}}};
+    auto           cfg    = make_config(data);
+    auto           errors = validate_per_class_section(cfg, "sec");
+    ASSERT_EQ(errors.size(), 1u);
+    EXPECT_NE(errors[0].find("personn"), std::string::npos);
+}
+
+TEST(PerClassConfig, Validate_MissingSectionReturnsEmpty) {
+    nlohmann::json data   = {{"other", 1}};
+    auto           cfg    = make_config(data);
+    auto           errors = validate_per_class_section(cfg, "sec");
+    EXPECT_TRUE(errors.empty());
+}


### PR DESCRIPTION
## Summary

- Adds reusable `load_per_class<T>()` utility (`per_class_config.h`) that maps JSON sections like `{ "default": 5.0, "person": 2.0 }` into `std::array<T, 8>` indexed by `ObjectClass` enum
- ObstacleAvoider3D now uses per-class overrides for influence radius, repulsive gain, min distance, prediction horizon, and confidence threshold
- KalmanBoxTracker supports per-class motion model (`constant_velocity` vs `constant_acceleration`)
- `ConfigSchema::per_class_section()` validates class names at startup — typos like `"personn"` are rejected with clear error messages
- `config/default.json` populated with safe per-class defaults (e.g., `person` gets tighter influence radius, `building`/`tree` get zero prediction horizon)

## Design Decisions

- **Two-phase initialization**: constructors sync per-class arrays from global scalars (backward compat for legacy configs/tests), then Config-driven constructors overwrite from JSON per-class sections
- **Header-only utility** in `common/util/` — usable by both P2 and P4 with no new deps
- **`mutable_config()` accessor** exposed for tests needing per-class overrides after construction
- Close-regime hysteresis still uses global `min_distance_m` (aggregate check across all obstacles, not per-obstacle)

## Files Changed

| File | Change |
|------|--------|
| `common/util/include/util/per_class_config.h` | **NEW** — core utility |
| `common/util/include/util/config_keys.h` | +6 per-class key constants |
| `common/util/include/util/config_validator.h` | `per_class_section()` + schema updates |
| `process4_mission_planner/include/planner/obstacle_avoider_3d.h` | 5 per-class arrays, `sync_per_class_from_globals()`, per-class lookups in `avoid()` |
| `process2_perception/include/perception/kalman_tracker.h` | `MotionModel` enum |
| `process2_perception/include/perception/bytetrack_tracker.h` | per-class motion model array |
| `process2_perception/src/kalman_tracker.cpp` | motion-model-aware velocity noise |
| `process2_perception/src/bytetrack_tracker.cpp` | per-class model at track creation |
| `config/default.json` | per-class sections |
| `tests/test_per_class_config.cpp` | **NEW** — 12 tests |
| `tests/test_obstacle_avoider_3d.cpp` | +3 per-class tests |
| `tests/test_kalman_tracker.cpp` | +3 motion model tests |
| `tests/test_config_validator.cpp` | +4 per-class validation tests |

## Test plan

- [x] `bash deploy/build.sh` — zero warnings
- [x] `./tests/run_tests.sh` — 1704/1704 pass
- [x] `clang-format-18 --dry-run --Werror` — clean
- [ ] Review agents: memory safety, concurrency, API contract, test quality

Closes #519, #550, #551, #552, #553, #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)