### PR TITLE
feat(#515): E1 HAL Interface Layer — Perception v2 Abstractions

### DIFF
--- a/common/hal/include/hal/cpu_semantic_projector.h
+++ b/common/hal/include/hal/cpu_semantic_projector.h
@@ -1,0 +1,138 @@
+// common/hal/include/hal/cpu_semantic_projector.h
+// CPU reference implementation of ISemanticProjector.
+// Back-projects detections through a pinhole model using depth map samples.
+#pragma once
+
+#include "hal/isemantic_projector.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace drone::hal {
+
+class CpuSemanticProjector : public ISemanticProjector {
+public:
+    [[nodiscard]] bool init(const CameraIntrinsics& intrinsics) override {
+        if (intrinsics.width == 0 || intrinsics.height == 0) return false;
+        if (intrinsics.fx <= 0.0f || intrinsics.fy <= 0.0f) return false;
+        intrinsics_  = intrinsics;
+        initialized_ = true;
+        return true;
+    }
+
+    [[nodiscard]] drone::util::Result<std::vector<VoxelUpdate>, std::string> project(
+        const std::vector<InferenceDetection>& detections, const DepthMap& depth,
+        const Eigen::Affine3f& camera_pose) override {
+        if (!initialized_) {
+            return drone::util::Result<std::vector<VoxelUpdate>, std::string>::err(
+                "CpuSemanticProjector not initialized");
+        }
+        if (depth.data.empty() || depth.width == 0 || depth.height == 0) {
+            return drone::util::Result<std::vector<VoxelUpdate>, std::string>::err(
+                "Invalid depth map");
+        }
+
+        std::vector<VoxelUpdate> updates;
+        updates.reserve(detections.size());
+
+        // Scale factors from image coords to depth map coords
+        const float depth_src_w = depth.source_width > 0 ? static_cast<float>(depth.source_width)
+                                                         : static_cast<float>(depth.width);
+        const float depth_src_h = depth.source_height > 0 ? static_cast<float>(depth.source_height)
+                                                          : static_cast<float>(depth.height);
+        const float scale_x     = static_cast<float>(depth.width) / depth_src_w;
+        const float scale_y     = static_cast<float>(depth.height) / depth_src_h;
+
+        for (const auto& det : detections) {
+            if (!det.mask.empty() && det.mask_width > 0 && det.mask_height > 0) {
+                // Sparse grid sampling within mask
+                project_masked(det, depth, camera_pose, scale_x, scale_y, updates);
+            } else {
+                // Single sample at bbox centre
+                project_bbox_centre(det, depth, camera_pose, scale_x, scale_y, updates);
+            }
+        }
+
+        return drone::util::Result<std::vector<VoxelUpdate>, std::string>::ok(std::move(updates));
+    }
+
+    [[nodiscard]] std::string name() const override { return "CpuSemanticProjector"; }
+
+private:
+    CameraIntrinsics intrinsics_{};
+    bool             initialized_{false};
+
+    // Back-project pixel (u,v) at depth Z to a world-frame 3D point
+    [[nodiscard]] Eigen::Vector3f backproject(float u, float v, float z,
+                                              const Eigen::Affine3f& camera_pose) const {
+        const float     x_cam = (u - intrinsics_.cx) * z / intrinsics_.fx;
+        const float     y_cam = (v - intrinsics_.cy) * z / intrinsics_.fy;
+        Eigen::Vector3f pt_cam(x_cam, y_cam, z);
+        return camera_pose * pt_cam;
+    }
+
+    [[nodiscard]] float sample_depth(const DepthMap& depth, float u, float v, float scale_x,
+                                     float scale_y) const {
+        const auto dx = static_cast<uint32_t>(
+            std::clamp(u * scale_x, 0.0f, static_cast<float>(depth.width - 1)));
+        const auto dy = static_cast<uint32_t>(
+            std::clamp(v * scale_y, 0.0f, static_cast<float>(depth.height - 1)));
+        const float d = depth.data[dy * depth.width + dx] * depth.scale;
+        if (!std::isfinite(d) || d <= 0.0f) return 0.0f;
+        return d;
+    }
+
+    void project_bbox_centre(const InferenceDetection& det, const DepthMap& depth,
+                             const Eigen::Affine3f& camera_pose, float scale_x, float scale_y,
+                             std::vector<VoxelUpdate>& updates) const {
+        const float u = det.bbox.x + det.bbox.w * 0.5f;
+        const float v = det.bbox.y + det.bbox.h * 0.5f;
+        const float z = sample_depth(depth, u, v, scale_x, scale_y);
+        if (z <= 0.0f) return;
+
+        VoxelUpdate vu;
+        vu.position_m     = backproject(u, v, z, camera_pose);
+        vu.semantic_label = static_cast<uint8_t>(std::max(det.class_id, 0));
+        vu.confidence     = det.confidence;
+        vu.occupancy      = 1.0f;
+        updates.push_back(vu);
+    }
+
+    void project_masked(const InferenceDetection& det, const DepthMap& depth,
+                        const Eigen::Affine3f& camera_pose, float scale_x, float scale_y,
+                        std::vector<VoxelUpdate>& updates) const {
+        // Sparse 4x4 grid within the mask bounding box
+        constexpr int GRID   = 4;
+        const float   step_x = det.bbox.w / static_cast<float>(GRID);
+        const float   step_y = det.bbox.h / static_cast<float>(GRID);
+
+        for (int gy = 0; gy < GRID; ++gy) {
+            for (int gx = 0; gx < GRID; ++gx) {
+                const float u = det.bbox.x + (static_cast<float>(gx) + 0.5f) * step_x;
+                const float v = det.bbox.y + (static_cast<float>(gy) + 0.5f) * step_y;
+
+                // Check mask at this sample point
+                const auto mx = static_cast<uint32_t>(
+                    std::clamp((u - det.bbox.x) / det.bbox.w * static_cast<float>(det.mask_width),
+                               0.0f, static_cast<float>(det.mask_width - 1)));
+                const auto my = static_cast<uint32_t>(
+                    std::clamp((v - det.bbox.y) / det.bbox.h * static_cast<float>(det.mask_height),
+                               0.0f, static_cast<float>(det.mask_height - 1)));
+                if (det.mask[my * det.mask_width + mx] < 128) continue;
+
+                const float z = sample_depth(depth, u, v, scale_x, scale_y);
+                if (z <= 0.0f) continue;
+
+                VoxelUpdate vu;
+                vu.position_m     = backproject(u, v, z, camera_pose);
+                vu.semantic_label = static_cast<uint8_t>(std::max(det.class_id, 0));
+                vu.confidence     = det.confidence;
+                vu.occupancy      = 1.0f;
+                updates.push_back(vu);
+            }
+        }
+    }
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -16,18 +16,26 @@
 // Future backends: "v4l2", "udp", "siyi", "bmi088", etc.
 #pragma once
 
+#include "hal/cpu_semantic_projector.h"
 #include "hal/icamera.h"
+#include "hal/ievent_camera.h"
 #include "hal/ifc_link.h"
 #include "hal/igcs_link.h"
 #include "hal/igimbal.h"
 #include "hal/iimu_source.h"
+#include "hal/iinference_backend.h"
+#include "hal/isemantic_projector.h"
+#include "hal/ivolumetric_map.h"
 #include "hal/simulated_camera.h"
 #include "hal/simulated_depth_estimator.h"
+#include "hal/simulated_event_camera.h"
 #include "hal/simulated_fc_link.h"
 #include "hal/simulated_gcs_link.h"
 #include "hal/simulated_gimbal.h"
 #include "hal/simulated_imu.h"
+#include "hal/simulated_inference_backend.h"
 #include "hal/simulated_radar.h"
+#include "hal/simulated_volumetric_map.h"
 
 
 // Optional backends — only included when the dependency is found by CMake
@@ -332,6 +340,90 @@ template<typename Interface>
 #endif
 
     throw std::runtime_error("[HAL] Unknown depth estimator backend: " + backend);
+}
+
+/// Create an inference backend from config.
+/// @param cfg      Loaded configuration
+/// @param section  Config path prefix (e.g. "perception.inference_backend")
+[[nodiscard]] inline std::unique_ptr<IInferenceBackend> create_inference_backend(
+    const drone::Config& cfg,
+    const std::string&   section = drone::cfg_key::perception::inference_backend::SECTION) {
+    auto backend = cfg.get<std::string>(section + drone::cfg_key::hal::BACKEND, "simulated");
+    DRONE_LOG_INFO("[HAL] Creating inference backend '{}' backend='{}'", section, backend);
+
+    if (backend == "simulated") {
+        return std::make_unique<SimulatedInferenceBackend>(cfg, section);
+    }
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        return load_plugin<IInferenceBackend>(cfg, section, "inference backend");
+    }
+#endif
+
+    throw std::runtime_error("[HAL] Unknown inference backend: " + backend);
+}
+
+/// Create a volumetric map from config.
+/// @param cfg      Loaded configuration
+/// @param section  Config path prefix (e.g. "perception.volumetric_map")
+[[nodiscard]] inline std::unique_ptr<IVolumetricMap> create_volumetric_map(
+    const drone::Config& cfg,
+    const std::string&   section = drone::cfg_key::perception::volumetric_map::SECTION) {
+    auto backend = cfg.get<std::string>(section + drone::cfg_key::hal::BACKEND, "simulated");
+    DRONE_LOG_INFO("[HAL] Creating volumetric map '{}' backend='{}'", section, backend);
+
+    if (backend == "simulated") {
+        return std::make_unique<SimulatedVolumetricMap>(cfg, section);
+    }
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        return load_plugin<IVolumetricMap>(cfg, section, "volumetric map");
+    }
+#endif
+
+    throw std::runtime_error("[HAL] Unknown volumetric map backend: " + backend);
+}
+
+/// Create an event camera from config.
+/// @param cfg      Loaded configuration
+/// @param section  Config path prefix (e.g. "perception.event_camera")
+[[nodiscard]] inline std::unique_ptr<IEventCamera> create_event_camera(
+    const drone::Config& cfg,
+    const std::string&   section = drone::cfg_key::perception::event_camera::SECTION) {
+    auto backend = cfg.get<std::string>(section + drone::cfg_key::hal::BACKEND, "simulated");
+    DRONE_LOG_INFO("[HAL] Creating event camera '{}' backend='{}'", section, backend);
+
+    if (backend == "simulated") {
+        return std::make_unique<SimulatedEventCamera>();
+    }
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        return load_plugin<IEventCamera>(cfg, section, "event camera");
+    }
+#endif
+
+    throw std::runtime_error("[HAL] Unknown event camera backend: " + backend);
+}
+
+/// Create a semantic projector from config.
+/// @param cfg      Loaded configuration
+/// @param section  Config path prefix (e.g. "perception.semantic_projector")
+[[nodiscard]] inline std::unique_ptr<ISemanticProjector> create_semantic_projector(
+    const drone::Config& cfg,
+    const std::string&   section = drone::cfg_key::perception::semantic_projector::SECTION) {
+    auto backend = cfg.get<std::string>(section + drone::cfg_key::hal::BACKEND, "cpu");
+    DRONE_LOG_INFO("[HAL] Creating semantic projector '{}' backend='{}'", section, backend);
+
+    if (backend == "cpu") {
+        return std::make_unique<CpuSemanticProjector>();
+    }
+#ifdef HAVE_PLUGINS
+    if (backend == "plugin") {
+        return load_plugin<ISemanticProjector>(cfg, section, "semantic projector");
+    }
+#endif
+
+    throw std::runtime_error("[HAL] Unknown semantic projector backend: " + backend);
 }
 
 }  // namespace drone::hal

--- a/common/hal/include/hal/ievent_camera.h
+++ b/common/hal/include/hal/ievent_camera.h
@@ -1,0 +1,57 @@
+// common/hal/include/hal/ievent_camera.h
+// HAL interface: Event camera (DVS) abstraction.
+// Reserved slot for future event camera integration.
+// Implementations: SimulatedEventCamera (built-in).
+// Future: Prophesee EVK4, iniVation DAVIS backends.
+#pragma once
+
+#include "hal/pixel_format.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drone::hal {
+
+/// Single contrast detection event from a DVS sensor.
+struct EventCD {
+    uint16_t x{0};
+    uint16_t y{0};
+    int8_t   polarity{0};
+    uint64_t timestamp_ns{0};
+};
+
+/// Batch of events read from the sensor in one call.
+struct EventBatch {
+    std::vector<EventCD> events;
+    uint64_t             batch_start_ns{0};
+    uint64_t             batch_end_ns{0};
+    bool                 valid{false};
+};
+
+/// Abstract event camera interface.
+class IEventCamera {
+public:
+    virtual ~IEventCamera() = default;
+
+    /// Open the event sensor with the given resolution.
+    [[nodiscard]] virtual bool open(uint32_t width, uint32_t height) = 0;
+
+    /// Close the sensor and release resources.
+    virtual void close() = 0;
+
+    /// Read the next batch of events. May block or return immediately
+    /// depending on backend. Check EventBatch::valid.
+    [[nodiscard]] virtual EventBatch read_events() = 0;
+
+    /// Check whether the sensor is currently open.
+    [[nodiscard]] virtual bool is_open() const = 0;
+
+    /// The pixel format this sensor produces.
+    [[nodiscard]] virtual PixelFormat pixel_format() const = 0;
+
+    /// Human-readable name.
+    [[nodiscard]] virtual std::string name() const = 0;
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/iinference_backend.h
+++ b/common/hal/include/hal/iinference_backend.h
@@ -1,0 +1,61 @@
+// common/hal/include/hal/iinference_backend.h
+// HAL interface: Detector-agnostic inference abstraction.
+// Wraps any model (YOLO, RT-DETR, SAM, etc.) behind a uniform API.
+// Implementations: SimulatedInferenceBackend (built-in).
+// Future: OpenCV DNN, ONNX Runtime, TensorRT backends.
+#pragma once
+
+#include "util/result.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace drone::hal {
+
+struct BoundingBox2D {
+    float x{0.0f};
+    float y{0.0f};
+    float w{0.0f};
+    float h{0.0f};
+};
+
+struct InferenceDetection {
+    BoundingBox2D        bbox;
+    int                  class_id{-1};
+    float                confidence{0.0f};
+    std::vector<uint8_t> mask;
+    uint32_t             mask_width{0};
+    uint32_t             mask_height{0};
+};
+
+struct InferenceOutput {
+    std::vector<InferenceDetection> detections;
+    uint64_t                        timestamp_ns{0};
+};
+
+/// Abstract inference backend interface.
+/// One instance per model (detector, segmenter, depth estimator, etc.).
+class IInferenceBackend {
+public:
+    virtual ~IInferenceBackend() = default;
+
+    /// Load the model from the given path. input_size is the model's expected
+    /// square input dimension (e.g. 640 for YOLOv8).
+    [[nodiscard]] virtual bool init(const std::string& model_path, int input_size) = 0;
+
+    /// Run inference on a single frame.
+    /// @param frame_data  Pointer to pixel data (RGB, valid for this call only).
+    /// @param width       Frame width in pixels
+    /// @param height      Frame height in pixels
+    /// @param channels    Number of channels (3=RGB, 4=RGBA)
+    /// @param stride      Row stride in bytes (0 = tightly packed)
+    [[nodiscard]] virtual drone::util::Result<InferenceOutput, std::string> infer(
+        const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
+        uint32_t stride = 0) = 0;
+
+    /// Human-readable backend name.
+    [[nodiscard]] virtual std::string name() const = 0;
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/isemantic_projector.h
+++ b/common/hal/include/hal/isemantic_projector.h
@@ -1,0 +1,42 @@
+// common/hal/include/hal/isemantic_projector.h
+// HAL interface: projects 2D detections + depth into 3D voxel updates.
+// Implementations: CpuSemanticProjector (pinhole back-projection).
+#pragma once
+
+#include "hal/idepth_estimator.h"
+#include "hal/iinference_backend.h"
+#include "hal/ivolumetric_map.h"
+#include "util/result.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace drone::hal {
+
+struct CameraIntrinsics {
+    float    fx{0.0f};
+    float    fy{0.0f};
+    float    cx{0.0f};
+    float    cy{0.0f};
+    uint32_t width{0};
+    uint32_t height{0};
+};
+
+class ISemanticProjector {
+public:
+    virtual ~ISemanticProjector() = default;
+
+    [[nodiscard]] virtual bool init(const CameraIntrinsics& intrinsics) = 0;
+
+    [[nodiscard]] virtual drone::util::Result<std::vector<VoxelUpdate>, std::string> project(
+        const std::vector<InferenceDetection>& detections, const DepthMap& depth,
+        const Eigen::Affine3f& camera_pose) = 0;
+
+    [[nodiscard]] virtual std::string name() const = 0;
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/ivolumetric_map.h
+++ b/common/hal/include/hal/ivolumetric_map.h
@@ -1,0 +1,78 @@
+// common/hal/include/hal/ivolumetric_map.h
+// HAL interface: Volumetric map abstraction for 3D occupancy + semantic labels.
+// Implementations: SimulatedVolumetricMap (built-in, hash-map CPU).
+// Future: UFOMap, nvblox (GPU), Vulkan-compute backends.
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace drone::hal {
+
+struct VoxelKey {
+    int32_t x{0};
+    int32_t y{0};
+    int32_t z{0};
+
+    bool operator==(const VoxelKey& o) const { return x == o.x && y == o.y && z == o.z; }
+};
+
+struct VoxelKeyHash {
+    std::size_t operator()(const VoxelKey& k) const {
+        auto h1 = std::hash<int32_t>{}(k.x);
+        auto h2 = std::hash<int32_t>{}(k.y);
+        auto h3 = std::hash<int32_t>{}(k.z);
+        return h1 ^ (h2 << 11) ^ (h3 << 22);
+    }
+};
+
+struct VoxelData {
+    float    occupancy{0.0f};
+    uint8_t  semantic_label{0};
+    float    confidence{0.0f};
+    uint64_t last_updated_ns{0};
+};
+
+struct VoxelUpdate {
+    Eigen::Vector3f position_m{Eigen::Vector3f::Zero()};
+    float           occupancy{1.0f};
+    uint8_t         semantic_label{0};
+    float           confidence{0.5f};
+    uint64_t        timestamp_ns{0};
+};
+
+/// Abstract volumetric map interface.
+/// Stores 3D occupancy with optional semantic labels per voxel.
+class IVolumetricMap {
+public:
+    virtual ~IVolumetricMap() = default;
+
+    /// Initialize the map with the given voxel resolution (meters per voxel side).
+    [[nodiscard]] virtual bool init(float resolution_m) = 0;
+
+    /// Insert voxel updates into the map.
+    [[nodiscard]] virtual bool insert(const std::vector<VoxelUpdate>& updates) = 0;
+
+    /// Query the voxel at a world-frame position. Returns nullopt if no data.
+    [[nodiscard]] virtual std::optional<VoxelData> query(
+        const Eigen::Vector3f& position_m) const = 0;
+
+    /// Number of occupied voxels in the map.
+    [[nodiscard]] virtual size_t size() const = 0;
+
+    /// Clear all voxels.
+    virtual void clear() = 0;
+
+    /// Voxel resolution in meters.
+    [[nodiscard]] virtual float resolution() const = 0;
+
+    /// Human-readable backend name.
+    [[nodiscard]] virtual std::string name() const = 0;
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/pixel_format.h
+++ b/common/hal/include/hal/pixel_format.h
@@ -1,0 +1,39 @@
+// common/hal/include/hal/pixel_format.h
+// Pixel format enumeration for camera and sensor data.
+// Includes reserved slots for thermal imaging and event cameras.
+#pragma once
+
+#include <cstdint>
+
+namespace drone::hal {
+
+enum class PixelFormat : uint8_t {
+    GRAY8       = 0,
+    RGB8        = 1,
+    BGR8        = 2,
+    RGBA8       = 3,
+    NV12        = 4,
+    YUYV        = 5,
+    BAYER_RGGB8 = 6,
+
+    // Reserved: thermal imaging (see docs/design/perception_architecture.md)
+    THERMAL_8  = 20,
+    THERMAL_16 = 21,
+
+    // Reserved: event cameras / DVS (see docs/design/perception_architecture.md)
+    EVENT_CD = 30,
+};
+
+inline constexpr uint8_t pixel_format_channels(PixelFormat fmt) {
+    switch (fmt) {
+        case PixelFormat::GRAY8: return 1;
+        case PixelFormat::RGB8: return 3;
+        case PixelFormat::BGR8: return 3;
+        case PixelFormat::RGBA8: return 4;
+        case PixelFormat::THERMAL_8: return 1;
+        case PixelFormat::THERMAL_16: return 1;
+        default: return 0;
+    }
+}
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/simulated_event_camera.h
+++ b/common/hal/include/hal/simulated_event_camera.h
@@ -1,0 +1,61 @@
+// common/hal/include/hal/simulated_event_camera.h
+// Simulated event camera: generates deterministic synthetic events.
+// Used by unit tests. No external dependencies.
+#pragma once
+
+#include "hal/ievent_camera.h"
+
+namespace drone::hal {
+
+class SimulatedEventCamera : public IEventCamera {
+public:
+    explicit SimulatedEventCamera(int events_per_batch = 100)
+        : events_per_batch_(events_per_batch) {}
+
+    [[nodiscard]] bool open(uint32_t width, uint32_t height) override {
+        if (width == 0 || height == 0) return false;
+        width_  = width;
+        height_ = height;
+        open_   = true;
+        return true;
+    }
+
+    void close() override { open_ = false; }
+
+    [[nodiscard]] EventBatch read_events() override {
+        EventBatch batch;
+        if (!open_) return batch;
+
+        batch.valid          = true;
+        batch.batch_start_ns = counter_ * 1000000;
+        batch.events.reserve(static_cast<size_t>(events_per_batch_));
+
+        for (int i = 0; i < events_per_batch_; ++i) {
+            EventCD ev;
+            ev.x        = static_cast<uint16_t>((counter_ + static_cast<uint64_t>(i)) % width_);
+            ev.y        = static_cast<uint16_t>((counter_ + static_cast<uint64_t>(i)) % height_);
+            ev.polarity = (i % 2 == 0) ? int8_t{1} : int8_t{-1};
+            ev.timestamp_ns = batch.batch_start_ns + static_cast<uint64_t>(i) * 10;
+            batch.events.push_back(ev);
+        }
+
+        batch.batch_end_ns = batch.batch_start_ns + static_cast<uint64_t>(events_per_batch_) * 10;
+        ++counter_;
+        return batch;
+    }
+
+    [[nodiscard]] bool is_open() const override { return open_; }
+
+    [[nodiscard]] PixelFormat pixel_format() const override { return PixelFormat::EVENT_CD; }
+
+    [[nodiscard]] std::string name() const override { return "SimulatedEventCamera"; }
+
+private:
+    int      events_per_batch_;
+    uint32_t width_{0};
+    uint32_t height_{0};
+    bool     open_{false};
+    uint64_t counter_{0};
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/simulated_inference_backend.h
+++ b/common/hal/include/hal/simulated_inference_backend.h
@@ -1,0 +1,74 @@
+// common/hal/include/hal/simulated_inference_backend.h
+// Simulated inference backend: returns deterministic synthetic detections.
+// Used by unit tests and quick dev cycles without ML models.
+#pragma once
+
+#include "hal/iinference_backend.h"
+#include "util/config.h"
+
+#include <algorithm>
+
+namespace drone::hal {
+
+class SimulatedInferenceBackend : public IInferenceBackend {
+public:
+    explicit SimulatedInferenceBackend(int num_detections = 2, float confidence_min = 0.4f,
+                                       float confidence_max = 0.9f)
+        : num_detections_(num_detections)
+        , confidence_min_(confidence_min)
+        , confidence_max_(confidence_max) {}
+
+    SimulatedInferenceBackend(const drone::Config& cfg, const std::string& section)
+        : num_detections_(cfg.get<int>(section + ".num_detections", 2))
+        , confidence_min_(cfg.get<float>(section + ".confidence_min", 0.4f))
+        , confidence_max_(cfg.get<float>(section + ".confidence_max", 0.9f)) {}
+
+    [[nodiscard]] bool init(const std::string& /*model_path*/, int input_size) override {
+        input_size_  = input_size;
+        initialized_ = true;
+        return true;
+    }
+
+    [[nodiscard]] drone::util::Result<InferenceOutput, std::string> infer(
+        const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
+        uint32_t /*stride*/) override {
+        using R = drone::util::Result<InferenceOutput, std::string>;
+        if (!frame_data) {
+            return R::err("Null frame data");
+        }
+        if (width == 0 || height == 0 || channels == 0) {
+            return R::err("Invalid frame dimensions");
+        }
+
+        InferenceOutput output;
+        output.timestamp_ns = counter_++;
+
+        const int n = std::max(0, num_detections_);
+        output.detections.reserve(static_cast<size_t>(n));
+
+        for (int i = 0; i < n; ++i) {
+            InferenceDetection det;
+            const float frac = (n > 1) ? static_cast<float>(i) / static_cast<float>(n - 1) : 0.5f;
+            det.bbox.x       = static_cast<float>(width) * (0.1f + 0.6f * frac);
+            det.bbox.y       = static_cast<float>(height) * 0.2f;
+            det.bbox.w       = static_cast<float>(width) * 0.15f;
+            det.bbox.h       = static_cast<float>(height) * 0.3f;
+            det.class_id     = i % 8;
+            det.confidence   = confidence_min_ + (confidence_max_ - confidence_min_) * frac;
+            output.detections.push_back(std::move(det));
+        }
+        return R::ok(std::move(output));
+    }
+
+    [[nodiscard]] std::string name() const override { return "SimulatedInferenceBackend"; }
+
+private:
+    int      num_detections_;
+    float    confidence_min_;
+    float    confidence_max_;
+    int      input_size_{640};
+    bool     initialized_{false};
+    uint64_t counter_{0};
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/simulated_volumetric_map.h
+++ b/common/hal/include/hal/simulated_volumetric_map.h
@@ -1,0 +1,68 @@
+// common/hal/include/hal/simulated_volumetric_map.h
+// CPU reference volumetric map using std::unordered_map.
+// No external dependencies. Used by unit tests and quick dev cycles.
+#pragma once
+
+#include "hal/ivolumetric_map.h"
+#include "util/config.h"
+
+#include <cmath>
+#include <unordered_map>
+
+namespace drone::hal {
+
+class SimulatedVolumetricMap : public IVolumetricMap {
+public:
+    explicit SimulatedVolumetricMap(float resolution_m = 0.2f) : resolution_(resolution_m) {}
+
+    SimulatedVolumetricMap(const drone::Config& cfg, const std::string& section)
+        : resolution_(cfg.get<float>(section + ".resolution_m", 0.2f)) {}
+
+    [[nodiscard]] bool init(float resolution_m) override {
+        if (resolution_m <= 0.0f) return false;
+        resolution_ = resolution_m;
+        map_.clear();
+        initialized_ = true;
+        return true;
+    }
+
+    [[nodiscard]] bool insert(const std::vector<VoxelUpdate>& updates) override {
+        for (const auto& u : updates) {
+            auto  key             = to_key(u.position_m);
+            auto& voxel           = map_[key];
+            voxel.occupancy       = u.occupancy;
+            voxel.semantic_label  = u.semantic_label;
+            voxel.confidence      = u.confidence;
+            voxel.last_updated_ns = u.timestamp_ns;
+        }
+        return true;
+    }
+
+    [[nodiscard]] std::optional<VoxelData> query(const Eigen::Vector3f& position_m) const override {
+        auto key = to_key(position_m);
+        auto it  = map_.find(key);
+        if (it == map_.end()) return std::nullopt;
+        return it->second;
+    }
+
+    [[nodiscard]] size_t size() const override { return map_.size(); }
+
+    void clear() override { map_.clear(); }
+
+    [[nodiscard]] float resolution() const override { return resolution_; }
+
+    [[nodiscard]] std::string name() const override { return "SimulatedVolumetricMap"; }
+
+private:
+    VoxelKey to_key(const Eigen::Vector3f& pos) const {
+        return {static_cast<int32_t>(std::floor(pos.x() / resolution_)),
+                static_cast<int32_t>(std::floor(pos.y() / resolution_)),
+                static_cast<int32_t>(std::floor(pos.z() / resolution_))};
+    }
+
+    float                                                 resolution_{0.2f};
+    bool                                                  initialized_{false};
+    std::unordered_map<VoxelKey, VoxelData, VoxelKeyHash> map_;
+};
+
+}  // namespace drone::hal

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -136,6 +136,25 @@ inline constexpr const char* HEIGHT_PRIORS_TREE     = "perception.fusion.height_
 inline constexpr const char* BBOX_HEIGHT_NOISE_PX   = "perception.fusion.bbox_height_noise_px";
 }  // namespace fusion
 
+namespace inference_backend {
+inline constexpr const char* SECTION    = "perception.inference_backend";
+inline constexpr const char* MODEL_PATH = "perception.inference_backend.model_path";
+inline constexpr const char* INPUT_SIZE = "perception.inference_backend.input_size";
+}  // namespace inference_backend
+
+namespace volumetric_map {
+inline constexpr const char* SECTION      = "perception.volumetric_map";
+inline constexpr const char* RESOLUTION_M = "perception.volumetric_map.resolution_m";
+}  // namespace volumetric_map
+
+namespace event_camera {
+inline constexpr const char* SECTION = "perception.event_camera";
+}  // namespace event_camera
+
+namespace semantic_projector {
+inline constexpr const char* SECTION = "perception.semantic_projector";
+}  // namespace semantic_projector
+
 // Shutdown drain behaviour (Issue #446)
 inline constexpr const char* DRAIN_TIMEOUT_MS = "perception.drain_timeout_ms";
 

--- a/config/default.json
+++ b/config/default.json
@@ -103,6 +103,21 @@
             "false_alarm_rate": 0.02,
             "num_targets": 3
         },
+        "inference_backend": {
+            "backend": "simulated",
+            "model_path": "",
+            "input_size": 640
+        },
+        "volumetric_map": {
+            "backend": "simulated",
+            "resolution_m": 0.2
+        },
+        "event_camera": {
+            "backend": "simulated"
+        },
+        "semantic_projector": {
+            "backend": "cpu"
+        },
         "fusion": {
             "rate_hz": 30,
             "camera_weight": 1.0,

--- a/docs/tracking/PROGRESS.md
+++ b/docs/tracking/PROGRESS.md
@@ -3302,4 +3302,29 @@ Scenario 30 also switched to the `color_contour` detector (live-validated: drone
 
 ---
 
-_Last updated after Improvement #84 (Epic #519). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._
+### Improvement #85 — HAL Interface Layer for Perception v2 (Epic #515)
+
+**Date:** 2026-04-21
+**Category:** Feature — Infrastructure / HAL
+**Epic:** [#515 — HAL Interface Layer for Perception v2](https://github.com/nmohamaya/companion_software_stack/issues/515) (sub-issues: #528, #529, #530, #531)
+
+**What:**
+
+- **`pixel_format.h`** — `PixelFormat` enum (GRAY8, RGB8, BGR8, RGBA8, NV12, YUYV, BAYER_RGGB8, THERMAL_8/16, EVENT_CD) + `pixel_format_channels()` helper. Reusable by ICamera, IEventCamera, IInferenceBackend.
+- **`iinference_backend.h`** — `IInferenceBackend` interface with HAL-local types (`BoundingBox2D`, `InferenceDetection`, `InferenceOutput`). Includes optional per-detection mask. `SimulatedInferenceBackend` returns N deterministic synthetic detections.
+- **`ivolumetric_map.h`** — `IVolumetricMap` interface with `VoxelKey`, `VoxelData`, `VoxelUpdate` structs. `SimulatedVolumetricMap` uses `std::unordered_map<VoxelKey, VoxelData, VoxelKeyHash>` with position discretization via `floor(pos / resolution)`.
+- **`ievent_camera.h`** — `IEventCamera` interface with `EventCD` and `EventBatch` structs. `SimulatedEventCamera` generates deterministic synthetic events.
+- **`isemantic_projector.h`** — `ISemanticProjector` interface with `CameraIntrinsics` struct. `CpuSemanticProjector` implements real pinhole back-projection: samples depth at bbox centre (or sparse 4×4 grid within mask), transforms to world frame via `camera_pose`.
+- **Factory** — `create_inference_backend()`, `create_volumetric_map()`, `create_event_camera()`, `create_semantic_projector()` added to `hal_factory.h`.
+- **Config** — `config_keys.h` extended with 4 new perception namespaces. `default.json` extended with 4 new sections.
+
+**Files added:** `pixel_format.h`, `iinference_backend.h`, `simulated_inference_backend.h`, `ivolumetric_map.h`, `simulated_volumetric_map.h`, `ievent_camera.h`, `simulated_event_camera.h`, `isemantic_projector.h`, `cpu_semantic_projector.h`, `test_inference_backend.cpp`, `test_volumetric_map.cpp`, `test_event_camera.cpp`, `test_semantic_projector.cpp`
+**Files modified:** `hal_factory.h`, `config_keys.h`, `config/default.json`, `tests/CMakeLists.txt`, `tests/TESTS.md`
+
+**Why:** Perception v2 components (grid, IMM tracker, SAM, radar fusion) all depend on these HAL abstractions. Defining them first as a foundational epic unblocks E2–E7. HAL-local types avoid circular dependency (perception → HAL → util, never backward).
+
+**Test count:** +39 new tests (7 inference, 9 volumetric map, 9 event camera, 14 semantic projector). 1585 → 1624 total.
+
+---
+
+_Last updated after Improvement #85 (Epic #515). See [tests/TESTS.md](../../tests/TESTS.md) for current test counts and scenario inventory._

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,12 @@ add_drone_test(test_hal             test_hal.cpp)
 # ── HAL Camera Lifetime tests (Issue #452) ───────────────────
 add_drone_test(test_hal_camera_lifetime test_hal_camera_lifetime.cpp)
 
+# ── HAL Perception v2 interface tests (Epic #515) ────────────
+add_drone_test(test_inference_backend  test_inference_backend.cpp)
+add_drone_test(test_volumetric_map     test_volumetric_map.cpp)
+add_drone_test(test_event_camera       test_event_camera.cpp)
+add_drone_test(test_semantic_projector test_semantic_projector.cpp)
+
 # ── MavlinkFCLink tests ─────────────────────────────────────
 add_drone_test(test_mavlink_fc_link test_mavlink_fc_link.cpp)
 

--- a/tests/TESTS.md
+++ b/tests/TESTS.md
@@ -130,7 +130,11 @@ bash deploy/build.sh --test-filter watchdog
 | [HAL — Depth Anything V2](#hal--depth-anything-v2) | 2 | 16 | DA V2 OpenCV DNN backend: model load, input validation, known-scene golden test, depth range (OPENCV_FOUND only) |
 | [HAL — Camera Lifetime](#test_hal_camera_lifetimecpp--7-tests) | 1 | 7 | CapturedFrame owned data lifetime safety: survives next capture, dimension match, close survival |
 | [HAL — Cosys-AirSim Camera Config](#test_cosys_camera_configcpp--6-tests) | 1 | 6 | CosysCameraBackend name-resolution precedence: per-section → top-level → default, plus symmetric empty-value-not-shadowing for vehicle_name (gated on `HAVE_COSYS_AIRSIM`) |
-| **Total** | **71 C++ + 5 shell** | **1566 (no SDK) / 1605 (+SDK) + 42 + 250+** | |
+| [HAL — Inference Backend](#hal--inference-backend) | 1 | 7 | IInferenceBackend + SimulatedInferenceBackend: init, infer, null/zero validation, factory |
+| [HAL — Volumetric Map](#hal--volumetric-map) | 1 | 9 | IVolumetricMap + SimulatedVolumetricMap: init, insert/query, clear, same-voxel merge, factory |
+| [HAL — Event Camera](#hal--event-camera) | 1 | 9 | PixelFormat channels, IEventCamera + SimulatedEventCamera: open/close, events, factory |
+| [HAL — Semantic Projector](#hal--semantic-projector) | 1 | 14 | ISemanticProjector + CpuSemanticProjector: pinhole back-projection, depth NaN/zero, mask, factory |
+| **Total** | **75 C++ + 5 shell** | **1605 (no SDK) / 1644 (+SDK) + 42 + 250+** | |
 
 ---
 
@@ -354,6 +358,63 @@ Compiled with `HAVE_MAVSDK`.  Tests gracefully handle missing PX4 SITL.
 **Key files under test:** `hal/cosys_name_resolver.h` (free functions `resolve_camera_name`, `resolve_vehicle_name`, `resolve_airsim_name`), `hal/cosys_camera.h` (thin static wrappers).
 
 **Why:** Regression test for the silent 256×144 downgrade that made scenario 30 produce zero detections for 39 YOLO inference frames. No RPC required — the helpers are `static` by design so the resolution logic can be unit-tested without instantiating the backend (which would need a live AirSim server). See BUG_FIXES.md → Fix #499a.
+
+---
+
+## HAL — Inference Backend
+
+### test_inference_backend.cpp — 7 tests
+
+**What it tests:** `IInferenceBackend` interface and `SimulatedInferenceBackend` — the HAL abstraction for ML inference engines (ONNX Runtime, TensorRT, etc.). The simulated backend returns N deterministic synthetic detections with configurable count.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `InferenceBackend` | 7 | `name()` returns `"SimulatedInferenceBackend"`; `init()` returns true; `infer()` returns correct detection count with valid bbox/confidence; null frame pointer returns error; zero dimensions returns error; factory creates simulated backend; factory throws on unknown backend |
+
+**Key files under test:** `hal/iinference_backend.h`, `hal/simulated_inference_backend.h`, `hal/hal_factory.h`
+
+---
+
+## HAL — Volumetric Map
+
+### test_volumetric_map.cpp — 9 tests
+
+**What it tests:** `IVolumetricMap` interface and `SimulatedVolumetricMap` — a hash-map-based 3D voxel store that discretizes positions into grid cells. Used for semantic 3D scene representation.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `VolumetricMap` | 9 | `name()` correct; `init()` with valid resolution; `init()` rejects zero/negative resolution; insert + query round-trip (occupancy, semantic label, confidence); query miss returns nullopt; `clear()` empties map; two inserts to same voxel (via discretization) keep latest; factory creates simulated backend; factory throws on unknown backend |
+
+**Key files under test:** `hal/ivolumetric_map.h`, `hal/simulated_volumetric_map.h`, `hal/hal_factory.h`
+
+---
+
+## HAL — Event Camera
+
+### test_event_camera.cpp — 9 tests
+
+**What it tests:** `PixelFormat` enum channel helper and `IEventCamera` + `SimulatedEventCamera` — the HAL abstraction for dynamic vision sensors (DVS/event cameras). The simulated backend generates deterministic synthetic events.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `PixelFormat` | 1 | `pixel_format_channels()` returns correct channel count for GRAY8(1), RGB8(3), BGR8(3), RGBA8(4), THERMAL_8(1), THERMAL_16(1), EVENT_CD(0) |
+| `EventCamera` | 8 | `name()` correct; open/close lifecycle; zero-dimension open fails; read when closed returns invalid batch; read produces correct event count with valid coordinates and polarity; pixel format is EVENT_CD; factory creates simulated backend; factory throws on unknown backend |
+
+**Key files under test:** `hal/pixel_format.h`, `hal/ievent_camera.h`, `hal/simulated_event_camera.h`, `hal/hal_factory.h`
+
+---
+
+## HAL — Semantic Projector
+
+### test_semantic_projector.cpp — 14 tests
+
+**What it tests:** `ISemanticProjector` interface and `CpuSemanticProjector` — pinhole-model back-projection of 2D detections + depth maps into 3D `VoxelUpdate` structs. The CPU implementation handles both bbox-centre sampling and sparse grid sampling within detection masks.
+
+| Suite | Tests | What is validated |
+|-------|-------|-------------------|
+| `SemanticProjector` | 14 | `name()` correct; init with valid intrinsics; init rejects zero dimensions; init rejects zero focal length; project before init fails; empty detections returns empty updates; single detection back-projects to correct 3D position; NaN depth skipped; zero depth skipped; camera pose translation applied to world frame; invalid (empty) depth map returns error; masked detection produces 4×4=16 voxel updates; factory creates CPU backend; factory throws on unknown backend |
+
+**Key files under test:** `hal/isemantic_projector.h`, `hal/cpu_semantic_projector.h`, `hal/hal_factory.h`
 
 ---
 

--- a/tests/test_event_camera.cpp
+++ b/tests/test_event_camera.cpp
@@ -1,0 +1,129 @@
+// tests/test_event_camera.cpp
+// Unit tests for IEventCamera HAL interface, PixelFormat, and SimulatedEventCamera.
+#include "hal/hal_factory.h"
+#include "hal/ievent_camera.h"
+#include "hal/pixel_format.h"
+#include "hal/simulated_event_camera.h"
+#include "util/config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace drone::hal;
+
+// ── Temp config helper ──
+
+static std::vector<std::string> g_temp_files;
+
+static std::string create_temp_config(const std::string& json_content) {
+    char tmpl[] = "/tmp/test_evcam_XXXXXX.json";
+    int  fd     = mkstemps(tmpl, 5);
+    if (fd < 0) {
+        std::string   path = "/tmp/test_evcam_" + std::to_string(getpid()) + ".json";
+        std::ofstream ofs(path);
+        ofs << json_content;
+        g_temp_files.push_back(path);
+        return path;
+    }
+    ::close(fd);
+    std::string   path(tmpl);
+    std::ofstream ofs(path);
+    ofs << json_content;
+    g_temp_files.push_back(path);
+    return path;
+}
+
+struct TempFileCleanup {
+    ~TempFileCleanup() {
+        for (auto& f : g_temp_files) std::remove(f.c_str());
+    }
+};
+static TempFileCleanup g_cleanup;
+
+// ── PixelFormat tests ──
+
+TEST(PixelFormat, ChannelCounts) {
+    EXPECT_EQ(pixel_format_channels(PixelFormat::GRAY8), 1);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::RGB8), 3);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::BGR8), 3);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::RGBA8), 4);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::THERMAL_8), 1);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::THERMAL_16), 1);
+    EXPECT_EQ(pixel_format_channels(PixelFormat::EVENT_CD), 0);
+}
+
+// ── SimulatedEventCamera tests ──
+
+TEST(EventCamera, SimulatedName) {
+    SimulatedEventCamera cam;
+    EXPECT_EQ(cam.name(), "SimulatedEventCamera");
+}
+
+TEST(EventCamera, OpenClose) {
+    SimulatedEventCamera cam;
+    EXPECT_FALSE(cam.is_open());
+
+    EXPECT_TRUE(cam.open(640, 480));
+    EXPECT_TRUE(cam.is_open());
+
+    cam.close();
+    EXPECT_FALSE(cam.is_open());
+}
+
+TEST(EventCamera, OpenZeroDimensionsFails) {
+    SimulatedEventCamera cam;
+    EXPECT_FALSE(cam.open(0, 480));
+    EXPECT_FALSE(cam.open(640, 0));
+}
+
+TEST(EventCamera, ReadEventsWhenClosed) {
+    SimulatedEventCamera cam;
+    auto                 batch = cam.read_events();
+    EXPECT_FALSE(batch.valid);
+    EXPECT_TRUE(batch.events.empty());
+}
+
+TEST(EventCamera, ReadEventsProducesEvents) {
+    SimulatedEventCamera cam(50);
+    ASSERT_TRUE(cam.open(320, 240));
+
+    auto batch = cam.read_events();
+    ASSERT_TRUE(batch.valid);
+    EXPECT_EQ(batch.events.size(), 50u);
+    EXPECT_LT(batch.batch_start_ns, batch.batch_end_ns);
+
+    for (const auto& ev : batch.events) {
+        EXPECT_LT(ev.x, 320);
+        EXPECT_LT(ev.y, 240);
+        EXPECT_TRUE(ev.polarity == 1 || ev.polarity == -1);
+    }
+}
+
+TEST(EventCamera, PixelFormatIsEventCD) {
+    SimulatedEventCamera cam;
+    EXPECT_EQ(cam.pixel_format(), PixelFormat::EVENT_CD);
+}
+
+TEST(EventCamera, FactorySimulated) {
+    auto          path = create_temp_config(R"({
+        "perception": { "event_camera": { "backend": "simulated" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    auto cam = drone::hal::create_event_camera(cfg);
+    ASSERT_NE(cam, nullptr);
+    EXPECT_EQ(cam->name(), "SimulatedEventCamera");
+}
+
+TEST(EventCamera, FactoryUnknownThrows) {
+    auto          path = create_temp_config(R"({
+        "perception": { "event_camera": { "backend": "nonexistent" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    EXPECT_THROW(drone::hal::create_event_camera(cfg), std::runtime_error);
+}

--- a/tests/test_inference_backend.cpp
+++ b/tests/test_inference_backend.cpp
@@ -1,0 +1,108 @@
+// tests/test_inference_backend.cpp
+// Unit tests for IInferenceBackend HAL interface + SimulatedInferenceBackend.
+#include "hal/hal_factory.h"
+#include "hal/iinference_backend.h"
+#include "hal/simulated_inference_backend.h"
+#include "util/config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace drone::hal;
+
+// ── Temp config helper ──
+
+static std::vector<std::string> g_temp_files;
+
+static std::string create_temp_config(const std::string& json_content) {
+    char tmpl[] = "/tmp/test_infer_XXXXXX.json";
+    int  fd     = mkstemps(tmpl, 5);
+    if (fd < 0) {
+        std::string   path = "/tmp/test_infer_" + std::to_string(getpid()) + ".json";
+        std::ofstream ofs(path);
+        ofs << json_content;
+        g_temp_files.push_back(path);
+        return path;
+    }
+    ::close(fd);
+    std::string   path(tmpl);
+    std::ofstream ofs(path);
+    ofs << json_content;
+    g_temp_files.push_back(path);
+    return path;
+}
+
+struct TempFileCleanup {
+    ~TempFileCleanup() {
+        for (auto& f : g_temp_files) std::remove(f.c_str());
+    }
+};
+static TempFileCleanup g_cleanup;
+
+// ── Tests ──
+
+TEST(InferenceBackend, SimulatedName) {
+    SimulatedInferenceBackend backend;
+    EXPECT_EQ(backend.name(), "SimulatedInferenceBackend");
+}
+
+TEST(InferenceBackend, InitReturnsTrue) {
+    SimulatedInferenceBackend backend;
+    EXPECT_TRUE(backend.init("dummy_model.onnx", 640));
+}
+
+TEST(InferenceBackend, InferReturnsDetections) {
+    SimulatedInferenceBackend backend(3);
+    ASSERT_TRUE(backend.init("model.onnx", 640));
+
+    std::vector<uint8_t> frame(640 * 480 * 3, 128);
+    auto                 result = backend.infer(frame.data(), 640, 480, 3, 0);
+
+    ASSERT_TRUE(result.is_ok());
+    const auto& output = result.value();
+    EXPECT_EQ(output.detections.size(), 3u);
+
+    for (const auto& det : output.detections) {
+        EXPECT_GE(det.confidence, 0.0f);
+        EXPECT_LE(det.confidence, 1.0f);
+        EXPECT_GT(det.bbox.w, 0.0f);
+        EXPECT_GT(det.bbox.h, 0.0f);
+    }
+}
+
+TEST(InferenceBackend, NullFrameReturnsError) {
+    SimulatedInferenceBackend backend;
+    auto                      result = backend.infer(nullptr, 640, 480, 3, 0);
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(InferenceBackend, ZeroDimensionsReturnsError) {
+    SimulatedInferenceBackend backend;
+    std::vector<uint8_t>      frame(100, 0);
+    auto                      result = backend.infer(frame.data(), 0, 0, 3, 0);
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(InferenceBackend, FactorySimulated) {
+    auto          path = create_temp_config(R"({
+        "perception": { "inference_backend": { "backend": "simulated" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    auto backend = drone::hal::create_inference_backend(cfg);
+    ASSERT_NE(backend, nullptr);
+    EXPECT_EQ(backend->name(), "SimulatedInferenceBackend");
+}
+
+TEST(InferenceBackend, FactoryUnknownThrows) {
+    auto          path = create_temp_config(R"({
+        "perception": { "inference_backend": { "backend": "nonexistent" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    EXPECT_THROW(drone::hal::create_inference_backend(cfg), std::runtime_error);
+}

--- a/tests/test_semantic_projector.cpp
+++ b/tests/test_semantic_projector.cpp
@@ -1,0 +1,242 @@
+// tests/test_semantic_projector.cpp
+// Unit tests for ISemanticProjector HAL interface + CpuSemanticProjector.
+#include "hal/cpu_semantic_projector.h"
+#include "hal/hal_factory.h"
+#include "hal/isemantic_projector.h"
+#include "util/config.h"
+
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <vector>
+
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace drone::hal;
+
+// ── Temp config helper ──
+
+static std::vector<std::string> g_temp_files;
+
+static std::string create_temp_config(const std::string& json_content) {
+    char tmpl[] = "/tmp/test_sproj_XXXXXX.json";
+    int  fd     = mkstemps(tmpl, 5);
+    if (fd < 0) {
+        std::string   path = "/tmp/test_sproj_" + std::to_string(getpid()) + ".json";
+        std::ofstream ofs(path);
+        ofs << json_content;
+        g_temp_files.push_back(path);
+        return path;
+    }
+    ::close(fd);
+    std::string   path(tmpl);
+    std::ofstream ofs(path);
+    ofs << json_content;
+    g_temp_files.push_back(path);
+    return path;
+}
+
+struct TempFileCleanup {
+    ~TempFileCleanup() {
+        for (auto& f : g_temp_files) std::remove(f.c_str());
+    }
+};
+static TempFileCleanup g_cleanup;
+
+// ── Helper: create a uniform depth map ──
+
+static DepthMap make_depth_map(uint32_t w, uint32_t h, float depth_val) {
+    DepthMap dm;
+    dm.width         = w;
+    dm.height        = h;
+    dm.source_width  = w;
+    dm.source_height = h;
+    dm.scale         = 1.0f;
+    dm.confidence    = 0.9f;
+    dm.data.assign(w * h, depth_val);
+    return dm;
+}
+
+// ── Tests ──
+
+TEST(SemanticProjector, CpuName) {
+    CpuSemanticProjector proj;
+    EXPECT_EQ(proj.name(), "CpuSemanticProjector");
+}
+
+TEST(SemanticProjector, InitValid) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    EXPECT_TRUE(proj.init(intr));
+}
+
+TEST(SemanticProjector, InitInvalidZeroDimensions) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 0, 0};
+    EXPECT_FALSE(proj.init(intr));
+}
+
+TEST(SemanticProjector, InitInvalidFocalLength) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{0.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    EXPECT_FALSE(proj.init(intr));
+}
+
+TEST(SemanticProjector, ProjectBeforeInitFails) {
+    CpuSemanticProjector proj;
+    auto                 depth  = make_depth_map(640, 480, 5.0f);
+    auto                 result = proj.project({}, depth, Eigen::Affine3f::Identity());
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(SemanticProjector, ProjectEmptyDetections) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    auto depth  = make_depth_map(640, 480, 5.0f);
+    auto result = proj.project({}, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST(SemanticProjector, ProjectSingleDetection) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    InferenceDetection det;
+    det.bbox       = {300.0f, 220.0f, 40.0f, 40.0f};
+    det.class_id   = 3;
+    det.confidence = 0.85f;
+
+    auto depth  = make_depth_map(640, 480, 10.0f);
+    auto result = proj.project({det}, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+
+    const auto& updates = result.value();
+    ASSERT_EQ(updates.size(), 1u);
+    EXPECT_EQ(updates[0].semantic_label, 3);
+    EXPECT_FLOAT_EQ(updates[0].confidence, 0.85f);
+    EXPECT_FLOAT_EQ(updates[0].occupancy, 1.0f);
+
+    // At identity pose, bbox centre (320, 240) with depth 10 should map near origin
+    // u=320, cx=320 → x_cam = 0; v=240, cy=240 → y_cam = 0; z=10
+    EXPECT_NEAR(updates[0].position_m.x(), 0.0f, 0.5f);
+    EXPECT_NEAR(updates[0].position_m.y(), 0.0f, 0.5f);
+    EXPECT_FLOAT_EQ(updates[0].position_m.z(), 10.0f);
+}
+
+TEST(SemanticProjector, DepthNaNSkipped) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    InferenceDetection det;
+    det.bbox       = {300.0f, 220.0f, 40.0f, 40.0f};
+    det.class_id   = 1;
+    det.confidence = 0.9f;
+
+    auto depth  = make_depth_map(640, 480, std::numeric_limits<float>::quiet_NaN());
+    auto result = proj.project({det}, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST(SemanticProjector, DepthZeroSkipped) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    InferenceDetection det;
+    det.bbox       = {300.0f, 220.0f, 40.0f, 40.0f};
+    det.class_id   = 1;
+    det.confidence = 0.9f;
+
+    auto depth  = make_depth_map(640, 480, 0.0f);
+    auto result = proj.project({det}, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().empty());
+}
+
+TEST(SemanticProjector, WorldFrameTransform) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    InferenceDetection det;
+    det.bbox       = {300.0f, 220.0f, 40.0f, 40.0f};
+    det.class_id   = 2;
+    det.confidence = 0.7f;
+
+    auto depth = make_depth_map(640, 480, 10.0f);
+
+    // Translate camera 5m along X
+    Eigen::Affine3f pose = Eigen::Affine3f::Identity();
+    pose.translation()   = Eigen::Vector3f(5.0f, 0.0f, 0.0f);
+
+    auto result = proj.project({det}, depth, pose);
+    ASSERT_TRUE(result.is_ok());
+    ASSERT_EQ(result.value().size(), 1u);
+
+    // Point at image centre with depth 10 → camera frame (0,0,10)
+    // Translated by (5,0,0) → world frame (5, 0, 10)
+    EXPECT_NEAR(result.value()[0].position_m.x(), 5.0f, 0.5f);
+    EXPECT_NEAR(result.value()[0].position_m.z(), 10.0f, 0.5f);
+}
+
+TEST(SemanticProjector, InvalidDepthMapReturnsError) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    DepthMap empty_depth;
+    auto     result = proj.project({}, empty_depth, Eigen::Affine3f::Identity());
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(SemanticProjector, MaskedDetectionProducesMultipleUpdates) {
+    CpuSemanticProjector proj;
+    CameraIntrinsics     intr{500.0f, 500.0f, 320.0f, 240.0f, 640, 480};
+    ASSERT_TRUE(proj.init(intr));
+
+    InferenceDetection det;
+    det.bbox        = {100.0f, 100.0f, 80.0f, 80.0f};
+    det.class_id    = 5;
+    det.confidence  = 0.8f;
+    det.mask_width  = 8;
+    det.mask_height = 8;
+    det.mask.assign(64, 255);  // all foreground
+
+    auto depth  = make_depth_map(640, 480, 8.0f);
+    auto result = proj.project({det}, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+
+    // 4x4 grid with all mask pixels active → 16 updates
+    EXPECT_EQ(result.value().size(), 16u);
+    for (const auto& vu : result.value()) {
+        EXPECT_EQ(vu.semantic_label, 5);
+    }
+}
+
+TEST(SemanticProjector, FactoryCpu) {
+    auto          path = create_temp_config(R"({
+        "perception": { "semantic_projector": { "backend": "cpu" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    auto proj = drone::hal::create_semantic_projector(cfg);
+    ASSERT_NE(proj, nullptr);
+    EXPECT_EQ(proj->name(), "CpuSemanticProjector");
+}
+
+TEST(SemanticProjector, FactoryUnknownThrows) {
+    auto          path = create_temp_config(R"({
+        "perception": { "semantic_projector": { "backend": "nonexistent" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    EXPECT_THROW(drone::hal::create_semantic_projector(cfg), std::runtime_error);
+}

--- a/tests/test_volumetric_map.cpp
+++ b/tests/test_volumetric_map.cpp
@@ -1,0 +1,147 @@
+// tests/test_volumetric_map.cpp
+// Unit tests for IVolumetricMap HAL interface + SimulatedVolumetricMap.
+#include "hal/hal_factory.h"
+#include "hal/ivolumetric_map.h"
+#include "hal/simulated_volumetric_map.h"
+#include "util/config.h"
+
+#include <cstdio>
+#include <fstream>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+using namespace drone::hal;
+
+// ── Temp config helper ──
+
+static std::vector<std::string> g_temp_files;
+
+static std::string create_temp_config(const std::string& json_content) {
+    char tmpl[] = "/tmp/test_vmap_XXXXXX.json";
+    int  fd     = mkstemps(tmpl, 5);
+    if (fd < 0) {
+        std::string   path = "/tmp/test_vmap_" + std::to_string(getpid()) + ".json";
+        std::ofstream ofs(path);
+        ofs << json_content;
+        g_temp_files.push_back(path);
+        return path;
+    }
+    ::close(fd);
+    std::string   path(tmpl);
+    std::ofstream ofs(path);
+    ofs << json_content;
+    g_temp_files.push_back(path);
+    return path;
+}
+
+struct TempFileCleanup {
+    ~TempFileCleanup() {
+        for (auto& f : g_temp_files) std::remove(f.c_str());
+    }
+};
+static TempFileCleanup g_cleanup;
+
+// ── Tests ──
+
+TEST(VolumetricMap, SimulatedName) {
+    SimulatedVolumetricMap map;
+    EXPECT_EQ(map.name(), "SimulatedVolumetricMap");
+}
+
+TEST(VolumetricMap, InitValid) {
+    SimulatedVolumetricMap map;
+    EXPECT_TRUE(map.init(0.5f));
+    EXPECT_FLOAT_EQ(map.resolution(), 0.5f);
+}
+
+TEST(VolumetricMap, InitInvalidResolution) {
+    SimulatedVolumetricMap map;
+    EXPECT_FALSE(map.init(0.0f));
+    EXPECT_FALSE(map.init(-1.0f));
+}
+
+TEST(VolumetricMap, InsertAndQuery) {
+    SimulatedVolumetricMap map(0.5f);
+    ASSERT_TRUE(map.init(0.5f));
+
+    VoxelUpdate update;
+    update.position_m     = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    update.occupancy      = 0.9f;
+    update.semantic_label = 1;
+    update.confidence     = 0.8f;
+    update.timestamp_ns   = 1000;
+
+    EXPECT_TRUE(map.insert({update}));
+    EXPECT_EQ(map.size(), 1u);
+
+    auto result = map.query(Eigen::Vector3f(1.1f, 2.1f, 3.1f));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FLOAT_EQ(result->occupancy, 0.9f);
+    EXPECT_EQ(result->semantic_label, 1);
+    EXPECT_FLOAT_EQ(result->confidence, 0.8f);
+}
+
+TEST(VolumetricMap, QueryMissReturnsNullopt) {
+    SimulatedVolumetricMap map(0.5f);
+    ASSERT_TRUE(map.init(0.5f));
+
+    auto result = map.query(Eigen::Vector3f(100.0f, 200.0f, 300.0f));
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(VolumetricMap, Clear) {
+    SimulatedVolumetricMap map(0.5f);
+    ASSERT_TRUE(map.init(0.5f));
+
+    VoxelUpdate update;
+    update.position_m = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    ASSERT_TRUE(map.insert({update}));
+    EXPECT_EQ(map.size(), 1u);
+
+    map.clear();
+    EXPECT_EQ(map.size(), 0u);
+}
+
+TEST(VolumetricMap, MultipleInsertsSameVoxel) {
+    SimulatedVolumetricMap map(1.0f);
+    ASSERT_TRUE(map.init(1.0f));
+
+    VoxelUpdate u1;
+    u1.position_m     = Eigen::Vector3f(0.3f, 0.3f, 0.3f);
+    u1.semantic_label = 1;
+    u1.confidence     = 0.5f;
+
+    VoxelUpdate u2;
+    u2.position_m     = Eigen::Vector3f(0.7f, 0.7f, 0.7f);
+    u2.semantic_label = 2;
+    u2.confidence     = 0.9f;
+
+    ASSERT_TRUE(map.insert({u1, u2}));
+    EXPECT_EQ(map.size(), 1u);
+
+    auto result = map.query(Eigen::Vector3f(0.5f, 0.5f, 0.5f));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->semantic_label, 2);
+}
+
+TEST(VolumetricMap, FactorySimulated) {
+    auto          path = create_temp_config(R"({
+        "perception": { "volumetric_map": { "backend": "simulated" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    auto map = drone::hal::create_volumetric_map(cfg);
+    ASSERT_NE(map, nullptr);
+    EXPECT_EQ(map->name(), "SimulatedVolumetricMap");
+}
+
+TEST(VolumetricMap, FactoryUnknownThrows) {
+    auto          path = create_temp_config(R"({
+        "perception": { "volumetric_map": { "backend": "nonexistent" } }
+    })");
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    EXPECT_THROW(drone::hal::create_volumetric_map(cfg), std::runtime_error);
+}


### PR DESCRIPTION
## Summary

Implements **Epic E1 (#515)** — all 4 sub-issues in a single PR:

- **#528 IInferenceBackend** — HAL-local types (`BoundingBox2D`, `InferenceDetection`, `InferenceOutput`), `SimulatedInferenceBackend` reference backend
- **#529 IVolumetricMap** — `VoxelKey`/`VoxelData`/`VoxelUpdate` structs, `SimulatedVolumetricMap` (CPU hash-map backend with position discretization)
- **#530 ISemanticProjector** — `CameraIntrinsics` struct, `CpuSemanticProjector` (real pinhole back-projection with bbox-centre and masked sparse-grid sampling)
- **#531 IEventCamera/PixelFormat** — `PixelFormat` enum + `pixel_format_channels()`, `EventCD`/`EventBatch`, `SimulatedEventCamera`

### Key design decisions

- **HAL-local types** — `BoundingBox2D`, `InferenceDetection`, `CameraIntrinsics` defined in HAL headers, not imported from `perception/`. Dependency flows `perception → HAL → util`, never backward.
- **No ONNX Runtime / UFOMap** — simulated backends are CPU-only, zero external deps. Real backends (OpenCV DNN, UFOMap, etc.) are additive future work.
- **CpuSemanticProjector is real** — not a stub. Implements pinhole back-projection with depth-map sampling, NaN/zero filtering, mask support (4×4 sparse grid), and camera pose transform.
- **Factory pattern** — 4 new `create_*()` functions in `hal_factory.h`, config-driven, throw on unknown backend.

### Files

**9 new headers:** `pixel_format.h`, `iinference_backend.h`, `simulated_inference_backend.h`, `ivolumetric_map.h`, `simulated_volumetric_map.h`, `ievent_camera.h`, `simulated_event_camera.h`, `isemantic_projector.h`, `cpu_semantic_projector.h`

**4 new test files:** `test_inference_backend.cpp` (7), `test_volumetric_map.cpp` (9), `test_event_camera.cpp` (9), `test_semantic_projector.cpp` (14)

**Modified:** `hal_factory.h`, `config_keys.h`, `default.json`, `CMakeLists.txt`, `TESTS.md`, `PROGRESS.md`

Closes #528, Closes #529, Closes #530, Closes #531

## Test plan

- [x] `bash deploy/build.sh` — zero warnings
- [x] `clang-format-18 --dry-run --Werror` — clean
- [x] 39 new tests pass (7 + 9 + 9 + 14)
- [x] Full quick suite: 1498/1498 pass (100%)
- [x] Total ctest count: 1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)