### PR TITLE
feat(#608): PATH A end-to-end integration — P2 publisher + P4 consumer + SAM backends

### DIFF
--- a/common/hal/include/hal/cpu_semantic_projector.h
+++ b/common/hal/include/hal/cpu_semantic_projector.h
@@ -125,9 +125,8 @@ private:
         // original code assumed only convention (1), silently filtered almost
         // every sample when convention (2) backends were used (~99% probe
         // rejection), producing 1-2 voxels/frame instead of ~10-50.
-        const bool mask_is_full_image =
-            static_cast<float>(det.mask_width) >= det.bbox.w * 1.5f &&
-            static_cast<float>(det.mask_height) >= det.bbox.h * 1.5f;
+        const bool mask_is_full_image = static_cast<float>(det.mask_width) >= det.bbox.w * 1.5f &&
+                                        static_cast<float>(det.mask_height) >= det.bbox.h * 1.5f;
 
         for (int gy = 0; gy < GRID; ++gy) {
             for (int gx = 0; gx < GRID; ++gx) {
@@ -142,14 +141,12 @@ private:
                     my = static_cast<uint32_t>(
                         std::clamp(v, 0.0f, static_cast<float>(det.mask_height - 1)));
                 } else {
-                    mx = static_cast<uint32_t>(std::clamp((u - det.bbox.x) / det.bbox.w *
-                                                              static_cast<float>(det.mask_width),
-                                                          0.0f,
-                                                          static_cast<float>(det.mask_width - 1)));
-                    my = static_cast<uint32_t>(std::clamp((v - det.bbox.y) / det.bbox.h *
-                                                              static_cast<float>(det.mask_height),
-                                                          0.0f,
-                                                          static_cast<float>(det.mask_height - 1)));
+                    mx = static_cast<uint32_t>(std::clamp(
+                        (u - det.bbox.x) / det.bbox.w * static_cast<float>(det.mask_width), 0.0f,
+                        static_cast<float>(det.mask_width - 1)));
+                    my = static_cast<uint32_t>(std::clamp(
+                        (v - det.bbox.y) / det.bbox.h * static_cast<float>(det.mask_height), 0.0f,
+                        static_cast<float>(det.mask_height - 1)));
                 }
                 if (det.mask[my * det.mask_width + mx] < 128) continue;
 

--- a/common/hal/include/hal/cpu_semantic_projector.h
+++ b/common/hal/include/hal/cpu_semantic_projector.h
@@ -80,6 +80,16 @@ private:
             std::clamp(v * scale_y, 0.0f, static_cast<float>(depth.height - 1)));
         const float d = depth.data[dy * depth.width + dx] * depth.scale;
         if (!std::isfinite(d) || d <= 0.0f) return 0.0f;
+        // Reject samples beyond kMaxObstacleDepth — distant horizon / sky /
+        // scenery contours are not navigation-relevant and would otherwise
+        // flood the downstream occupancy grid with ghost voxels.  20 m is a
+        // conservative drone-scale cutoff; real obstacles the planner needs
+        // to route around are well within this range at scenario cruise
+        // speeds.  (#608 E5.INT — discovered when EdgeContourSAM masks
+        // picked up every image edge and back-projected them into voxels at
+        // 50-100 m depth, filling the grid far past `max_static_cells`.)
+        constexpr float kMaxObstacleDepth = 20.0f;
+        if (d > kMaxObstacleDepth) return 0.0f;
         return d;
     }
 
@@ -107,18 +117,40 @@ private:
         const float   step_x = det.bbox.w / static_cast<float>(GRID);
         const float   step_y = det.bbox.h / static_cast<float>(GRID);
 
+        // Backends in the codebase use two mask conventions:
+        //   1. bbox-local      — mask_width ≈ bbox.w (e.g. YOLOv8-seg tiled masks)
+        //   2. full-image      — mask_width ≫ bbox.w, pixel indexed by (u, v)
+        //                        directly (EdgeContourSAMBackend, SimulatedSAMBackend).
+        // Auto-detect from geometry to accept both.  Issue #608 E5.INT: the
+        // original code assumed only convention (1), silently filtered almost
+        // every sample when convention (2) backends were used (~99% probe
+        // rejection), producing 1-2 voxels/frame instead of ~10-50.
+        const bool mask_is_full_image =
+            static_cast<float>(det.mask_width) >= det.bbox.w * 1.5f &&
+            static_cast<float>(det.mask_height) >= det.bbox.h * 1.5f;
+
         for (int gy = 0; gy < GRID; ++gy) {
             for (int gx = 0; gx < GRID; ++gx) {
                 const float u = det.bbox.x + (static_cast<float>(gx) + 0.5f) * step_x;
                 const float v = det.bbox.y + (static_cast<float>(gy) + 0.5f) * step_y;
 
-                // Check mask at this sample point
-                const auto mx = static_cast<uint32_t>(
-                    std::clamp((u - det.bbox.x) / det.bbox.w * static_cast<float>(det.mask_width),
-                               0.0f, static_cast<float>(det.mask_width - 1)));
-                const auto my = static_cast<uint32_t>(
-                    std::clamp((v - det.bbox.y) / det.bbox.h * static_cast<float>(det.mask_height),
-                               0.0f, static_cast<float>(det.mask_height - 1)));
+                uint32_t mx = 0;
+                uint32_t my = 0;
+                if (mask_is_full_image) {
+                    mx = static_cast<uint32_t>(
+                        std::clamp(u, 0.0f, static_cast<float>(det.mask_width - 1)));
+                    my = static_cast<uint32_t>(
+                        std::clamp(v, 0.0f, static_cast<float>(det.mask_height - 1)));
+                } else {
+                    mx = static_cast<uint32_t>(std::clamp((u - det.bbox.x) / det.bbox.w *
+                                                              static_cast<float>(det.mask_width),
+                                                          0.0f,
+                                                          static_cast<float>(det.mask_width - 1)));
+                    my = static_cast<uint32_t>(std::clamp((v - det.bbox.y) / det.bbox.h *
+                                                              static_cast<float>(det.mask_height),
+                                                          0.0f,
+                                                          static_cast<float>(det.mask_height - 1)));
+                }
                 if (det.mask[my * det.mask_width + mx] < 128) continue;
 
                 const float z = sample_depth(depth, u, v, scale_x, scale_y);

--- a/common/hal/include/hal/edge_contour_sam_backend.h
+++ b/common/hal/include/hal/edge_contour_sam_backend.h
@@ -90,9 +90,9 @@ public:
 #else
         const int step = (stride > 0) ? static_cast<int>(stride)
                                       : static_cast<int>(width * channels);
-        cv::Mat rgb(static_cast<int>(height), static_cast<int>(width),
+        cv::Mat   rgb(static_cast<int>(height), static_cast<int>(width),
                     channels == 3 ? CV_8UC3 : (channels == 4 ? CV_8UC4 : CV_8UC1),
-                    const_cast<uint8_t*>(frame_data), static_cast<size_t>(step));
+                      const_cast<uint8_t*>(frame_data), static_cast<size_t>(step));
 
         cv::Mat gray;
         if (channels == 1) {
@@ -122,8 +122,8 @@ public:
         cv::Canny(blurred, edges, canny_low_, canny_high_);
 
         if (dilate_ksize_ > 1) {
-            cv::Mat kernel = cv::getStructuringElement(
-                cv::MORPH_ELLIPSE, cv::Size(dilate_ksize_, dilate_ksize_));
+            cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE,
+                                                       cv::Size(dilate_ksize_, dilate_ksize_));
             cv::dilate(edges, edges, kernel);
         }
 
@@ -156,8 +156,8 @@ public:
         // map without a scale factor on the downstream side.
         output.detections.reserve(kept.size());
         for (size_t rank = 0; rank < kept.size(); ++rank) {
-            const auto& ic         = kept[rank];
-            const auto& contour    = contours[ic.idx];
+            const auto&    ic      = kept[rank];
+            const auto&    contour = contours[ic.idx];
             const cv::Rect r_small = cv::boundingRect(contour);
 
             InferenceDetection det;
@@ -175,8 +175,8 @@ public:
             // to full resolution. cv::resize with INTER_NEAREST keeps the
             // mask binary (0/255).
             cv::Mat mask_small(small.rows, small.cols, CV_8UC1, cv::Scalar(0));
-            cv::drawContours(mask_small, contours, static_cast<int>(ic.idx),
-                             cv::Scalar(255), cv::FILLED);
+            cv::drawContours(mask_small, contours, static_cast<int>(ic.idx), cv::Scalar(255),
+                             cv::FILLED);
 
             if (downsample_ > 1) {
                 cv::Mat mask_full(static_cast<int>(height), static_cast<int>(width), CV_8UC1,

--- a/common/hal/include/hal/edge_contour_sam_backend.h
+++ b/common/hal/include/hal/edge_contour_sam_backend.h
@@ -1,0 +1,210 @@
+// common/hal/include/hal/edge_contour_sam_backend.h
+//
+// Algorithmic class-agnostic segmentation via OpenCV edge detection +
+// contour extraction.  Produces real masks tied to actual image content —
+// the interim fill between SimulatedSAMBackend (fake masks, test scaffold)
+// and a real SAM-2 ONNX backend (E5.1 #555, scoped but not shipped).
+//
+// Algorithm (tuned for obstacle-dominated scenes like scenario 33):
+//   1. RGB → grayscale
+//   2. Gaussian blur to suppress texture noise
+//   3. Canny edge detection (auto-threshold from image median)
+//   4. Morphological dilate to close edge gaps
+//   5. findContours (external, CHAIN_APPROX_SIMPLE)
+//   6. Sort by area; keep top-N with area >= min_area_px
+//   7. For each kept contour: fill a binary mask covering the contour's
+//      bbox + interior
+//
+// Output: vector of `hal::InferenceDetection` with class_id = -1 (class-
+// agnostic), mask populated from the filled contour, bbox = contour bbox.
+// Confidence is 1.0 for the largest contour, scaling down by area rank.
+//
+// Runtime cost: ~5-15 ms on 1280x720 / Intel-class CPU. Fits comfortably
+// inside the 33 ms/frame budget at 30 Hz.
+//
+// Gracefully degrades when OpenCV isn't available (returns empty output,
+// same pattern as `DepthAnythingV2`).  Scenarios that need this backend
+// must therefore run on builds with `HAS_OPENCV` defined.
+//
+// See Epic #520 / Issue #608 — scenario 33 uses this via
+// `perception.path_a.sam.backend = "edge_contour_sam"`.
+
+#pragma once
+
+#include "hal/iinference_backend.h"
+#include "util/config.h"
+#include "util/ilogger.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef HAS_OPENCV
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
+namespace drone::hal {
+
+class EdgeContourSAMBackend : public IInferenceBackend {
+public:
+    EdgeContourSAMBackend() = default;
+
+    EdgeContourSAMBackend(const drone::Config& cfg, const std::string& section)
+        : max_masks_(std::clamp(cfg.get<int>(section + ".max_masks", 8), 1, kMaxMasks))
+        , min_area_px_(std::max(100, cfg.get<int>(section + ".min_area_px", 500)))
+        , canny_low_(std::clamp(cfg.get<int>(section + ".canny_low", 50), 0, 255))
+        , canny_high_(std::clamp(cfg.get<int>(section + ".canny_high", 150), 0, 255))
+        , blur_ksize_(cfg.get<int>(section + ".blur_ksize", 5) | 1)  // force odd
+        , dilate_ksize_(std::max(1, cfg.get<int>(section + ".dilate_ksize", 3)))
+        , downsample_(std::clamp(cfg.get<int>(section + ".downsample_factor", 2), 1, 8)) {
+        if (canny_low_ > canny_high_) std::swap(canny_low_, canny_high_);
+    }
+
+    [[nodiscard]] bool init(const std::string& /*model_path*/, int /*input_size*/) override {
+#ifdef HAS_OPENCV
+        return true;
+#else
+        DRONE_LOG_WARN("[EdgeContourSAM] OpenCV not available at compile time — backend will "
+                       "return empty output.  Build with HAS_OPENCV to enable.");
+        return true;  // Allow construction; runtime fallback returns empty masks.
+#endif
+    }
+
+    [[nodiscard]] drone::util::Result<InferenceOutput, std::string> infer(
+        const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
+        uint32_t stride = 0) override {
+        using R = drone::util::Result<InferenceOutput, std::string>;
+        if (!frame_data) return R::err("Null frame data");
+        if (width == 0 || height == 0 || channels == 0) {
+            return R::err("Invalid frame dimensions");
+        }
+
+        InferenceOutput output;
+        output.timestamp_ns = ++counter_;
+
+#ifndef HAS_OPENCV
+        (void)stride;
+        return R::ok(std::move(output));
+#else
+        const int step = (stride > 0) ? static_cast<int>(stride)
+                                      : static_cast<int>(width * channels);
+        cv::Mat rgb(static_cast<int>(height), static_cast<int>(width),
+                    channels == 3 ? CV_8UC3 : (channels == 4 ? CV_8UC4 : CV_8UC1),
+                    const_cast<uint8_t*>(frame_data), static_cast<size_t>(step));
+
+        cv::Mat gray;
+        if (channels == 1) {
+            gray = rgb;
+        } else if (channels == 3) {
+            cv::cvtColor(rgb, gray, cv::COLOR_RGB2GRAY);
+        } else {
+            cv::cvtColor(rgb, gray, cv::COLOR_RGBA2GRAY);
+        }
+
+        // Downsample for speed — masks are upscaled back at the end.
+        cv::Mat small;
+        if (downsample_ > 1) {
+            cv::resize(gray, small,
+                       cv::Size(static_cast<int>(width) / downsample_,
+                                static_cast<int>(height) / downsample_),
+                       0.0, 0.0, cv::INTER_AREA);
+        } else {
+            small = gray;
+        }
+
+        // Blur → Canny → Dilate → findContours pipeline.
+        cv::Mat blurred;
+        cv::GaussianBlur(small, blurred, cv::Size(blur_ksize_, blur_ksize_), 0);
+
+        cv::Mat edges;
+        cv::Canny(blurred, edges, canny_low_, canny_high_);
+
+        if (dilate_ksize_ > 1) {
+            cv::Mat kernel = cv::getStructuringElement(
+                cv::MORPH_ELLIPSE, cv::Size(dilate_ksize_, dilate_ksize_));
+            cv::dilate(edges, edges, kernel);
+        }
+
+        std::vector<std::vector<cv::Point>> contours;
+        cv::findContours(edges, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
+
+        // Scale per-downsample so min_area_px stays in original-image units.
+        const int ds_min_area_px = std::max(1, min_area_px_ / (downsample_ * downsample_));
+
+        struct IndexedContour {
+            size_t idx;
+            double area;
+        };
+        std::vector<IndexedContour> kept;
+        kept.reserve(contours.size());
+        for (size_t i = 0; i < contours.size(); ++i) {
+            const double area = cv::contourArea(contours[i]);
+            if (area >= static_cast<double>(ds_min_area_px)) {
+                kept.push_back({i, area});
+            }
+        }
+        std::sort(kept.begin(), kept.end(),
+                  [](const IndexedContour& a, const IndexedContour& b) { return a.area > b.area; });
+        if (static_cast<int>(kept.size()) > max_masks_) {
+            kept.resize(static_cast<size_t>(max_masks_));
+        }
+
+        // Emit an InferenceDetection per kept contour.  Masks are stored at
+        // full image resolution so MaskDepthProjector can index the depth
+        // map without a scale factor on the downstream side.
+        output.detections.reserve(kept.size());
+        for (size_t rank = 0; rank < kept.size(); ++rank) {
+            const auto& ic         = kept[rank];
+            const auto& contour    = contours[ic.idx];
+            const cv::Rect r_small = cv::boundingRect(contour);
+
+            InferenceDetection det;
+            det.bbox.x      = static_cast<float>(r_small.x * downsample_);
+            det.bbox.y      = static_cast<float>(r_small.y * downsample_);
+            det.bbox.w      = static_cast<float>(r_small.width * downsample_);
+            det.bbox.h      = static_cast<float>(r_small.height * downsample_);
+            det.class_id    = -1;  // class-agnostic
+            det.confidence  = std::max(0.1f, 1.0f - 0.05f * static_cast<float>(rank));
+            det.mask_width  = width;
+            det.mask_height = height;
+            det.mask.assign(static_cast<size_t>(width) * height, uint8_t{0});
+
+            // Render the filled contour onto a small canvas, then up-sample
+            // to full resolution. cv::resize with INTER_NEAREST keeps the
+            // mask binary (0/255).
+            cv::Mat mask_small(small.rows, small.cols, CV_8UC1, cv::Scalar(0));
+            cv::drawContours(mask_small, contours, static_cast<int>(ic.idx),
+                             cv::Scalar(255), cv::FILLED);
+
+            if (downsample_ > 1) {
+                cv::Mat mask_full(static_cast<int>(height), static_cast<int>(width), CV_8UC1,
+                                  det.mask.data());
+                cv::resize(mask_small, mask_full, mask_full.size(), 0.0, 0.0, cv::INTER_NEAREST);
+            } else {
+                std::copy(mask_small.datastart, mask_small.dataend, det.mask.begin());
+            }
+
+            output.detections.push_back(std::move(det));
+        }
+        return R::ok(std::move(output));
+#endif
+    }
+
+    [[nodiscard]] std::string name() const override { return "EdgeContourSAMBackend"; }
+
+private:
+    static constexpr int kMaxMasks = 32;
+
+    int      max_masks_{8};
+    int      min_area_px_{500};
+    int      canny_low_{50};
+    int      canny_high_{150};
+    int      blur_ksize_{5};
+    int      dilate_ksize_{3};
+    int      downsample_{2};
+    uint64_t counter_{0};
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/fastsam_inference_backend.h
+++ b/common/hal/include/hal/fastsam_inference_backend.h
@@ -55,10 +55,9 @@ public:
     FastSamInferenceBackend() = default;
 
     FastSamInferenceBackend(const drone::Config& cfg, const std::string& section) {
-        model_path_           = cfg.get<std::string>(section + ".model_path",
-                                                     "models/fastsam_s.onnx");
-        confidence_threshold_ = std::clamp(
-            cfg.get<float>(section + ".confidence_threshold", 0.40f), 0.0f, 1.0f);
+        model_path_ = cfg.get<std::string>(section + ".model_path", "models/fastsam_s.onnx");
+        confidence_threshold_ = std::clamp(cfg.get<float>(section + ".confidence_threshold", 0.40f),
+                                           0.0f, 1.0f);
         nms_threshold_ = std::clamp(cfg.get<float>(section + ".nms_threshold", 0.45f), 0.0f, 1.0f);
         input_size_    = std::clamp(cfg.get<int>(section + ".input_size", 1024), kMinInputSize,
                                     kMaxInputSize);
@@ -147,7 +146,7 @@ public:
         std::vector<float>              confidences;
         std::vector<cv::Rect>           boxes;
         std::vector<std::vector<float>> mask_coeffs_all;
-        const auto reserve_count = static_cast<size_t>(std::min(cols, 512));
+        const auto                      reserve_count = static_cast<size_t>(std::min(cols, 512));
         confidences.reserve(reserve_count);
         boxes.reserve(reserve_count);
         mask_coeffs_all.reserve(reserve_count);
@@ -209,12 +208,12 @@ public:
                                         static_cast<float>(input_size_);
             const int rx = std::max(0, static_cast<int>(boxes[idx].x / x_scale * proto_scale_x));
             const int ry = std::max(0, static_cast<int>(boxes[idx].y / y_scale * proto_scale_y));
-            const int rw = std::min(mask_w - rx, std::max(1, static_cast<int>(boxes[idx].width /
-                                                                              x_scale *
-                                                                              proto_scale_x)));
-            const int rh = std::min(mask_h - ry, std::max(1, static_cast<int>(boxes[idx].height /
-                                                                              y_scale *
-                                                                              proto_scale_y)));
+            const int rw =
+                std::min(mask_w - rx,
+                         std::max(1, static_cast<int>(boxes[idx].width / x_scale * proto_scale_x)));
+            const int rh = std::min(
+                mask_h - ry,
+                std::max(1, static_cast<int>(boxes[idx].height / y_scale * proto_scale_y)));
             cv::Mat mask_crop = mask_raw(cv::Rect(rx, ry, rw, rh));
 
             const int bbox_px_w = std::max(1, static_cast<int>(det.bbox.w));

--- a/common/hal/include/hal/fastsam_inference_backend.h
+++ b/common/hal/include/hal/fastsam_inference_backend.h
@@ -1,0 +1,313 @@
+// common/hal/include/hal/fastsam_inference_backend.h
+//
+// FastSAM class-agnostic segmentation via OpenCV DNN — real SAM for the
+// PATH A pipeline.  This is what Epic #520 / Issue #555 scoped and never
+// actually shipped: a drop-in class-agnostic segmenter that finds objects
+// in the image regardless of category.
+//
+// FastSAM (github.com/CASIA-IVA-Lab/FastSAM) is YOLOv8-seg architecture
+// trained on SA-1B (Meta's Segment Anything dataset).  It produces
+// bounding boxes + instance masks for every distinct object/surface in a
+// frame in a single forward pass, where standard SAM-2 needs prompts or
+// an expensive grid-of-prompts AMG loop.  Output format matches YOLOv8-seg
+// exactly — 2 tensors: detection head (4 bbox + 1 class + 32 mask-coeffs)
+// and mask prototypes (32 × 160 × 160 at 1024×1024 input).
+//
+// Why a dedicated backend (vs. reusing YoloSegInferenceBackend):
+//   * YoloSeg lives in process2_perception/ and pulls in detector_class_maps
+//     (COCO/VisDrone classes); FastSAM is class-agnostic, would carry a
+//     layer-violation include (HAL → perception).
+//   * This backend outputs class_id = -1 on every detection so downstream
+//     MaskClassAssigner correctly labels unmatched masks as
+//     GEOMETRIC_OBSTACLE — the behaviour scenario 33 needs.
+//
+// Model: run `models/download_fastsam.sh` to fetch FastSAM-s.pt and export
+// to `models/fastsam_s.onnx` (~50 MB).  The script installs `ultralytics`
+// into the local pip environment — same pattern as
+// `download_depth_anything_v2.sh`.
+//
+// Runtime: ~80 ms per 1024×1024 frame on CPU (OpenCV DNN backend), ~20 ms
+// with OpenVINO/CUDA target.  Gracefully no-ops when OpenCV isn't available.
+
+#pragma once
+
+#include "hal/iinference_backend.h"
+#include "util/config.h"
+#include "util/ilogger.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#ifdef HAS_OPENCV
+#include <opencv2/core.hpp>
+#include <opencv2/dnn.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
+namespace drone::hal {
+
+class FastSamInferenceBackend : public IInferenceBackend {
+public:
+    FastSamInferenceBackend() = default;
+
+    FastSamInferenceBackend(const drone::Config& cfg, const std::string& section) {
+        model_path_           = cfg.get<std::string>(section + ".model_path",
+                                                     "models/fastsam_s.onnx");
+        confidence_threshold_ = std::clamp(
+            cfg.get<float>(section + ".confidence_threshold", 0.40f), 0.0f, 1.0f);
+        nms_threshold_ = std::clamp(cfg.get<float>(section + ".nms_threshold", 0.45f), 0.0f, 1.0f);
+        input_size_    = std::clamp(cfg.get<int>(section + ".input_size", 1024), kMinInputSize,
+                                    kMaxInputSize);
+        mask_channels_ = std::clamp(cfg.get<int>(section + ".mask_channels", 32), 1, 128);
+    }
+
+    FastSamInferenceBackend(const FastSamInferenceBackend&)            = delete;
+    FastSamInferenceBackend& operator=(const FastSamInferenceBackend&) = delete;
+    FastSamInferenceBackend(FastSamInferenceBackend&&)                 = default;
+    FastSamInferenceBackend& operator=(FastSamInferenceBackend&&)      = default;
+
+    [[nodiscard]] bool init(const std::string& model_path, int input_size) override {
+        if (!model_path.empty()) model_path_ = model_path;
+        if (input_size > 0) input_size_ = std::clamp(input_size, kMinInputSize, kMaxInputSize);
+        return load_model();
+    }
+
+    [[nodiscard]] drone::util::Result<InferenceOutput, std::string> infer(
+        const uint8_t* frame_data, uint32_t width, uint32_t height, uint32_t channels,
+        uint32_t /*stride*/) override {
+        using R = drone::util::Result<InferenceOutput, std::string>;
+        if (!frame_data) return R::err("Null frame data");
+        if (width == 0 || height == 0 || channels == 0) return R::err("Invalid frame dimensions");
+
+        InferenceOutput output;
+        output.timestamp_ns =
+            static_cast<uint64_t>(std::chrono::steady_clock::now().time_since_epoch().count());
+
+#ifdef HAS_OPENCV
+        if (!model_loaded_) return R::ok(std::move(output));
+
+        const int cv_type = (channels == 4) ? CV_8UC4 : CV_8UC3;
+        cv::Mat   frame(static_cast<int>(height), static_cast<int>(width), cv_type,
+                        const_cast<uint8_t*>(frame_data));
+        cv::Mat   rgb;
+        if (channels == 4) {
+            cv::cvtColor(frame, rgb, cv::COLOR_RGBA2RGB);
+        } else if (channels == 1) {
+            cv::cvtColor(frame, rgb, cv::COLOR_GRAY2RGB);
+        } else {
+            rgb = frame;
+        }
+
+        // Blob → forward
+        cv::Mat blob;
+        cv::dnn::blobFromImage(rgb, blob, 1.0 / 255.0, cv::Size(input_size_, input_size_),
+                               cv::Scalar(), true, false);
+        net_.setInput(blob);
+
+        std::vector<cv::Mat> outputs;
+        try {
+            net_.forward(outputs, output_layer_names_);
+        } catch (const cv::Exception& e) {
+            return R::err(std::string("[FastSAM] forward() failed: ") + e.what());
+        }
+        if (outputs.size() < 2) {
+            return R::err("[FastSAM] expected 2 outputs (det + mask proto), got " +
+                          std::to_string(outputs.size()));
+        }
+
+        // outputs[0] shape: [1, 4 + 1 + mask_channels, num_proposals]
+        // outputs[1] shape: [1, mask_channels, mask_h, mask_w]
+        cv::Mat det_output  = outputs[0];
+        cv::Mat mask_protos = outputs[1];
+
+        const int rows          = det_output.size[1];
+        const int cols          = det_output.size[2];
+        const int expected_rows = 4 + kNumClasses + mask_channels_;
+        if (rows != expected_rows) {
+            return R::err("[FastSAM] detection output shape: expected " +
+                          std::to_string(expected_rows) + " rows, got " + std::to_string(rows));
+        }
+        if (cols <= 0 || cols > kMaxProposals) {
+            return R::err("[FastSAM] unexpected proposal count: " + std::to_string(cols));
+        }
+
+        CV_Assert(det_output.type() == CV_32F);
+        float* data = reinterpret_cast<float*>(det_output.data);
+
+        const float x_scale  = static_cast<float>(width) / static_cast<float>(input_size_);
+        const float y_scale  = static_cast<float>(height) / static_cast<float>(input_size_);
+        const int   mask_h   = mask_protos.size[2];
+        const int   mask_w   = mask_protos.size[3];
+        cv::Mat     proto_2d = mask_protos.reshape(1, {mask_channels_, mask_h * mask_w});
+
+        std::vector<float>              confidences;
+        std::vector<cv::Rect>           boxes;
+        std::vector<std::vector<float>> mask_coeffs_all;
+        const auto reserve_count = static_cast<size_t>(std::min(cols, 512));
+        confidences.reserve(reserve_count);
+        boxes.reserve(reserve_count);
+        mask_coeffs_all.reserve(reserve_count);
+
+        // FastSAM is class-agnostic: single class score at index 4.
+        for (int i = 0; i < cols; ++i) {
+            const float conf = data[4 * cols + i];
+            if (conf < confidence_threshold_) continue;
+
+            const float cx = data[0 * cols + i] * x_scale;
+            const float cy = data[1 * cols + i] * y_scale;
+            const float w  = data[2 * cols + i] * x_scale;
+            const float h  = data[3 * cols + i] * y_scale;
+
+            const int left = static_cast<int>(cx - w / 2.0f);
+            const int top  = static_cast<int>(cy - h / 2.0f);
+            const int bw   = static_cast<int>(w);
+            const int bh   = static_cast<int>(h);
+            boxes.emplace_back(left, top, bw, bh);
+            confidences.push_back(conf);
+
+            std::vector<float> mc(static_cast<size_t>(mask_channels_));
+            for (int m = 0; m < mask_channels_; ++m) {
+                mc[static_cast<size_t>(m)] = data[(4 + kNumClasses + m) * cols + i];
+            }
+            mask_coeffs_all.push_back(std::move(mc));
+        }
+
+        std::vector<int> nms_indices;
+        cv::dnn::NMSBoxes(boxes, confidences, confidence_threshold_, nms_threshold_, nms_indices);
+
+        output.detections.reserve(nms_indices.size());
+        for (int idx : nms_indices) {
+            InferenceDetection det;
+            det.bbox.x     = static_cast<float>(std::max(0, boxes[idx].x));
+            det.bbox.y     = static_cast<float>(std::max(0, boxes[idx].y));
+            det.bbox.w     = static_cast<float>(boxes[idx].width);
+            det.bbox.h     = static_cast<float>(boxes[idx].height);
+            det.confidence = confidences[idx];
+            det.class_id   = -1;  // class-agnostic — MaskClassAssigner applies label downstream
+
+            if (det.bbox.x + det.bbox.w > static_cast<float>(width))
+                det.bbox.w = static_cast<float>(width) - det.bbox.x;
+            if (det.bbox.y + det.bbox.h > static_cast<float>(height))
+                det.bbox.h = static_cast<float>(height) - det.bbox.y;
+            if (det.bbox.w <= 0.0f || det.bbox.h <= 0.0f) continue;
+
+            // Decode mask: coeffs @ proto → sigmoid → crop → resize to bbox
+            cv::Mat coeffs(1, mask_channels_, CV_32F,
+                           mask_coeffs_all[static_cast<size_t>(idx)].data());
+            cv::Mat mask_raw = coeffs * proto_2d;
+            mask_raw         = mask_raw.reshape(1, {mask_h, mask_w});
+            cv::exp(-mask_raw, mask_raw);
+            mask_raw = 1.0f / (1.0f + mask_raw);
+
+            const float proto_scale_x = static_cast<float>(mask_w) /
+                                        static_cast<float>(input_size_);
+            const float proto_scale_y = static_cast<float>(mask_h) /
+                                        static_cast<float>(input_size_);
+            const int rx = std::max(0, static_cast<int>(boxes[idx].x / x_scale * proto_scale_x));
+            const int ry = std::max(0, static_cast<int>(boxes[idx].y / y_scale * proto_scale_y));
+            const int rw = std::min(mask_w - rx, std::max(1, static_cast<int>(boxes[idx].width /
+                                                                              x_scale *
+                                                                              proto_scale_x)));
+            const int rh = std::min(mask_h - ry, std::max(1, static_cast<int>(boxes[idx].height /
+                                                                              y_scale *
+                                                                              proto_scale_y)));
+            cv::Mat mask_crop = mask_raw(cv::Rect(rx, ry, rw, rh));
+
+            const int bbox_px_w = std::max(1, static_cast<int>(det.bbox.w));
+            const int bbox_px_h = std::max(1, static_cast<int>(det.bbox.h));
+            cv::Mat   mask_resized;
+            cv::resize(mask_crop, mask_resized, cv::Size(bbox_px_w, bbox_px_h), 0, 0,
+                       cv::INTER_LINEAR);
+            cv::Mat mask_binary;
+            mask_resized.convertTo(mask_binary, CV_8U, 255.0);
+            cv::threshold(mask_binary, mask_binary, 127, 255, cv::THRESH_BINARY);
+
+            // Output mask is full-image resolution (matches EdgeContour /
+            // SimulatedSAM convention — CpuSemanticProjector auto-detects).
+            det.mask_width  = width;
+            det.mask_height = height;
+            det.mask.assign(static_cast<size_t>(width) * height, uint8_t{0});
+            const int dst_x = static_cast<int>(det.bbox.x);
+            const int dst_y = static_cast<int>(det.bbox.y);
+            for (int row = 0; row < bbox_px_h && (dst_y + row) < static_cast<int>(height); ++row) {
+                const auto dst_off = static_cast<size_t>(dst_y + row) * width +
+                                     static_cast<size_t>(dst_x);
+                const int copy_w = std::min(bbox_px_w, static_cast<int>(width) - dst_x);
+                if (copy_w > 0) {
+                    std::copy(mask_binary.ptr<uint8_t>(row), mask_binary.ptr<uint8_t>(row) + copy_w,
+                              &det.mask[dst_off]);
+                }
+            }
+            output.detections.push_back(std::move(det));
+        }
+        return R::ok(std::move(output));
+#else
+        (void)width;
+        (void)height;
+        (void)channels;
+        return R::ok(std::move(output));
+#endif
+    }
+
+    [[nodiscard]] std::string name() const override { return "FastSamInferenceBackend"; }
+
+private:
+    static constexpr int kMinInputSize = 128;
+    static constexpr int kMaxInputSize = 2048;
+    static constexpr int kMaxProposals = 16384;
+    static constexpr int kNumClasses   = 1;  // FastSAM is class-agnostic
+
+    [[nodiscard]] bool load_model() {
+#ifdef HAS_OPENCV
+        if (model_path_.empty()) {
+            DRONE_LOG_ERROR("[FastSAM] Empty model path — no inference available.  Run "
+                            "models/download_fastsam.sh to fetch + export FastSAM-s.");
+            model_loaded_ = false;
+            return false;
+        }
+        if (!std::filesystem::exists(model_path_)) {
+            DRONE_LOG_ERROR("[FastSAM] Model file does not exist: '{}'.  Run "
+                            "models/download_fastsam.sh.",
+                            model_path_);
+            model_loaded_ = false;
+            return false;
+        }
+        try {
+            net_ = cv::dnn::readNetFromONNX(model_path_);
+            net_.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);
+            net_.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);
+            output_layer_names_ = net_.getUnconnectedOutLayersNames();
+            model_loaded_       = true;
+            DRONE_LOG_INFO("[FastSAM] Model loaded: {} (conf={:.2f}, nms={:.2f}, input={}x{}, "
+                           "mask_channels={})",
+                           model_path_, confidence_threshold_, nms_threshold_, input_size_,
+                           input_size_, mask_channels_);
+            return true;
+        } catch (const cv::Exception& e) {
+            DRONE_LOG_ERROR("[FastSAM] Failed to load '{}': {}", model_path_, e.what());
+            model_loaded_ = false;
+            return false;
+        }
+#else
+        DRONE_LOG_WARN("[FastSAM] OpenCV not available at compile time — backend inert.");
+        return false;
+#endif
+    }
+
+#ifdef HAS_OPENCV
+    cv::dnn::Net             net_;
+    std::vector<std::string> output_layer_names_;
+#endif
+    std::string model_path_;
+    bool        model_loaded_         = false;
+    float       confidence_threshold_ = 0.40f;
+    float       nms_threshold_        = 0.45f;
+    int         input_size_           = 1024;
+    int         mask_channels_        = 32;
+};
+
+}  // namespace drone::hal

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "hal/cpu_semantic_projector.h"
+#include "hal/edge_contour_sam_backend.h"
+#include "hal/fastsam_inference_backend.h"
 #include "hal/icamera.h"
 #include "hal/ievent_camera.h"
 #include "hal/ifc_link.h"
@@ -33,8 +35,6 @@
 #include "hal/simulated_gcs_link.h"
 #include "hal/simulated_gimbal.h"
 #include "hal/simulated_imu.h"
-#include "hal/edge_contour_sam_backend.h"
-#include "hal/fastsam_inference_backend.h"
 #include "hal/simulated_inference_backend.h"
 #include "hal/simulated_radar.h"
 #include "hal/simulated_sam_backend.h"

--- a/common/hal/include/hal/hal_factory.h
+++ b/common/hal/include/hal/hal_factory.h
@@ -33,6 +33,8 @@
 #include "hal/simulated_gcs_link.h"
 #include "hal/simulated_gimbal.h"
 #include "hal/simulated_imu.h"
+#include "hal/edge_contour_sam_backend.h"
+#include "hal/fastsam_inference_backend.h"
 #include "hal/simulated_inference_backend.h"
 #include "hal/simulated_radar.h"
 #include "hal/simulated_sam_backend.h"
@@ -357,6 +359,20 @@ template<typename Interface>
     }
     if (backend == "sam_simulated") {
         return std::make_unique<SimulatedSAMBackend>(cfg, section);
+    }
+    // Algorithmic class-agnostic segmentation — OpenCV edge+contour based.
+    // Produces real masks from image content without any ML dependency;
+    // the interim fill between SimulatedSAMBackend (test scaffold) and a
+    // real SAM-2 ONNX backend (Epic #520 / Issue #555).
+    if (backend == "edge_contour_sam") {
+        return std::make_unique<EdgeContourSAMBackend>(cfg, section);
+    }
+    // Real class-agnostic SAM via FastSAM ONNX (YOLOv8-seg architecture
+    // trained on Meta's SA-1B).  The drop-in for what Epic #520 / Issue
+    // #555 actually needed.  Requires `models/fastsam_s.onnx` — run
+    // `bash models/download_fastsam.sh` to fetch + export.
+    if (backend == "fastsam") {
+        return std::make_unique<FastSamInferenceBackend>(cfg, section);
     }
 #ifdef HAVE_PLUGINS
     if (backend == "plugin") {

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -286,6 +286,18 @@ inline constexpr const char* REQUIRE_RADAR_FOR_PROMOTION =
 inline constexpr const char* PREDICTION_ENABLED =
     "mission_planner.occupancy_grid.prediction_enabled";
 inline constexpr const char* PREDICTION_DT_S = "mission_planner.occupancy_grid.prediction_dt_s";
+
+// Semantic-voxel input (Epic #520 / Issue #608 PATH A).  When enabled, P4 subscribes
+// to /semantic_voxels and inserts each voxel directly into the static layer, bypassing
+// the promotion_hits filter (voxels are already mask-gated and confidence-scored on
+// the P2 side).  The position clamp is enforced at the P4 boundary as a final guard
+// against out-of-world-extent positions (addresses review security P3 from PR #609).
+inline constexpr const char* VOXEL_INPUT_ENABLED =
+    "mission_planner.occupancy_grid.voxel_input.enabled";
+inline constexpr const char* VOXEL_INPUT_POSITION_CLAMP_M =
+    "mission_planner.occupancy_grid.voxel_input.position_clamp_m";
+inline constexpr const char* VOXEL_INPUT_MIN_CONFIDENCE =
+    "mission_planner.occupancy_grid.voxel_input.min_confidence";
 }  // namespace occupancy_grid
 
 namespace obstacle_avoidance {

--- a/config/default.json
+++ b/config/default.json
@@ -227,7 +227,13 @@
             "max_static_cells": 0,
             "require_radar_for_promotion": false,
             "prediction_enabled": true,
-            "prediction_dt_s": 2.0
+            "prediction_dt_s": 2.0,
+            "voxel_input": {
+                "_comment": "PATH A voxel subscriber (Epic #520 / Issue #608). Disabled by default; scenario 33 enables it.",
+                "enabled": false,
+                "position_clamp_m": 1000.0,
+                "min_confidence": 0.3
+            }
         },
         "obstacle_avoider": {
             "backend": "potential_field_3d"

--- a/config/scenarios/33_non_coco_obstacles.json
+++ b/config/scenarios/33_non_coco_obstacles.json
@@ -53,13 +53,13 @@
             }
         },
         "perception": {
+            "_comment_detector": "Perception v2 (Epic #520) design: detector provides class labels only — SAM masks are the primary obstacle source. Switched from color_contour (ground-texture ghost cells) to YOLOv8 so the detector fires ONLY on real COCO objects (person, chair, couch, bush). Non-COCO obstacles (wall, pillar, cube) have no detector bbox, get GEOMETRIC_OBSTACLE via MaskClassAssigner fallback, and are represented in the grid purely through PATH A voxels. Detector output also drives dynamic TTL cells for reactive avoidance of moving objects — static promotion is paused when voxel_input is enabled (see mission_planner.occupancy_grid.voxel_input).",
             "detector": {
-                "backend": "color_contour",
-                "min_contour_area": 2000,
+                "backend": "yolov8",
+                "model_path": "models/yolov8n.onnx",
                 "confidence_threshold": 0.4,
                 "max_fps": 30,
-                "min_bbox_height_px": 60,
-                "max_aspect_ratio": 5.0
+                "input_size": 640
             },
             "depth_estimator": {
                 "backend": "depth_anything_v2",
@@ -81,13 +81,15 @@
                 "measurement_noise_bearing": 0.05
             },
             "path_a": {
-                "_comment": "PATH A enabled — SAM-simulated masks fused with detector output. MaskDepthProjector produces GEOMETRIC_OBSTACLE voxels for non-COCO objects.",
+                "_comment": "PATH A enabled with real class-agnostic SAM via FastSAM ONNX (YOLOv8-seg architecture trained on SA-1B). Produces masks for every distinct object/surface in the frame regardless of COCO class. Prerequisite: run `bash models/download_fastsam.sh` once to fetch FastSAM-s.pt and export to models/fastsam_s.onnx (~50 MB, ~80 ms/frame CPU). MaskDepthProjector back-projects the masks via Depth Anything V2 into world-frame voxels; non-COCO obstacles (walls, pillars, TemplateCubes) get GEOMETRIC_OBSTACLE labels because they don't match any YOLOv8 detector bbox.",
                 "enabled": true,
                 "sam": {
-                    "backend": "sam_simulated",
-                    "model_path": "",
+                    "backend": "fastsam",
+                    "model_path": "models/fastsam_s.onnx",
                     "input_size": 1024,
-                    "num_masks": 5
+                    "confidence_threshold": 0.4,
+                    "nms_threshold": 0.45,
+                    "mask_channels": 32
                 },
                 "mask_class_iou_threshold": 0.5
             }
@@ -149,7 +151,13 @@
                 "dynamic_obstacle_ttl_s": 2.0,
                 "min_confidence": 0.5,
                 "promotion_hits": 10,
-                "max_static_cells": 500
+                "max_static_cells": 500,
+                "voxel_input": {
+                    "_comment": "PATH A voxel subscriber enabled — MaskDepthProjector batches from P2 feed the static layer directly (bypassing promotion_hits, since voxels are already mask-gated + confidence-scored).",
+                    "enabled": true,
+                    "position_clamp_m": 200.0,
+                    "min_confidence": 0.3
+                }
             },
             "_comment_static_obstacles": "No HD-map. Perception-driven avoidance via PATH A pipeline — SAM masks + depth → occupancy grid.",
             "static_obstacles": [],
@@ -196,6 +204,31 @@
             "enable_memory_monitoring": true,
             "watchdog_interval_ms": 500
         }
+    },
+    "pass_criteria": {
+        "_comment": "Enforced by tests/run_scenario_cosys.sh Phase 6 (grep against combined.log). Validates the full PATH A pipeline is engaged: P2 SAM thread + MaskDepthProjector publisher and P4 voxel subscriber + grid writer. The log_must_not_contain list rejects the failure modes from the pre-#608 run (STUCK loop → LOITER escalation + silent PATH A init failure).",
+        "log_contains": [
+            "[PathA] Enabled",
+            "[SAM] Thread started",
+            "[MaskProj] Thread started",
+            "[MaskProj] Published",
+            "[VoxelSub] Subscribed to",
+            "[VoxelSub]",
+            "Advanced to waypoint 5/5"
+        ],
+        "log_must_not_contain": [
+            "[PathA] Requested via config but initialisation failed",
+            "STUCK count 4 exceeded cap 3"
+        ],
+        "processes_alive": [
+            "video_capture",
+            "perception",
+            "slam_vio_nav",
+            "mission_planner",
+            "comms",
+            "payload_manager",
+            "system_monitor"
+        ]
     },
     "validation": {
         "checks": [

--- a/docs/tracking/IMPROVEMENTS.md
+++ b/docs/tracking/IMPROVEMENTS.md
@@ -18,6 +18,19 @@ Running list of improvements noticed in passing while doing other work. Not urge
 
 ### 2026-04-22
 
+#### (new) Revisit: extract PATH A (SAM + mask projection) into its own process
+
+- **Priority:** P3
+- **Category:** architecture
+- **Noticed while:** Issue #608 PR 2 design discussion — weighing "new process P8" vs. "two more threads in P2" for the SAM + MaskDepthProjector pipeline.
+- **Current decision:** Stay in P2 as threads (per-path factory from Epic #516 supports this cleanly). Data locality is the dominant factor — MaskDepthProjector needs frame, bboxes, SAM masks, depth, and camera pose, all of which already exist in P2.
+- **Revisit trigger:** When the first real SAM backend lands (non-`SimulatedSAMBackend`). At that point, evaluate:
+  - Does SAM's ONNX / GPU footprint cause OOMs, hangs, or CUDA-context fights that take P2's core detection/tracking down with it?
+  - Is the GPU memory ceiling pushing us toward per-process cgroups + CUDA budgeting?
+  - Would a restart policy specific to the ML-heavy SAM path (exponential backoff, disable-on-repeated-failure) be meaningfully different from the current shared P2 policy?
+- **If yes to any:** extract PATH A to a new process (P8). The per-path factory means the extraction is primarily moving the two thread constructors and wiring new IPC hops; protocol-level breakage is limited to making `/drone_mission_cam` have a second subscriber and adding a new `/semantic_voxels` publisher location — both low-risk given existing patterns.
+- **If no:** leave as threads, document the decision's residual risk in a DR entry.
+
 #### 15. MaskClassAssigner copies full InferenceDetection (including mask pixel buffer) per mask per frame
 
 - **Priority:** P2

--- a/models/download_fastsam.sh
+++ b/models/download_fastsam.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# models/download_fastsam.sh
+# Fetches FastSAM-s (small variant) and exports to ONNX for OpenCV DNN.
+#
+# FastSAM is YOLOv8-seg architecture trained on SA-1B — Meta's Segment
+# Anything dataset — giving class-agnostic segmentation of every distinct
+# object/surface in a single forward pass.  This is what Epic #520 /
+# Issue #555 scoped and never actually shipped.  Consumed by
+# `hal::FastSamInferenceBackend` (Issue #608 E5.INT) via
+# `perception.path_a.sam.backend = "fastsam"`.
+#
+# Model footprint:
+#   FastSAM-s.pt  → ~23 MB (download from Ultralytics)
+#   fastsam_s.onnx → ~50 MB (after export, opset=12, imgsz=1024)
+#
+# Inference cost (~1280×720 frames → downsampled to 1024×1024):
+#   ~80 ms CPU (OpenCV DNN, single thread)
+#   ~20 ms CUDA (DNN_TARGET_CUDA, if built with it)
+#
+# Dependencies (installed automatically via pip if missing):
+#   ultralytics>=8.0  — provides FastSAM + export
+#   onnx, onnxsim   — graph cleanup
+#
+# Usage:
+#   cd <project_root>
+#   bash models/download_fastsam.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODEL_PATH="${SCRIPT_DIR}/fastsam_s.onnx"
+
+if [[ -f "$MODEL_PATH" ]]; then
+    echo "Model already exists: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
+    exit 0
+fi
+
+echo "=== FastSAM-s download + ONNX export ==="
+echo "Target: $MODEL_PATH"
+
+# ── Ensure Python + ultralytics are available ──
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is required but not found." >&2
+    exit 1
+fi
+
+echo "Installing Python deps (ultralytics, onnx, onnxsim)..."
+python3 -m pip install --quiet --user ultralytics onnx onnxsim onnxruntime 1>&2 || {
+    echo "WARN: --user install failed, retrying without --user (may need sudo)..."
+    python3 -m pip install --quiet ultralytics onnx onnxsim onnxruntime
+}
+
+# ── Download + export via ultralytics in a temp dir ──
+TMPDIR="$(mktemp -d -t fastsam.XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT
+cd "$TMPDIR"
+
+# Ultralytics will download FastSAM-s.pt on first instantiation.  Export to
+# ONNX with opset=12 (OpenCV DNN 4.5+ compatibility) and imgsz=1024 (FastSAM
+# default — the mask prototypes are at 256×256 at this input size, which
+# matches the dimensions `FastSamInferenceBackend` expects).
+python3 - <<'PY'
+from ultralytics import FastSAM
+import pathlib
+model = FastSAM('FastSAM-s.pt')
+exported = model.export(format='onnx', imgsz=1024, opset=12, simplify=True)
+src = pathlib.Path(exported)
+print(f"Exported: {src} ({src.stat().st_size / 1e6:.1f} MB)")
+PY
+
+# Move the exported file into place.  Ultralytics names it "FastSAM-s.onnx".
+SRC_ONNX="$(find "$TMPDIR" -maxdepth 2 -name 'FastSAM-s.onnx' -o -name 'fastsam-s.onnx' | head -1)"
+if [[ -z "$SRC_ONNX" ]]; then
+    echo "ERROR: FastSAM ONNX export did not produce the expected file." >&2
+    exit 1
+fi
+
+# Ultralytics' built-in simplify leaves shape-inference Floor nodes that
+# OpenCV DNN 4.10 chokes on (parse error: Node [Floor@ai.onnx]).
+# Run onnxsim as a second pass to constant-fold them away.  This is what
+# actually makes the model load into our perception runtime.
+echo "Running onnxsim post-pass (folds shape-computation Floor nodes)..."
+python3 -m onnxsim "$SRC_ONNX" "$MODEL_PATH"
+
+echo ""
+echo "=== done ==="
+echo "Model: $MODEL_PATH ($(du -h "$MODEL_PATH" | cut -f1))"
+echo ""
+echo "Use via:"
+echo '  "perception": { "path_a": { "sam": { "backend": "fastsam",'
+echo "                                        \"model_path\": \"$MODEL_PATH\","
+echo '                                        "input_size": 1024,'
+echo '                                        "confidence_threshold": 0.4,'
+echo '                                        "mask_channels": 32 } } }'

--- a/process2_perception/include/perception/types.h
+++ b/process2_perception/include/perception/types.h
@@ -1,6 +1,8 @@
 // process2_perception/include/perception/types.h
 // All data types for perception: detections, tracked/fused objects.
 #pragma once
+#include "hal/iinference_backend.h"
+
 #include <array>
 #include <cstdint>
 #include <string>
@@ -56,6 +58,18 @@ struct Detection2DList {
     std::vector<Detection2D> detections;
     uint64_t                 timestamp_ns   = 0;
     uint64_t                 frame_sequence = 0;
+};
+
+// ═══════════════════════════════════════════════════════════
+// SAM Masks (PATH A — Epic #520, Issue #608)
+// Carries class-agnostic mask output from an IInferenceBackend (e.g.
+// SimulatedSAMBackend) plus the source frame's sequence number so the
+// mask_projection_thread can correlate with detector bboxes + depth.
+// ═══════════════════════════════════════════════════════════
+struct Masks2DList {
+    std::vector<drone::hal::InferenceDetection> masks;
+    uint64_t                                    timestamp_ns   = 0;
+    uint64_t                                    frame_sequence = 0;
 };
 
 // ═══════════════════════════════════════════════════════════

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -932,7 +932,7 @@ int main(int argc, char* argv[]) {
             // is "sam_simulated" (scenario 33's current setting).
             const std::string sam_section =
                 std::string(drone::cfg_key::perception::path_a::SECTION) + ".sam";
-            sam_backend      = drone::hal::create_inference_backend(ctx.cfg, sam_section);
+            sam_backend = drone::hal::create_inference_backend(ctx.cfg, sam_section);
             const std::string sam_model_path =
                 ctx.cfg.get<std::string>(drone::cfg_key::perception::path_a::SAM_MODEL_PATH, "");
             const int sam_input_size =

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -3,15 +3,19 @@
 // Reads video frames from SHM, runs detection → tracking → fusion,
 // publishes fused objects to SHM.
 
+#include "hal/cpu_semantic_projector.h"
 #include "hal/hal_factory.h"
 #include "hal/idepth_estimator.h"
+#include "hal/iinference_backend.h"
 #include "hal/iradar.h"
+#include "hal/simulated_sam_backend.h"
 #include "ipc/ipc_types.h"
 #include "perception/detector_interface.h"
 #include "perception/fusion_engine.h"
 #include "perception/ifusion_engine.h"
 #include "perception/itracker.h"
 #include "perception/kalman_tracker.h"
+#include "perception/mask_depth_projector.h"
 #include "perception/types.h"
 #include "perception/ukf_fusion_engine.h"
 #include "util/config_keys.h"
@@ -54,6 +58,11 @@ static std::atomic<int> g_shutdown_phase{0};
 // ── Inference thread ────────────────────────────────────────
 // Stops when shutdown_phase >= 1.  No drain needed — inference is the
 // pipeline source; stopping it is what triggers downstream drains.
+// @param projection_output_queue nullable — when PATH A is enabled
+//                 (Epic #520, Issue #608), the mask_projection_thread reads
+//                 from a second TripleBuffer.  inference_thread writes to
+//                 it in addition to the primary tracker queue.  Each
+//                 TripleBuffer has a single consumer — fanout is explicit.
 // @param profiler nullable — pass nullptr to disable per-stage latency
 //                 profiling. See DR-022 for the safety analysis of
 //                 mutex-protected recording from this flight-critical
@@ -61,8 +70,10 @@ static std::atomic<int> g_shutdown_phase{0};
 static void inference_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& video_sub,
                              drone::TripleBuffer<Detection2DList>&            output_queue,
                              std::atomic<int>& shutdown_phase, IDetector& detector,
-                             drone::util::LatencyProfiler* profiler) {
-    DRONE_LOG_INFO("[Inference] Thread started — using detector: {}", detector.name());
+                             drone::util::LatencyProfiler*         profiler,
+                             drone::TripleBuffer<Detection2DList>* projection_output_queue) {
+    DRONE_LOG_INFO("[Inference] Thread started — using detector: {}{}", detector.name(),
+                   projection_output_queue ? " (PATH A fanout active)" : "");
 
     auto hb = drone::util::ScopedHeartbeat("inference", true);
 
@@ -94,6 +105,12 @@ static void inference_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& vi
             diag.add_metric("Detect", "n_detections",
                             static_cast<double>(det_list.detections.size()));
 
+            // PATH A fanout — mask_projection_thread needs the raw detector
+            // bboxes alongside SAM masks.  Write a copy first; move into the
+            // primary queue second.
+            if (projection_output_queue) {
+                projection_output_queue->write(det_list);  // copy
+            }
             output_queue.write(std::move(det_list));
             ++frame_count;
 
@@ -111,6 +128,203 @@ static void inference_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& vi
     }
     DRONE_LOG_INFO("[Inference] Thread stopped — {} frames, {} writes", frame_count,
                    output_queue.write_count());
+}
+
+// ── SAM thread ──────────────────────────────────────────────
+// Stops when shutdown_phase >= 1.  Consumes video frames via its own
+// Zenoh subscriber (same pattern as depth_thread) and produces
+// class-agnostic masks for the mask_projection_thread.  Only started
+// when perception.path_a.enabled is true.
+// @param sam   IInferenceBackend that returns per-mask
+//              InferenceDetection entries (e.g. SimulatedSAMBackend).
+static void sam_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& video_sub,
+                       drone::TripleBuffer<Masks2DList>&                output_queue,
+                       std::atomic<int>& shutdown_phase, drone::hal::IInferenceBackend& sam) {
+    DRONE_LOG_INFO("[SAM] Thread started — backend: {}", sam.name());
+
+    auto hb = drone::util::ScopedHeartbeat("sam", true);
+
+    uint64_t frame_count = 0;
+    uint64_t fail_count  = 0;
+    while (shutdown_phase.load(std::memory_order_acquire) < 1) {
+        drone::util::ThreadHeartbeatRegistry::instance().touch(hb.handle());
+        drone::ipc::VideoFrame frame;
+        bool                   got_frame = video_sub.receive(frame);
+
+        if (!got_frame) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        auto result = sam.infer(frame.pixel_data, frame.width, frame.height, frame.channels);
+        if (!result.is_ok()) {
+            ++fail_count;
+            if (fail_count % 100 == 1) {
+                DRONE_LOG_WARN("[SAM] infer() failed ({} consecutive): {}", fail_count,
+                               result.error());
+            }
+            continue;
+        }
+        fail_count = 0;
+
+        Masks2DList list;
+        list.masks          = std::move(result).value().detections;
+        list.timestamp_ns   = frame.timestamp_ns;
+        list.frame_sequence = frame.sequence_number;
+        output_queue.write(std::move(list));
+        ++frame_count;
+
+        if (frame_count % 100 == 0) {
+            DRONE_LOG_INFO("[SAM] Processed {} frames (writes={})", frame_count,
+                           output_queue.write_count());
+        }
+    }
+    DRONE_LOG_INFO("[SAM] Thread stopped — {} frames, {} writes", frame_count,
+                   output_queue.write_count());
+}
+
+// ── Mask projection thread (PATH A consumer) ─────────────────
+// Stops when shutdown_phase >= 2 (same as fusion_thread — runs alongside
+// fusion, not downstream of it).  Correlates SAM masks, detector bboxes,
+// depth, and camera pose, runs MaskDepthProjector, converts the
+// resulting VoxelUpdate[] to a SemanticVoxelBatch, and publishes on
+// `/semantic_voxels` for P4's voxel subscriber.
+//
+// Synchronization: primary trigger is SAM output (the most expensive
+// stage).  On each arriving mask list, pull latest-value from the other
+// three inputs.  If detections or depth are missing for this tick,
+// skip — the MaskDepthProjector needs both (masks alone can't produce
+// voxels without depth).
+static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          masks_queue,
+                                   drone::TripleBuffer<Detection2DList>&      detections_queue,
+                                   drone::TripleBuffer<drone::hal::DepthMap>& depth_queue,
+                                   drone::ipc::ISubscriber<drone::ipc::Pose>& pose_sub,
+                                   drone::ipc::IPublisher<drone::ipc::SemanticVoxelBatch>& voxel_pub,
+                                   std::atomic<int>&                      shutdown_phase,
+                                   drone::perception::MaskDepthProjector& projector) {
+    DRONE_LOG_INFO("[MaskProj] Thread started — publishing to {}",
+                   drone::ipc::topics::SEMANTIC_VOXELS);
+
+    auto hb = drone::util::ScopedHeartbeat("mask_projection", true);
+
+    uint64_t                            tick_count      = 0;
+    uint64_t                            published_count = 0;
+    uint64_t                            skipped_count   = 0;
+    std::optional<drone::ipc::Pose>     latest_pose;
+    std::optional<drone::hal::DepthMap> latest_depth;
+    std::optional<Detection2DList>      latest_dets;
+
+    while (shutdown_phase.load(std::memory_order_acquire) < 2) {
+        drone::util::ThreadHeartbeatRegistry::instance().touch(hb.handle());
+
+        auto masks_opt = masks_queue.read();
+        if (!masks_opt) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            continue;
+        }
+
+        ++tick_count;
+
+        // Refresh latest detections + depth + pose (best-effort; keep prior
+        // snapshot if the triple buffer hasn't produced new data this tick).
+        if (auto d = detections_queue.read()) latest_dets = std::move(*d);
+        if (auto d = depth_queue.read()) latest_depth = std::move(*d);
+        drone::ipc::Pose pose_msg;
+        if (pose_sub.receive(pose_msg)) latest_pose = pose_msg;
+
+        // Need all four inputs for projection to produce meaningful voxels.
+        // Skip the tick if any are missing — next tick will retry with the
+        // cached snapshot.
+        if (!latest_dets || !latest_depth || !latest_pose) {
+            ++skipped_count;
+            if (skipped_count % 100 == 1) {
+                DRONE_LOG_DEBUG("[MaskProj] skip — dets={} depth={} pose={}",
+                                latest_dets.has_value(), latest_depth.has_value(),
+                                latest_pose.has_value());
+            }
+            continue;
+        }
+
+        // Convert perception::Detection2D -> hal::InferenceDetection for the
+        // MaskDepthProjector API.  Masks are empty on these (detector doesn't
+        // produce masks — SAM does).
+        std::vector<drone::hal::InferenceDetection> det_hal;
+        det_hal.reserve(latest_dets->detections.size());
+        for (const auto& d : latest_dets->detections) {
+            drone::hal::InferenceDetection h;
+            h.bbox.x      = d.x;
+            h.bbox.y      = d.y;
+            h.bbox.w      = d.w;
+            h.bbox.h      = d.h;
+            h.class_id    = static_cast<int>(d.class_id);
+            h.confidence  = d.confidence;
+            h.mask_width  = 0;
+            h.mask_height = 0;
+            det_hal.push_back(std::move(h));
+        }
+
+        // Build camera pose as an Affine3f from the SLAM quaternion/translation.
+        Eigen::Quaternionf q(static_cast<float>(latest_pose->quaternion[0]),
+                             static_cast<float>(latest_pose->quaternion[1]),
+                             static_cast<float>(latest_pose->quaternion[2]),
+                             static_cast<float>(latest_pose->quaternion[3]));
+        if (q.squaredNorm() < 1e-6f) {
+            ++skipped_count;
+            continue;
+        }
+        q.normalize();
+        Eigen::Affine3f cam_pose = Eigen::Affine3f::Identity();
+        cam_pose.linear()        = q.toRotationMatrix();
+        cam_pose.translation()   = Eigen::Vector3f(static_cast<float>(latest_pose->translation[0]),
+                                                   static_cast<float>(latest_pose->translation[1]),
+                                                   static_cast<float>(latest_pose->translation[2]));
+
+        auto proj = projector.project(masks_opt->masks, det_hal, *latest_depth, cam_pose);
+        if (!proj.is_ok()) {
+            if (tick_count % 100 == 1) {
+                DRONE_LOG_WARN("[MaskProj] project() failed: {}", proj.error());
+            }
+            continue;
+        }
+        const auto voxels = std::move(proj).value();
+        if (voxels.empty()) {
+            continue;
+        }
+
+        // Pack VoxelUpdate[] -> SemanticVoxelBatch.  Truncate by descending
+        // confidence if we ever overshoot MAX_VOXELS_PER_BATCH (see #608).
+        auto batch            = std::make_unique<drone::ipc::SemanticVoxelBatch>();
+        batch->timestamp_ns   = masks_opt->timestamp_ns;
+        batch->frame_sequence = static_cast<uint64_t>(masks_opt->frame_sequence);
+        const size_t n_voxels = std::min<size_t>(voxels.size(), drone::ipc::MAX_VOXELS_PER_BATCH);
+        batch->num_voxels     = static_cast<uint32_t>(n_voxels);
+        for (size_t i = 0; i < n_voxels; ++i) {
+            const auto& v   = voxels[i];
+            auto&       out = batch->voxels[i];
+            out.position_x  = v.position_m.x();
+            out.position_y  = v.position_m.y();
+            out.position_z  = v.position_m.z();
+            out.occupancy   = std::clamp(v.occupancy, 0.0f, 1.0f);
+            out.confidence  = std::clamp(v.confidence, 0.0f, 1.0f);
+            // hal::VoxelUpdate::semantic_label is a uint8_t that the
+            // CpuSemanticProjector sets from the detection's assigned class.
+            // Clamp to the ObjectClass range so validate() accepts it.
+            const uint8_t label_byte = std::min<uint8_t>(
+                v.semantic_label,
+                static_cast<uint8_t>(drone::ipc::ObjectClass::GEOMETRIC_OBSTACLE));
+            out.semantic_label = static_cast<drone::ipc::ObjectClass>(label_byte);
+            out.timestamp_ns   = v.timestamp_ns;
+        }
+        voxel_pub.publish(*batch);
+        ++published_count;
+
+        if (published_count % 50 == 0) {
+            DRONE_LOG_INFO("[MaskProj] Published {} batches — last batch: {} voxels, {} skipped",
+                           published_count, batch->num_voxels, skipped_count);
+        }
+    }
+    DRONE_LOG_INFO("[MaskProj] Thread stopped — {} ticks, {} published, {} skipped", tick_count,
+                   published_count, skipped_count);
 }
 
 // ── Tracker thread ──────────────────────────────────────────
@@ -435,11 +649,18 @@ static void fusion_thread(drone::TripleBuffer<TrackedObjectList>&               
 // to a triple buffer for consumption by the fusion thread.
 // Stops when shutdown_phase >= 3.  Depth is a leaf node (writes to fusion's
 // TripleBuffer) — no downstream drain needed, just stop consuming frames.
+// @param projection_output_queue nullable — when PATH A is enabled
+//                 (Epic #520, Issue #608), mask_projection_thread needs its
+//                 own depth stream.  TripleBuffer is single-consumer, so we
+//                 fanout by writing the same depth map twice.  Same pattern
+//                 as inference_thread's projection_output_queue.
 static void depth_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& video_sub,
                          drone::TripleBuffer<drone::hal::DepthMap>&       output_queue,
                          std::atomic<int>& shutdown_phase, drone::hal::IDepthEstimator& estimator,
-                         int max_fps) {
-    DRONE_LOG_INFO("[Depth] Thread started — backend: {}, max_fps: {}", estimator.name(), max_fps);
+                         int                                        max_fps,
+                         drone::TripleBuffer<drone::hal::DepthMap>* projection_output_queue) {
+    DRONE_LOG_INFO("[Depth] Thread started — backend: {}, max_fps: {}{}", estimator.name(), max_fps,
+                   projection_output_queue ? " (PATH A fanout active)" : "");
 
     auto hb = drone::util::ScopedHeartbeat("depth", true);
 
@@ -472,6 +693,12 @@ static void depth_thread(drone::ipc::ISubscriber<drone::ipc::VideoFrame>& video_
             if (result.is_ok()) {
                 auto depth_map         = std::move(result).value();
                 depth_map.timestamp_ns = frame.timestamp_ns;
+                // PATH A fanout — mask_projection_thread needs its own depth
+                // stream.  Write the copy first so output_queue can move the
+                // original into its scratch slot without reallocation.
+                if (projection_output_queue) {
+                    projection_output_queue->write(depth_map);  // copy
+                }
                 output_queue.write(std::move(depth_map));
                 ++frame_count;
                 fail_count = 0;  // reset on success
@@ -682,6 +909,107 @@ int main(int argc, char* argv[]) {
                        "(perception.depth_estimator.enabled=false)");
     }
 
+    // ── PATH A — SAM + mask projection (Epic #520, Issue #608) ──
+    // Gated on perception.path_a.enabled (default false); scenario 33
+    // turns it on to exercise the mask-aware voxelisation path that
+    // classifies non-COCO obstacles (cubes, panels, pillars) as
+    // GEOMETRIC_OBSTACLE voxels for the P4 occupancy grid.
+    const bool path_a_enabled = ctx.cfg.get<bool>(drone::cfg_key::perception::path_a::ENABLED,
+                                                  false);
+    std::unique_ptr<drone::hal::IInferenceBackend>                          sam_backend;
+    std::unique_ptr<drone::hal::ISemanticProjector>                         semantic_projector;
+    std::unique_ptr<drone::perception::MaskDepthProjector>                  mask_projector;
+    std::unique_ptr<drone::ipc::IPublisher<drone::ipc::SemanticVoxelBatch>> voxel_pub;
+    if (path_a_enabled) {
+        try {
+            // Route through the HAL factory so `perception.path_a.sam.backend`
+            // in config actually selects the backend.  The factory reads
+            // `{section}.backend` under the SAM section and returns the matching
+            // IInferenceBackend ("sam_simulated", "simulated", or plugin-loaded).
+            // Previous code hardcoded SimulatedSAMBackend regardless of the
+            // config value — that's why `sam.backend = "yolov8_seg"` had no
+            // effect.  Factory still returns SimulatedSAMBackend when the value
+            // is "sam_simulated" (scenario 33's current setting).
+            const std::string sam_section =
+                std::string(drone::cfg_key::perception::path_a::SECTION) + ".sam";
+            sam_backend      = drone::hal::create_inference_backend(ctx.cfg, sam_section);
+            const std::string sam_model_path =
+                ctx.cfg.get<std::string>(drone::cfg_key::perception::path_a::SAM_MODEL_PATH, "");
+            const int sam_input_size =
+                ctx.cfg.get<int>(drone::cfg_key::perception::path_a::SAM_INPUT_SIZE, 512);
+            if (!sam_backend->init(sam_model_path, sam_input_size)) {
+                DRONE_LOG_ERROR("[PathA] SAM init() failed (backend={}, model='{}') — PATH A "
+                                "disabled",
+                                sam_backend->name(), sam_model_path);
+                sam_backend.reset();
+            }
+        } catch (const std::exception& e) {
+            DRONE_LOG_ERROR("[PathA] SAM construction failed: {} — PATH A disabled", e.what());
+            sam_backend.reset();
+        }
+
+        if (sam_backend) {
+            auto                         sp = std::make_unique<drone::hal::CpuSemanticProjector>();
+            drone::hal::CameraIntrinsics intr;
+            intr.fx = calib.camera_intrinsics(0, 0);
+            intr.fy = calib.camera_intrinsics(1, 1);
+            intr.cx = calib.camera_intrinsics(0, 2);
+            intr.cy = calib.camera_intrinsics(1, 2);
+            intr.width =
+                static_cast<uint32_t>(ctx.cfg.get<int>("video_capture.mission_cam.width", 1280));
+            intr.height =
+                static_cast<uint32_t>(ctx.cfg.get<int>("video_capture.mission_cam.height", 720));
+            if (!sp->init(intr)) {
+                DRONE_LOG_ERROR("[PathA] CpuSemanticProjector init failed (intrinsics={}x{}) — "
+                                "PATH A disabled",
+                                intr.width, intr.height);
+                sam_backend.reset();
+            } else {
+                semantic_projector = std::move(sp);
+                const float iou    = ctx.cfg.get<float>(
+                    drone::cfg_key::perception::path_a::MASK_CLASS_IOU_THRESHOLD, 0.5f);
+                mask_projector = std::make_unique<drone::perception::MaskDepthProjector>(
+                    *semantic_projector, iou);
+                voxel_pub = ctx.bus.advertise<drone::ipc::SemanticVoxelBatch>(
+                    drone::ipc::topics::SEMANTIC_VOXELS);
+                if (!voxel_pub->is_ready()) {
+                    DRONE_LOG_ERROR("[PathA] Failed to create publisher for {} — PATH A disabled",
+                                    drone::ipc::topics::SEMANTIC_VOXELS);
+                    sam_backend.reset();
+                    mask_projector.reset();
+                    semantic_projector.reset();
+                    voxel_pub.reset();
+                }
+            }
+        }
+
+        if (sam_backend && mask_projector && voxel_pub) {
+            DRONE_LOG_INFO("[PathA] Enabled — SAM: {}, projector: {}, publish: {}",
+                           sam_backend->name(), semantic_projector->name(),
+                           drone::ipc::topics::SEMANTIC_VOXELS);
+        } else {
+            DRONE_LOG_WARN(
+                "[PathA] Requested via config but initialisation failed — running "
+                "without PATH A (scenario behaviour degrades to PATH B / detector only)");
+        }
+    } else {
+        DRONE_LOG_INFO("[Perception] PATH A disabled (perception.path_a.enabled=false)");
+    }
+    // PATH A requires the depth thread — MaskDepthProjector has nothing to
+    // project without depth, so mask_projection_thread would skip forever.
+    // Refuse to enable if depth is off rather than let the scenario run with
+    // a silently-inert pipeline (same class of failure as #605).
+    if (path_a_enabled && !depth_enabled) {
+        DRONE_LOG_ERROR("[PathA] perception.path_a.enabled=true requires "
+                        "perception.depth_estimator.enabled=true — PATH A disabled");
+        sam_backend.reset();
+        mask_projector.reset();
+        semantic_projector.reset();
+        voxel_pub.reset();
+    }
+    const bool path_a_active = path_a_enabled && depth_enabled && sam_backend && mask_projector &&
+                               voxel_pub;
+
     // ── Drain timeout (Issue #446) — configurable, default 500ms ──
     const int drain_timeout_ms =
         std::clamp(ctx.cfg.get<int>(drone::cfg_key::perception::DRAIN_TIMEOUT_MS, 500), 50, 5000);
@@ -691,6 +1019,11 @@ int main(int argc, char* argv[]) {
     drone::TripleBuffer<TrackedObjectList> tracker_to_fusion;
     // Depth map triple buffer — only used when depth estimator is enabled
     drone::TripleBuffer<drone::hal::DepthMap> depth_to_fusion;
+    // PATH A fanout — inference + depth both fanout an extra copy so the
+    // projection thread has its own single-consumer slot on each.
+    drone::TripleBuffer<Detection2DList>      inference_to_projection;
+    drone::TripleBuffer<Masks2DList>          sam_to_projection;
+    drone::TripleBuffer<drone::hal::DepthMap> depth_to_projection;
 
     // ── Optional benchmark profiler (Epic #523, Issue #571) ──────────
     // Opt-in via config (benchmark.profiler.enabled). Disabled by default
@@ -713,7 +1046,8 @@ int main(int argc, char* argv[]) {
 
     // ── Launch threads ──────────────────────────────────────
     std::thread t_inference(inference_thread, std::ref(*video_sub), std::ref(inference_to_tracker),
-                            std::ref(g_shutdown_phase), std::ref(*detector), profiler_ptr);
+                            std::ref(g_shutdown_phase), std::ref(*detector), profiler_ptr,
+                            path_a_active ? &inference_to_projection : nullptr);
 
     std::thread t_tracker(tracker_thread, std::ref(inference_to_tracker),
                           std::ref(tracker_to_fusion), std::ref(g_shutdown_phase),
@@ -745,8 +1079,8 @@ int main(int argc, char* argv[]) {
         const int depth_max_fps = std::clamp(
             ctx.cfg.get<int>(drone::cfg_key::perception::depth_estimator::MAX_FPS, 15), 0, 60);
         t_depth = std::thread(depth_thread, std::ref(*depth_video_sub), std::ref(depth_to_fusion),
-                              std::ref(g_shutdown_phase), std::ref(*depth_estimator),
-                              depth_max_fps);
+                              std::ref(g_shutdown_phase), std::ref(*depth_estimator), depth_max_fps,
+                              path_a_active ? &depth_to_projection : nullptr);
     }
 
     // Launch radar read thread if HAL is active and publisher is ready
@@ -756,6 +1090,24 @@ int main(int argc, char* argv[]) {
                               std::ref(g_shutdown_phase), radar_update_rate_hz);
     } else if (radar) {
         DRONE_LOG_WARN("[Radar] HAL active but publisher not ready — radar read thread disabled");
+    }
+
+    // Launch PATH A threads (Epic #520, Issue #608) if enabled + initialised.
+    // Each needs its own video subscriber (Zenoh SHM topology — see depth_video_sub pattern).
+    std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::VideoFrame>> sam_video_sub;
+    std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::Pose>>       pathA_pose_sub;
+    std::thread                                                      t_sam;
+    std::thread                                                      t_mask_proj;
+    if (path_a_active) {
+        sam_video_sub =
+            ctx.bus.subscribe<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
+        pathA_pose_sub = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+        t_sam       = std::thread(sam_thread, std::ref(*sam_video_sub), std::ref(sam_to_projection),
+                                  std::ref(g_shutdown_phase), std::ref(*sam_backend));
+        t_mask_proj = std::thread(mask_projection_thread, std::ref(sam_to_projection),
+                                  std::ref(inference_to_projection), std::ref(depth_to_projection),
+                                  std::ref(*pathA_pose_sub), std::ref(*voxel_pub),
+                                  std::ref(g_shutdown_phase), std::ref(*mask_projector));
     }
 
     // ── Thread watchdog + health publisher ──────────────────
@@ -789,15 +1141,17 @@ int main(int argc, char* argv[]) {
     // window.
     DRONE_LOG_INFO("Shutting down — phased drain (timeout={}ms per stage)...", drain_timeout_ms);
 
-    // Phase 1: stop inference (pipeline source)
+    // Phase 1: stop inference + SAM (pipeline sources)
     g_shutdown_phase.store(1, std::memory_order_release);
-    DRONE_LOG_INFO("[Shutdown] Phase 1 — stopping inference");
+    DRONE_LOG_INFO("[Shutdown] Phase 1 — stopping inference (+ SAM if active)");
     t_inference.join();
+    if (t_sam.joinable()) t_sam.join();
 
-    // Phase 2: stop tracker (drains inference→tracker buffer)
+    // Phase 2: stop tracker + mask projection (drain upstream buffers)
     g_shutdown_phase.store(2, std::memory_order_release);
-    DRONE_LOG_INFO("[Shutdown] Phase 2 — stopping tracker (draining)");
+    DRONE_LOG_INFO("[Shutdown] Phase 2 — stopping tracker (+ mask projection if active)");
     t_tracker.join();
+    if (t_mask_proj.joinable()) t_mask_proj.join();
 
     // Phase 3: stop fusion, depth, radar (fusion drains tracker→fusion buffer)
     g_shutdown_phase.store(3, std::memory_order_release);

--- a/process4_mission_planner/include/planner/grid_planner_base.h
+++ b/process4_mission_planner/include/planner/grid_planner_base.h
@@ -79,6 +79,14 @@ public:
     /// Pre-load a static obstacle from the HD map (scenario config).
     virtual void add_static_obstacle(float wx, float wy, float radius_m, float height_m) = 0;
 
+    /// Insert world-frame voxels from the PATH A semantic-voxels pipeline
+    /// (Epic #520 / Issue #608).  See `OccupancyGrid3D::insert_voxels` for
+    /// semantics; this is the IGridPlanner pass-through so the P4 voxel
+    /// subscriber thread doesn't need a downcast to GridPlannerBase.
+    virtual OccupancyGrid3D::VoxelInsertStats insert_voxels(const drone::ipc::SemanticVoxel* voxels,
+                                                            uint32_t n, float clamp_m,
+                                                            float min_confidence) = 0;
+
     /// True if the last planning cycle could not find a search path
     /// and fell back to a direct line toward the target.
     [[nodiscard]] virtual bool using_direct_fallback() const = 0;
@@ -131,6 +139,18 @@ public:
     void add_static_obstacle(float wx, float wy, float radius_m, float height_m) override {
         grid_.add_static_obstacle(wx, wy, radius_m, height_m);
         snap_valid_ = false;
+    }
+
+    OccupancyGrid3D::VoxelInsertStats insert_voxels(const drone::ipc::SemanticVoxel* voxels,
+                                                    uint32_t n, float clamp_m,
+                                                    float min_confidence) override {
+        auto stats = grid_.insert_voxels(voxels, n, clamp_m, min_confidence);
+        // If any voxel landed, invalidate the cached path so D*Lite/A* replan
+        // against the updated grid on the next tick.
+        if (stats.inserted > 0) {
+            snap_valid_ = false;
+        }
+        return stats;
     }
 
     [[nodiscard]] bool using_direct_fallback() const override { return direct_fallback_; }

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -175,6 +175,107 @@ public:
                        wx, wy, radius_m, height_m, added, static_occupied_.size());
     }
 
+    /// Insert world-frame voxels from the PATH A pipeline (Epic #520 / Issue #608).
+    ///
+    /// The voxels arrive on `/semantic_voxels`, already confidence-scored and
+    /// mask-gated by MaskDepthProjector on the P2 side.  That upstream work
+    /// means we intentionally **bypass** the `promotion_hits` filter used in
+    /// `update_from_objects()` — those hits guard against ghost cells from
+    /// the detector/depth pipeline's false positives on ground texture, which
+    /// the mask-aware path has already filtered out.
+    ///
+    /// Position clamp: the final safety guard before writing to the grid.
+    /// A malformed sender (or a numerical edge case in MaskDepthProjector)
+    /// could emit positions outside the world extent, which would overflow
+    /// grid indexing.  Any voxel whose |position| exceeds `clamp_m` on any
+    /// axis is dropped.  Addresses the security P3 deferred from PR #609.
+    ///
+    /// Cells written here land in the static layer but are NOT recorded in
+    /// `hd_map_cells_` — an upstream pipeline regression (e.g. a future SAM
+    /// misfire) can still be cleared by `clear_static()`.
+    ///
+    /// @return `{inserted, clamped_dropped, low_confidence_dropped, out_of_bounds}`
+    struct VoxelInsertStats {
+        size_t inserted               = 0;
+        size_t clamped_dropped        = 0;
+        size_t low_confidence_dropped = 0;
+        size_t out_of_bounds          = 0;
+    };
+    VoxelInsertStats insert_voxels(const drone::ipc::SemanticVoxel* voxels, uint32_t n,
+                                   float clamp_m, float min_confidence) {
+        VoxelInsertStats s;
+        if (voxels == nullptr || n == 0) return s;
+        const float clamp = std::max(0.0f, clamp_m);
+
+        // Each voxel carries a point sample of an obstacle surface.  Without
+        // inflation a 5 m cube hit by 4 depth samples produces only 2-3
+        // unique grid cells and the avoider's repulsive field has gaps big
+        // enough for the drone to squeeze through (observed during scenario
+        // 33 testing).  Inflate symmetrically in 3D — voxels are point
+        // samples with no height prior.  Radius 1 cell → 3×3×3-minus-corners
+        // neighbourhood (~7 cells per voxel) keeps the grid bounded while
+        // still filling the gap between scattered mask probes.
+        constexpr int kInflate  = 1;
+        constexpr int kInflate2 = kInflate * kInflate;
+
+        // Ground-plane reject threshold.  At 2 m grid resolution, voxels
+        // with world z < 0.3 m are ground textures / shadows / floor patches
+        // that EdgeContourSAM latches onto — promoting them to static would
+        // make every patch of grass an obstacle.  Scenario drone cruise
+        // altitude is 5 m, so no real navigation-relevant obstacle lives
+        // below 0.3 m from this camera's vantage point.
+        constexpr float kMinObstacleZ = 0.3f;
+
+        for (uint32_t i = 0; i < n; ++i) {
+            const auto& v = voxels[i];
+            // Position clamp (PR #609 review P3 deferred to consumer boundary).
+            // Reject voxels whose |x|, |y|, or |z| exceeds the world extent.
+            if (clamp > 0.0f && (std::abs(v.position_x) > clamp || std::abs(v.position_y) > clamp ||
+                                 std::abs(v.position_z) > clamp)) {
+                ++s.clamped_dropped;
+                continue;
+            }
+            if (v.confidence < min_confidence) {
+                ++s.low_confidence_dropped;
+                continue;
+            }
+            // Ground-plane filter — count under clamped_dropped to keep the
+            // stats tuple compact; the diagnostic log groups all boundary
+            // drops together anyway.
+            if (v.position_z < kMinObstacleZ) {
+                ++s.clamped_dropped;
+                continue;
+            }
+            const GridCell center = world_to_grid(v.position_x, v.position_y, v.position_z);
+            if (!in_bounds(center)) {
+                ++s.out_of_bounds;
+                continue;
+            }
+            // Small 3D inflation — every cell within `kInflate` of the sample.
+            // Most neighbouring inserts collide with cells already present
+            // from nearby voxels, so this is idempotent on repeated observations.
+            for (int dz = -kInflate; dz <= kInflate; ++dz) {
+                for (int dy = -kInflate; dy <= kInflate; ++dy) {
+                    for (int dx = -kInflate; dx <= kInflate; ++dx) {
+                        if (dx * dx + dy * dy + dz * dz > kInflate2) continue;
+                        const GridCell c{center.x + dx, center.y + dy, center.z + dz};
+                        if (!in_bounds(c)) continue;
+                        auto [it, inserted] = static_occupied_.insert(c);
+                        if (inserted) {
+                            changed_cells_.push_back({c, true});
+                            // Do NOT record in hd_map_cells_ — these are PATH A
+                            // voxels, clearable by clear_static() if the
+                            // pipeline misbehaves.
+                            ++s.inserted;
+                            ++promoted_count_;
+                        }
+                    }
+                }
+            }
+        }
+        return s;
+    }
+
     /// Insert obstacles from a detected object list.
     /// Updates timestamps for observed cells; stale cells expire after TTL.
     void update_from_objects(const drone::ipc::DetectedObjectList& objects,

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -365,6 +365,42 @@ int main(int argc, char* argv[]) {
     // ── Create fault manager (config-driven thresholds) ────
     FaultManager fault_mgr(ctx.cfg);
 
+    // ── PATH A voxel subscriber (Epic #520 / Issue #608) ──
+    // Gated on mission_planner.occupancy_grid.voxel_input.enabled; polled
+    // each planning tick alongside the detected-objects stream.  Stays on
+    // the main thread so P4's "single-threaded planner" invariant holds.
+    const bool voxel_input_enabled = ctx.cfg.get<bool>(
+        drone::cfg_key::mission_planner::occupancy_grid::VOXEL_INPUT_ENABLED, false);
+    const float voxel_input_clamp_m = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::occupancy_grid::VOXEL_INPUT_POSITION_CLAMP_M, 1000.0f);
+    const float voxel_input_min_confidence = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::occupancy_grid::VOXEL_INPUT_MIN_CONFIDENCE, 0.3f);
+    std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::SemanticVoxelBatch>> voxel_sub;
+    if (voxel_input_enabled) {
+        if (grid_planner == nullptr) {
+            DRONE_LOG_ERROR(
+                "[VoxelSub] voxel_input.enabled=true but path planner is not grid-based "
+                "— voxel input disabled");
+        } else {
+            voxel_sub = ctx.bus.subscribe<drone::ipc::SemanticVoxelBatch>(
+                drone::ipc::topics::SEMANTIC_VOXELS);
+            // Suppress detector-path static promotion while voxel input is active.
+            // Otherwise `update_from_objects()` + `color_contour + depth` flood
+            // the static layer with ghost cells faster than the mask-aware PATH A
+            // voxels can make an impact on the repulsive field (uncovered during
+            // scenario-33 end-to-end testing — 1286 promoted cells, mostly false
+            // positives, dominated the avoider over 5 real wall cells).  The
+            // dynamic TTL layer keeps populating, so reactive avoidance of
+            // moving objects still works.
+            grid_planner->set_promotion_paused(true);
+            DRONE_LOG_INFO("[VoxelSub] Subscribed to {} (clamp={:.0f} m, min_conf={:.2f}); "
+                           "detector-path static promotion PAUSED — PATH A is sole static-cell "
+                           "source while voxel_input is enabled",
+                           drone::ipc::topics::SEMANTIC_VOXELS, voxel_input_clamp_m,
+                           voxel_input_min_confidence);
+        }
+    }
+
     DRONE_LOG_INFO("Mission Planner READY — {} waypoints loaded", fsm.total_waypoints());
     drone::systemd::notify_ready();
 
@@ -418,6 +454,40 @@ int main(int argc, char* argv[]) {
 
         drone::ipc::DetectedObjectList objects{};
         obj_sub->receive(objects);
+
+        // ── 1b. Drain PATH A voxel batches (Epic #520 / Issue #608) ──
+        // Polled on the planner thread to preserve P4's single-threaded
+        // invariant.  Each batch is validated, clamped, and inserted into
+        // the occupancy grid's static layer.  Non-empty inserts invalidate
+        // the cached path via the GridPlannerBase::insert_voxels hook.
+        if (voxel_sub && grid_planner) {
+            uint32_t batches_drained = 0;
+            uint32_t inserted_total  = 0;
+            uint32_t dropped_total   = 0;
+            for (;;) {
+                drone::ipc::SemanticVoxelBatch batch{};
+                if (!voxel_sub->receive(batch)) break;
+                if (!batch.validate()) {
+                    DRONE_LOG_WARN("[VoxelSub] rejected malformed batch (num_voxels={})",
+                                   batch.num_voxels);
+                    continue;
+                }
+                auto stats = grid_planner->insert_voxels(batch.voxels, batch.num_voxels,
+                                                         voxel_input_clamp_m,
+                                                         voxel_input_min_confidence);
+                inserted_total += static_cast<uint32_t>(stats.inserted);
+                dropped_total += static_cast<uint32_t>(
+                    stats.clamped_dropped + stats.low_confidence_dropped + stats.out_of_bounds);
+                ++batches_drained;
+                // Hard cap on drain iterations per tick — a runaway publisher
+                // must not starve the planning loop.
+                if (batches_drained >= 10) break;
+            }
+            if (batches_drained > 0) {
+                DRONE_LOG_INFO("[VoxelSub] tick={} batches={} inserted={} dropped={}", loop_tick,
+                               batches_drained, inserted_total, dropped_total);
+            }
+        }
 
         drone::ipc::FCState fc_state{};
         if (fc_state_sub->is_connected()) {


### PR DESCRIPTION
## Summary

PR 2 of 2 for [#608](https://github.com/nmohamaya/companion_software_stack/issues/608). [PR #609](https://github.com/nmohamaya/companion_software_stack/pull/609) landed the wire type; this PR wires every producer and consumer:

- **P2**: new `sam_thread` + new `mask_projection_thread` with explicit fan-out from inference and depth, config-gated on `perception.path_a.enabled`, factory-routed SAM backend selection.
- **P4**: voxel subscriber polled in the main planning loop (single-threaded invariant preserved), `OccupancyGrid3D::insert_voxels()` with position clamp + ground-plane reject + 3D inflation, `set_promotion_paused(true)` coexistence with the detector path.
- **New SAM backends**:
  - `EdgeContourSAMBackend` — OpenCV Canny+contours algorithmic fallback
  - `FastSamInferenceBackend` — **real** class-agnostic SAM via FastSAM ONNX (what #555 scoped and never shipped)
- **CpuSemanticProjector fixes**: mask-convention auto-detect (full-image vs bbox-local), 20 m max-depth reject.

## Scope

| Area | Changes |
|---|---|
| `common/hal/` | `edge_contour_sam_backend.h` (+), `fastsam_inference_backend.h` (+), `cpu_semantic_projector.h` (mask convention + depth filter), `hal_factory.h` (`edge_contour_sam` + `fastsam` routing) |
| `common/util/` | `config_keys.h` — `occupancy_grid.voxel_input.*` keys |
| `process2_perception/` | `main.cpp` — SAM + mask-projection threads, fan-out from inference/depth, PATH A gate; `types.h` — `Masks2DList` |
| `process4_mission_planner/` | `main.cpp` — voxel subscriber + `set_promotion_paused`; `grid_planner_base.h` — `insert_voxels` interface; `occupancy_grid_3d.h` — `insert_voxels` with clamp + ground filter + inflation |
| `config/` | `default.json` — voxel_input defaults (disabled); `scenarios/33_non_coco_obstacles.json` — YOLOv8 detector + FastSAM backend + real `pass_criteria` |
| `models/` | `download_fastsam.sh` — Ultralytics-based ONNX export + onnxsim cleanup |
| `docs/tracking/` | `IMPROVEMENTS.md` — deferred \"extract PATH A to its own process\" design-call |

**Totals**: +1315 / −28 across 14 files, 3 new. Build: zero warnings. Format: CI-scope clean. Existing tests: all pass (14 semantic_projector + 29 obstacle_avoider_3d + 86 grid/planner, plus ~1700 others).

## Why this PR is so big

Splitting into smaller PRs was attempted during the work but each piece hard-requires its counterparts for any runtime behaviour to be observable: the SAM thread produces nothing without a publisher; the publisher means nothing without a subscriber; the subscriber means nothing without the grid write. The eight in-PR fix iterations in the commit history (factory routing → promotion_paused → detector switch → EdgeContourSAM → mask-convention fix → inflation → max-depth filter → ground-plane reject → FastSAM) were discovered live during scenario-33 Cosys runs — each one exposed the next.

## Residual known-issue (flagged for holistic follow-up)

Scenario 33 with FastSAM + all filters **still collides with a Blocks UE5 `TemplateCube_Rounded_9`**. The pipeline is visibly alive — PATH A threads running, ~30-60 voxels/batch, grid populating (not saturating anymore), `set_promotion_paused` preventing ghost-cell flood — but the drone's trajectory doesn't detour around the cube. This points at a deeper systemic issue further downstream (camera-pose transform, depth calibration, D*Lite replan timing, coordinate-frame mismatch, or something else) that more pipeline tuning won't fix.

**Explicitly NOT the goal of this PR** to chase that further. The next step is a holistic review of the whole pipeline — filed as a follow-up.

## Test plan

- [x] `bash deploy/build.sh` — zero warnings, Release
- [x] `ctest --test-dir build -j$(nproc)` — 1849/1849 pass
- [x] `clang-format-18` clean on `.h` + `.cpp` scope
- [x] Scenario 33 confirms plumbing active: `[PathA] Enabled — SAM: FastSamInferenceBackend`, `[SAM] Thread started`, `[MaskProj] Published N batches — N voxels`, `[VoxelSub] inserted=N dropped=N`, `[Grid] promoted=N`
- [ ] **Scenario 33 collision-free pass** — deferred to follow-up pipeline review

## Related

- Issue: [#608](https://github.com/nmohamaya/companion_software_stack/issues/608)
- Parent epic: [#520](https://github.com/nmohamaya/companion_software_stack/issues/520)
- Prior PR (wire type): [#609](https://github.com/nmohamaya/companion_software_stack/pull/609) (merged)
- Follow-ups: holistic pipeline review (to be filed), scenario-runner collision telemetry [#607](https://github.com/nmohamaya/companion_software_stack/issues/607), missing-model preflight [#605](https://github.com/nmohamaya/companion_software_stack/issues/605)

🤖 Generated with [Claude Code](https://claude.com/claude-code)