### PR TITLE
feat(#612,#613): PATH A diagnostic infra + 8 perception fixes + Cosys runner/deploy UX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ add_subdirectory(tools/fault_injector)
 add_subdirectory(tools/flight_replay)
 if(COSYS_AIRSIM_FOUND)
     add_subdirectory(tools/cosys_populate_scene)
+    add_subdirectory(tools/cosys_telemetry_poller)
 endif()
 
 # ── Tests ────────────────────────────────────────────────────

--- a/common/hal/include/hal/fastsam_inference_backend.h
+++ b/common/hal/include/hal/fastsam_inference_backend.h
@@ -257,7 +257,12 @@ public:
 private:
     static constexpr int kMinInputSize = 128;
     static constexpr int kMaxInputSize = 2048;
-    static constexpr int kMaxProposals = 16384;
+    // FastSAM at 1024×1024 input emits 21504 proposals from the anchor-free
+    // head (strides 8/16/32: 128² + 64² + 32² = 21504).  Larger inputs scale
+    // roughly ∝ h·w, so give generous headroom without becoming unbounded —
+    // a malformed model should still be caught.  YOLOv8-seg at 640 emits
+    // 8400, so this cap covers both pathways.
+    static constexpr int kMaxProposals = 65536;
     static constexpr int kNumClasses   = 1;  // FastSAM is class-agnostic
 
     [[nodiscard]] bool load_model() {

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -179,6 +179,15 @@ inline constexpr const char* SAM_INPUT_SIZE = "perception.path_a.sam.input_size"
 inline constexpr const char* SAM_NUM_MASKS  = "perception.path_a.sam.num_masks";
 inline constexpr const char* MASK_CLASS_IOU_THRESHOLD =
     "perception.path_a.mask_class_iou_threshold";
+
+// Diagnostic voxel-position trace (Issue #612). When enabled, the P2
+// mask_projection_thread writes one JSON line per published batch to
+// TRACE_PATH, carrying pose + detector bboxes + SAM masks + per-voxel
+// image-origin + world-frame position. Off by default — production builds
+// pay zero cost. Consumed by tools/plot_voxel_trace.py to visualise where
+// voxels actually land vs scene-object ground truth.
+inline constexpr const char* DIAG_TRACE_VOXELS = "perception.path_a.diag.trace_voxels";
+inline constexpr const char* DIAG_TRACE_PATH   = "perception.path_a.diag.trace_path";
 }  // namespace path_a
 
 // Shutdown drain behaviour (Issue #446)
@@ -265,6 +274,11 @@ inline constexpr const char* Z_BAND_CELLS       = "mission_planner.path_planner.
 inline constexpr const char* LOOK_AHEAD_M       = "mission_planner.path_planner.look_ahead_m";
 inline constexpr const char* YAW_TOWARDS_TRAVEL = "mission_planner.path_planner.yaw_towards_travel";
 inline constexpr const char* YAW_SMOOTHING_RATE = "mission_planner.path_planner.yaw_smoothing_rate";
+// Follow velocity direction instead of bee-line-to-waypoint (Issue #612).
+// Lets PATH A voxelise the obstacle's far face during a detour by pointing
+// the camera at the actual flight direction.
+inline constexpr const char* YAW_TOWARDS_VELOCITY =
+    "mission_planner.path_planner.yaw_towards_velocity";
 inline constexpr const char* SNAP_APPROACH_BIAS = "mission_planner.path_planner.snap_approach_bias";
 }  // namespace path_planner
 

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -279,6 +279,10 @@ inline constexpr const char* YAW_SMOOTHING_RATE = "mission_planner.path_planner.
 // the camera at the actual flight direction.
 inline constexpr const char* YAW_TOWARDS_VELOCITY =
     "mission_planner.path_planner.yaw_towards_velocity";
+// Minimum |v| (m/s) below which yaw_towards_velocity falls back to
+// bee-line-to-goal.  Prevents yaw jitter when hovering (Issue #612).
+inline constexpr const char* YAW_VELOCITY_THRESHOLD_MPS =
+    "mission_planner.path_planner.yaw_velocity_threshold_mps";
 inline constexpr const char* SNAP_APPROACH_BIAS = "mission_planner.path_planner.snap_approach_bias";
 }  // namespace path_planner
 

--- a/common/util/include/util/path_a_trace.h
+++ b/common/util/include/util/path_a_trace.h
@@ -23,6 +23,21 @@
 // `record_batch`).  The constructor opens the file once; writes are
 // buffered by `std::ofstream`.  No locking needed.
 //
+// Path confinement: `trace_path` is config-controlled; the constructor
+// rejects absolute paths outside the project root and rejects any path
+// that, after lexical normalisation, escapes the project tree (`..`
+// components surviving normalisation).  Scenario runners rewrite this to
+// `<scenario_log_dir>/path_a_voxel_trace.jsonl` before process launch.
+//
+// Flight-critical constraint (DR-026, docs/guides/DESIGN_RATIONALE.md):
+// `record_batch()` performs `std::ofstream` I/O from the caller thread
+// (`mask_projection_thread`).  The CPP_PATTERNS_GUIDE observability rule
+// prohibits mutex-backed observability on flight-critical threads; the
+// exception documented in DR-026 allows this diagnostic writer because
+// (a) it is opt-in with default `trace_voxels=false`, (b) it is never
+// enabled in production configs, and (c) the `enabled_` branch short-
+// circuits to a single `bool` load in the hot path.
+//
 // File format: JSON lines (RFC 7464 loose interpretation) — each line is an
 // independent JSON object, parseable with one `json::parse()` per line.
 // Python plotter example:
@@ -53,10 +68,19 @@ namespace drone::util {
 
 class PathATrace {
 public:
-    /// Constructor.  If `enabled` is false or the path cannot be opened, the
-    /// writer is inert — `record_batch()` becomes a no-op.
+    /// Constructor.  If `enabled` is false, the path cannot be opened, or the
+    /// path fails confinement (see `is_path_confined`), the writer is inert —
+    /// `record_batch()` becomes a no-op.
     PathATrace(bool enabled, const std::string& path) : enabled_(enabled), path_(path) {
         if (!enabled_) return;
+        if (!is_path_confined(path)) {
+            DRONE_LOG_ERROR(
+                "[PathATrace] Refusing trace path '{}' — must stay under drone_logs/ or a "
+                "project-root-relative subdirectory; no absolute or ../-escaping paths",
+                path);
+            enabled_ = false;
+            return;
+        }
         try {
             std::filesystem::create_directories(std::filesystem::path(path).parent_path());
         } catch (const std::exception& e) {
@@ -69,6 +93,26 @@ public:
             return;
         }
         DRONE_LOG_INFO("[PathATrace] Writing voxel trace to '{}'", path);
+    }
+
+    /// Confine trace paths to the project tree.  Accepts:
+    ///   - relative paths rooted under `drone_logs/` (the scenario runners
+    ///     rewrite trace_path to `<scenario_log_dir>/path_a_voxel_trace.jsonl`
+    ///     before launching the process, so this is the normal case).
+    ///   - any relative path whose lexically-normalised form does not start
+    ///     with `..` (covers CI / alternative log dirs).
+    /// Rejects:
+    ///   - absolute paths (e.g. `/etc/cron.d/...`).
+    ///   - relative paths that normalise to an escape (`../../etc/foo`).
+    static bool is_path_confined(const std::string& path) {
+        if (path.empty()) return false;
+        std::filesystem::path p(path);
+        if (p.is_absolute()) return false;
+        const auto normalised = p.lexically_normal();
+        const auto first      = normalised.begin();
+        if (first == normalised.end()) return false;
+        if (*first == "..") return false;
+        return true;
     }
 
     ~PathATrace() {
@@ -84,7 +128,13 @@ public:
 
     [[nodiscard]] bool enabled() const { return enabled_; }
 
-    /// Record one published batch.  Expects:
+    /// Record one published batch.
+    ///
+    /// **Thread-safety:** NOT thread-safe.  Must be called from a single thread
+    /// only — the thread that owns the `PathATrace` instance.  The class holds
+    /// no mutex; concurrent callers would race on `out_` and `lines_written_`.
+    ///
+    /// Expects:
     ///   @param t_ns    Batch emission time (source-frame timestamp)
     ///   @param seq     Source video-frame sequence number
     ///   @param pose    SLAM pose used for this projection
@@ -128,14 +178,22 @@ public:
                                        static_cast<int>(v.semantic_label), v.confidence}));
         }
 
-        // Single dump() → one line → one write → no interleaving risk.
+        // Single dump() → one line → one write.  nlohmann::json has no stream-
+        // sink overload (only indent/width params), so the intermediate
+        // std::string is unavoidable.  Acceptable because `enabled_` defaults
+        // to false in production (see DR-033).
         out_ << j.dump() << '\n';
         ++lines_written_;
-        // Flush every 50 lines so in-progress analyses can tail the file.
-        if ((lines_written_ % 50) == 0) out_.flush();
+        if ((lines_written_ % kFlushIntervalLines) == 0) out_.flush();
     }
 
 private:
+    // Flush every N lines so in-progress analyses can `tail -f` the file.
+    // At 30 Hz, N=50 yields ~1.7 s tail latency — matches the
+    // cosys_telemetry_poller's 2 s flush cadence (diagnostic-only paths
+    // should feel similar under the developer's terminal).
+    static constexpr uint64_t kFlushIntervalLines = 50;
+
     bool          enabled_{false};
     std::string   path_;
     std::ofstream out_;

--- a/common/util/include/util/path_a_trace.h
+++ b/common/util/include/util/path_a_trace.h
@@ -1,0 +1,145 @@
+// common/util/include/util/path_a_trace.h
+//
+// Diagnostic trace writer for the PATH A mask-projection pipeline
+// (Epic #520, Issue #612).  Writes one JSONL line per published voxel
+// batch so `tools/plot_voxel_trace.py` can visualise where voxels
+// actually land in 3D versus the scene's ground-truth object positions.
+//
+// Line schema (compact for grep/plot):
+//   {
+//     "t_ns":     uint64,                      // batch emission time
+//     "seq":      uint64,                      // source video-frame sequence
+//     "pose_t":   [x, y, z],                   // SLAM translation (world-frame, m)
+//     "pose_q":   [w, x, y, z],                // SLAM quaternion
+//     "det_bb":   [[x, y, w, h, class, conf], ...],   // detector bboxes (px)
+//     "sam_bb":   [[x, y, w, h, conf], ...],          // SAM mask bboxes (px)
+//     "voxels":   [[wx, wy, wz, label, conf], ...]    // world-frame voxel positions
+//   }
+//
+// Enabled via `perception.path_a.diag.trace_voxels`.  Default off — production
+// builds pay zero cost (constructor returns with `enabled_=false`).
+//
+// Thread-safety: single-writer (only `mask_projection_thread` calls
+// `record_batch`).  The constructor opens the file once; writes are
+// buffered by `std::ofstream`.  No locking needed.
+//
+// File format: JSON lines (RFC 7464 loose interpretation) — each line is an
+// independent JSON object, parseable with one `json::parse()` per line.
+// Python plotter example:
+//     with open(path) as f:
+//         for line in f:
+//             rec = json.loads(line)
+//             ...
+//
+// Run-size estimate: ~0.5-2 KB per batch at 30 Hz = ~50 KB/s = ~3 MB/min.
+// Truncated automatically on open (one trace per run).
+
+#pragma once
+
+#include "hal/iinference_backend.h"
+#include "hal/isemantic_projector.h"
+#include "ipc/ipc_types.h"
+#include "util/ilogger.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace drone::util {
+
+class PathATrace {
+public:
+    /// Constructor.  If `enabled` is false or the path cannot be opened, the
+    /// writer is inert — `record_batch()` becomes a no-op.
+    PathATrace(bool enabled, const std::string& path) : enabled_(enabled), path_(path) {
+        if (!enabled_) return;
+        try {
+            std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+        } catch (const std::exception& e) {
+            DRONE_LOG_WARN("[PathATrace] Could not create parent dir for '{}': {}", path, e.what());
+        }
+        out_.open(path, std::ios::out | std::ios::trunc);
+        if (!out_.is_open()) {
+            DRONE_LOG_ERROR("[PathATrace] Cannot open '{}' for write — trace disabled", path);
+            enabled_ = false;
+            return;
+        }
+        DRONE_LOG_INFO("[PathATrace] Writing voxel trace to '{}'", path);
+    }
+
+    ~PathATrace() {
+        if (out_.is_open()) {
+            out_.flush();
+            out_.close();
+            DRONE_LOG_INFO("[PathATrace] Closed '{}' — {} lines written", path_, lines_written_);
+        }
+    }
+
+    PathATrace(const PathATrace&)            = delete;
+    PathATrace& operator=(const PathATrace&) = delete;
+
+    [[nodiscard]] bool enabled() const { return enabled_; }
+
+    /// Record one published batch.  Expects:
+    ///   @param t_ns    Batch emission time (source-frame timestamp)
+    ///   @param seq     Source video-frame sequence number
+    ///   @param pose    SLAM pose used for this projection
+    ///   @param dets    Detector bboxes fed into MaskDepthProjector
+    ///   @param masks   SAM mask bboxes fed into MaskDepthProjector
+    ///   @param voxels  Resulting world-frame VoxelUpdates (pre-conversion-to-wire)
+    void record_batch(uint64_t t_ns, uint64_t seq, const drone::ipc::Pose& pose,
+                      const std::vector<drone::hal::InferenceDetection>& dets,
+                      const std::vector<drone::hal::InferenceDetection>& masks,
+                      const std::vector<drone::hal::VoxelUpdate>&        voxels) {
+        if (!enabled_ || !out_.is_open()) return;
+
+        // Build compact JSON per line.  Arrays-of-arrays (not arrays-of-
+        // objects) keep each record small — the plotter knows the schema.
+        nlohmann::json j;
+        j["t_ns"]   = t_ns;
+        j["seq"]    = seq;
+        j["pose_t"] = {pose.translation[0], pose.translation[1], pose.translation[2]};
+        j["pose_q"] = {pose.quaternion[0], pose.quaternion[1], pose.quaternion[2],
+                       pose.quaternion[3]};
+
+        auto& det_arr = j["det_bb"] = nlohmann::json::array();
+        det_arr.get_ref<nlohmann::json::array_t&>().reserve(dets.size());
+        for (const auto& d : dets) {
+            det_arr.push_back(nlohmann::json::array(
+                {d.bbox.x, d.bbox.y, d.bbox.w, d.bbox.h, d.class_id, d.confidence}));
+        }
+
+        auto& sam_arr = j["sam_bb"] = nlohmann::json::array();
+        sam_arr.get_ref<nlohmann::json::array_t&>().reserve(masks.size());
+        for (const auto& m : masks) {
+            sam_arr.push_back(
+                nlohmann::json::array({m.bbox.x, m.bbox.y, m.bbox.w, m.bbox.h, m.confidence}));
+        }
+
+        auto& vox_arr = j["voxels"] = nlohmann::json::array();
+        vox_arr.get_ref<nlohmann::json::array_t&>().reserve(voxels.size());
+        for (const auto& v : voxels) {
+            vox_arr.push_back(
+                nlohmann::json::array({v.position_m.x(), v.position_m.y(), v.position_m.z(),
+                                       static_cast<int>(v.semantic_label), v.confidence}));
+        }
+
+        // Single dump() → one line → one write → no interleaving risk.
+        out_ << j.dump() << '\n';
+        ++lines_written_;
+        // Flush every 50 lines so in-progress analyses can tail the file.
+        if ((lines_written_ % 50) == 0) out_.flush();
+    }
+
+private:
+    bool          enabled_{false};
+    std::string   path_;
+    std::ofstream out_;
+    uint64_t      lines_written_{0};
+};
+
+}  // namespace drone::util

--- a/config/cosys_airsim_dev.json
+++ b/config/cosys_airsim_dev.json
@@ -1,6 +1,7 @@
 {
     "_comment": "Cosys-AirSim dev profile — native desktop (GTX 1080 Ti, 11 GB VRAM)",
-    "log_level": "info",
+    "_comment_log_level": "Dev-profile default is debug so scenario runs on the laptop/desktop have maximum diagnostic signal. Cloud profile (cosys_airsim.json) and the project default (default.json) remain at info.",
+    "log_level": "debug",
     "ipc_backend": "zenoh",
 
     "cosys_airsim": {

--- a/config/scenarios/33_non_coco_obstacles.json
+++ b/config/scenarios/33_non_coco_obstacles.json
@@ -19,6 +19,8 @@
         "tier": 3,
         "timeout_s": 180,
         "requires_cosys_airsim": true,
+        "base_config": "config/cosys_airsim_dev.json",
+        "_comment_base_config": "Hint for tests/run_scenario_cosys.sh — used when caller does not pass --base-config. Makes `./tests/run_scenario_cosys.sh config/scenarios/33_non_coco_obstacles.json --gui` work without any extra flags.",
         "scene": {
             "file": "config/scenes/cosys_static.json"
         },
@@ -91,7 +93,12 @@
                     "nms_threshold": 0.45,
                     "mask_channels": 32
                 },
-                "mask_class_iou_threshold": 0.5
+                "mask_class_iou_threshold": 0.5,
+                "diag": {
+                    "_comment": "Issue #612 voxel-position trace — JSONL of pose + bboxes + voxel world positions per batch. Consumed by tools/plot_voxel_trace.py. The runner overwrites trace_path with <scenario_log_dir>/path_a_voxel_trace.jsonl so every run is self-contained; keep trace_voxels=true to opt in.",
+                    "trace_voxels": true,
+                    "trace_path": "path_a_voxel_trace.jsonl"
+                }
             }
         },
         "slam": {
@@ -129,7 +136,8 @@
                 "look_ahead_m": 0.0,
                 "smoothing_alpha": 0.5,
                 "yaw_towards_travel": true,
-                "yaw_smoothing_rate": 0.3,
+                "yaw_towards_velocity": true,
+                "yaw_smoothing_rate": 0.5,
                 "snap_approach_bias": 0.5
             },
             "obstacle_avoider": {

--- a/deploy/clean_run_build_cosys.sh
+++ b/deploy/clean_run_build_cosys.sh
@@ -87,18 +87,20 @@ if [[ ! -f "$SCENARIO_CONFIG" ]]; then
 fi
 
 # Build type: Debug if sanitizer or coverage requested, Release otherwise
+# Use arrays for cmake flags so paths with spaces or shell metacharacters
+# (e.g. ZENOH_CONFIG_PATH="/has space") don't break the invocation.
 BUILD_TYPE="Release"
-EXTRA_CMAKE_FLAGS=""
+EXTRA_CMAKE_FLAGS=()
 if [[ -n "$SANITIZER" ]]; then
     BUILD_TYPE="Debug"
     case "$SANITIZER" in
-        asan)  EXTRA_CMAKE_FLAGS="-DENABLE_ASAN=ON" ;;
-        ubsan) EXTRA_CMAKE_FLAGS="-DENABLE_UBSAN=ON" ;;
+        asan)  EXTRA_CMAKE_FLAGS+=("-DENABLE_ASAN=ON") ;;
+        ubsan) EXTRA_CMAKE_FLAGS+=("-DENABLE_UBSAN=ON") ;;
     esac
 fi
 if [[ "$ENABLE_COVERAGE" == "ON" ]]; then
     BUILD_TYPE="Debug"
-    EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENABLE_COVERAGE=ON"
+    EXTRA_CMAKE_FLAGS+=("-DENABLE_COVERAGE=ON")
 fi
 
 # ── Step 0: Verify zenohc is installed ────────────────────────
@@ -134,25 +136,26 @@ echo ""
 echo "═══ [2/4] Clean build (${BUILD_TYPE}) ═══"
 [[ -n "$SANITIZER" ]]            && echo "  Sanitizer: ${SANITIZER}"
 [[ "$ENABLE_COVERAGE" == "ON" ]] && echo "  Coverage : ON"
-# Determine Zenoh security configuration
-ZENOH_SECURITY_FLAGS=""
+# Determine Zenoh security configuration.  Use an array so paths with spaces
+# survive the cmake invocation without re-splitting.
+ZENOH_SECURITY_FLAGS=()
 if [[ -n "${ZENOH_CONFIG_PATH:-}" ]]; then
     if [[ ! -f "$ZENOH_CONFIG_PATH" ]]; then
         echo "ERROR: ZENOH_CONFIG_PATH='${ZENOH_CONFIG_PATH}' does not exist."
         exit 1
     fi
     echo "  Using secure Zenoh config: ${ZENOH_CONFIG_PATH}"
-    ZENOH_SECURITY_FLAGS="-DZENOH_CONFIG_PATH=${ZENOH_CONFIG_PATH}"
+    ZENOH_SECURITY_FLAGS+=("-DZENOH_CONFIG_PATH=${ZENOH_CONFIG_PATH}")
 else
     echo "  WARNING: No ZENOH_CONFIG_PATH set — using insecure mode (dev/test only)."
-    ZENOH_SECURITY_FLAGS="-DALLOW_INSECURE_ZENOH=ON"
+    ZENOH_SECURITY_FLAGS+=("-DALLOW_INSECURE_ZENOH=ON")
 fi
 
 rm -rf build/
 mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
-      ${ZENOH_SECURITY_FLAGS} \
-      ${EXTRA_CMAKE_FLAGS} \
+      "${ZENOH_SECURITY_FLAGS[@]}" \
+      "${EXTRA_CMAKE_FLAGS[@]}" \
       ..
 cmake --build . -j"$(nproc)"
 cd "$PROJECT_DIR"

--- a/deploy/clean_run_build_cosys.sh
+++ b/deploy/clean_run_build_cosys.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# deploy/clean_run_build_cosys.sh
+# Clean-build the companion stack and launch a Cosys-AirSim (UE5) scenario.
+#
+# Usage:
+#   bash deploy/clean_run_build_cosys.sh                        # default: scenario 33 + GUI
+#   bash deploy/clean_run_build_cosys.sh --scenario 30          # pick a different scenario
+#   bash deploy/clean_run_build_cosys.sh --headless             # no UE5 3D window
+#   bash deploy/clean_run_build_cosys.sh --no-tests             # skip unit tests
+#   bash deploy/clean_run_build_cosys.sh --asan                 # + AddressSanitizer
+#   bash deploy/clean_run_build_cosys.sh --ubsan                # + UBSan
+#   bash deploy/clean_run_build_cosys.sh --coverage             # + code coverage
+#   bash deploy/clean_run_build_cosys.sh --scenario-config PATH # absolute scenario json
+#
+# NOTE: --tsan is intentionally omitted because the zenohc library triggers
+#       TSan false-positives in its internal threading.
+#
+# What it does:
+#   1. Kill leftover UE5/PX4/companion processes
+#   2. Clean-build (Release by default, Debug if sanitizer/coverage)
+#   3. Run unit tests (unless --no-tests)
+#   4. Launch tests/run_scenario_cosys.sh with the selected scenario
+#
+# Prerequisites:
+#   - zenohc ≥ 1.0 installed  (apt: libzenohc libzenohc-dev)
+#   - Cosys-AirSim checkout with a pre-built environment (e.g., Blocks)
+#   - NVIDIA GPU + drivers for UE5
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+SCENARIO_NUM="33"
+SCENARIO_CONFIG=""
+GUI_FLAG="--gui"
+SANITIZER=""
+ENABLE_COVERAGE="OFF"
+RUN_TESTS=true
+VERBOSE_FLAG="--verbose"
+
+usage() {
+    sed -n '2,20p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scenario)          SCENARIO_NUM="$2"; shift ;;
+        --scenario-config)   SCENARIO_CONFIG="$2"; shift ;;
+        --headless)          GUI_FLAG="" ;;
+        --gui)               GUI_FLAG="--gui" ;;
+        --quiet)             VERBOSE_FLAG="" ;;
+        --no-tests)          RUN_TESTS=false ;;
+        --asan)              SANITIZER="asan" ;;
+        --tsan)
+            echo "ERROR: --tsan is not supported (false-positives in zenohc internal threading)."
+            echo "  Use --asan or --ubsan instead."
+            exit 1
+            ;;
+        --ubsan)             SANITIZER="ubsan" ;;
+        --coverage)          ENABLE_COVERAGE="ON" ;;
+        -h|--help)           usage; exit 0 ;;
+        *)
+            echo "Unknown argument: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Resolve scenario config path
+if [[ -z "$SCENARIO_CONFIG" ]]; then
+    # Match scenario number prefix against config/scenarios/<N>_*.json
+    matches=( "${PROJECT_DIR}/config/scenarios/${SCENARIO_NUM}_"*.json )
+    if [[ ${#matches[@]} -ne 1 || ! -f "${matches[0]}" ]]; then
+        echo "ERROR: Could not resolve scenario '${SCENARIO_NUM}' in config/scenarios/"
+        echo "  Try --scenario-config <path> or list with:"
+        echo "    ls config/scenarios/ | head"
+        exit 1
+    fi
+    SCENARIO_CONFIG="${matches[0]}"
+fi
+if [[ ! -f "$SCENARIO_CONFIG" ]]; then
+    echo "ERROR: Scenario config not found: ${SCENARIO_CONFIG}"
+    exit 1
+fi
+
+# Build type: Debug if sanitizer or coverage requested, Release otherwise
+BUILD_TYPE="Release"
+EXTRA_CMAKE_FLAGS=""
+if [[ -n "$SANITIZER" ]]; then
+    BUILD_TYPE="Debug"
+    case "$SANITIZER" in
+        asan)  EXTRA_CMAKE_FLAGS="-DENABLE_ASAN=ON" ;;
+        ubsan) EXTRA_CMAKE_FLAGS="-DENABLE_UBSAN=ON" ;;
+    esac
+fi
+if [[ "$ENABLE_COVERAGE" == "ON" ]]; then
+    BUILD_TYPE="Debug"
+    EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DENABLE_COVERAGE=ON"
+fi
+
+# ── Step 0: Verify zenohc is installed ────────────────────────
+if ! pkg-config --exists zenohc 2>/dev/null; then
+    echo "ERROR: zenohc not found. Install it first:"
+    echo "  sudo apt install libzenohc libzenohc-dev"
+    echo "  or see: https://github.com/eclipse-zenoh/zenoh-c/releases"
+    exit 1
+fi
+ZENOH_VER="$(pkg-config --modversion zenohc 2>/dev/null || echo 'unknown')"
+echo "[OK] zenohc ${ZENOH_VER} found"
+
+# ── Step 1: Kill leftover processes ───────────────────────────
+echo ""
+echo "═══ [1/4] Cleaning up old processes ═══"
+# UE5 / Cosys-AirSim
+pkill -9 -f "UnrealEditor"   2>/dev/null || true
+pkill -9 -f "Blocks-Linux"   2>/dev/null || true
+pkill -9 -f "AirSimEnv"      2>/dev/null || true
+# PX4 (defensive: Tier 3 uses SimpleFlight, but stale PX4 could still hold ports)
+pkill -9 -f "px4_sitl"                   2>/dev/null || true
+pkill -9 -f "PX4-Autopilot/build/px4"    2>/dev/null || true
+# Companion stack
+for p in video_capture perception slam_vio_nav mission_planner comms payload_manager system_monitor \
+         cosys_telemetry_poller cosys_populate_scene; do
+    pkill -f "build/bin/$p" 2>/dev/null || true
+done
+sleep 2
+echo "  Done."
+
+# ── Step 2: Clean build ──────────────────────────────────────
+echo ""
+echo "═══ [2/4] Clean build (${BUILD_TYPE}) ═══"
+[[ -n "$SANITIZER" ]]            && echo "  Sanitizer: ${SANITIZER}"
+[[ "$ENABLE_COVERAGE" == "ON" ]] && echo "  Coverage : ON"
+# Determine Zenoh security configuration
+ZENOH_SECURITY_FLAGS=""
+if [[ -n "${ZENOH_CONFIG_PATH:-}" ]]; then
+    if [[ ! -f "$ZENOH_CONFIG_PATH" ]]; then
+        echo "ERROR: ZENOH_CONFIG_PATH='${ZENOH_CONFIG_PATH}' does not exist."
+        exit 1
+    fi
+    echo "  Using secure Zenoh config: ${ZENOH_CONFIG_PATH}"
+    ZENOH_SECURITY_FLAGS="-DZENOH_CONFIG_PATH=${ZENOH_CONFIG_PATH}"
+else
+    echo "  WARNING: No ZENOH_CONFIG_PATH set — using insecure mode (dev/test only)."
+    ZENOH_SECURITY_FLAGS="-DALLOW_INSECURE_ZENOH=ON"
+fi
+
+rm -rf build/
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+      ${ZENOH_SECURITY_FLAGS} \
+      ${EXTRA_CMAKE_FLAGS} \
+      ..
+cmake --build . -j"$(nproc)"
+cd "$PROJECT_DIR"
+echo "  Build complete — binaries in build/bin/"
+
+# ── Step 3: Run tests ────────────────────────────────────────
+if [[ "$RUN_TESTS" == "true" ]]; then
+    echo ""
+    echo "═══ [3/4] Running unit tests ═══"
+    ctest --test-dir build --output-on-failure -j"$(nproc)"
+    echo "  All tests passed."
+else
+    echo ""
+    echo "═══ [3/4] Skipping unit tests (--no-tests) ═══"
+fi
+
+# ── Step 4: Launch Cosys-AirSim scenario ─────────────────────
+echo ""
+echo "═══ [4/4] Launching Cosys-AirSim scenario ═══"
+if [[ -n "$GUI_FLAG" ]]; then
+    echo "  Mode     : GUI (UE5 3-D viewport)"
+else
+    echo "  Mode     : Headless (-RenderOffScreen)"
+fi
+echo "  Scenario : ${SCENARIO_CONFIG}"
+echo "  Logs     : drone_logs/scenarios_cosys/<scenario>/..."
+echo "  Press Ctrl+C to stop."
+echo ""
+
+# Use exec so SIGINT from the user goes straight to the runner's trap
+exec bash "${PROJECT_DIR}/tests/run_scenario_cosys.sh" \
+    "$SCENARIO_CONFIG" \
+    $GUI_FLAG \
+    $VERBOSE_FLAG

--- a/deploy/clean_run_build_cosys.sh
+++ b/deploy/clean_run_build_cosys.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # deploy/clean_run_build_cosys.sh
-# Clean-build the companion stack and launch a Cosys-AirSim (UE5) scenario.
+# Clean-build the companion stack and smoke-test that all 7 processes start.
+#
+# Scope: this script is a *build + process-startup* verifier, not a scenario
+# runner.  It does NOT launch UE5 / Cosys-AirSim / Gazebo.  To actually run a
+# scenario against Cosys-AirSim, use:
+#
+#     ./tests/run_scenario_cosys.sh config/scenarios/33_non_coco_obstacles.json --gui --verbose
 #
 # Usage:
-#   bash deploy/clean_run_build_cosys.sh                        # default: scenario 33 + GUI
-#   bash deploy/clean_run_build_cosys.sh --scenario 30          # pick a different scenario
-#   bash deploy/clean_run_build_cosys.sh --headless             # no UE5 3D window
-#   bash deploy/clean_run_build_cosys.sh --no-tests             # skip unit tests
-#   bash deploy/clean_run_build_cosys.sh --asan                 # + AddressSanitizer
-#   bash deploy/clean_run_build_cosys.sh --ubsan                # + UBSan
-#   bash deploy/clean_run_build_cosys.sh --coverage             # + code coverage
-#   bash deploy/clean_run_build_cosys.sh --scenario-config PATH # absolute scenario json
+#   bash deploy/clean_run_build_cosys.sh               # default: clean build + smoke test
+#   bash deploy/clean_run_build_cosys.sh --no-tests    # skip ctest (saves ~60 s)
+#   bash deploy/clean_run_build_cosys.sh --asan        # + AddressSanitizer
+#   bash deploy/clean_run_build_cosys.sh --ubsan       # + UBSan
+#   bash deploy/clean_run_build_cosys.sh --coverage    # + code coverage
+#   bash deploy/clean_run_build_cosys.sh --smoke-seconds 15  # override 8 s wait
+#   bash deploy/clean_run_build_cosys.sh --no-smoke    # skip smoke test (build + ctest only)
 #
 # NOTE: --tsan is intentionally omitted because the zenohc library triggers
 #       TSan false-positives in its internal threading.
@@ -19,47 +24,47 @@
 #   1. Kill leftover UE5/PX4/companion processes
 #   2. Clean-build (Release by default, Debug if sanitizer/coverage)
 #   3. Run unit tests (unless --no-tests)
-#   4. Launch tests/run_scenario_cosys.sh with the selected scenario
+#   4. Launch the 7 companion processes via deploy/launch_all.sh (simulated
+#      backends — no UE5, no Gazebo), wait for them to come up, verify every
+#      process is alive, then shut them down cleanly.
+#
+# Exit codes:
+#   0  clean build + all 7 processes alive
+#   1  build or tests or smoke test failed
 #
 # Prerequisites:
-#   - zenohc ≥ 1.0 installed  (apt: libzenohc libzenohc-dev)
-#   - Cosys-AirSim checkout with a pre-built environment (e.g., Blocks)
-#   - NVIDIA GPU + drivers for UE5
+#   - zenohc ≥ 1.0 installed (apt: libzenohc libzenohc-dev)
+#   - NVIDIA GPU + drivers optional (only needed for scenario runs, not here)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_DIR"
 
-SCENARIO_NUM="33"
-SCENARIO_CONFIG=""
-GUI_FLAG="--gui"
 SANITIZER=""
 ENABLE_COVERAGE="OFF"
 RUN_TESTS=true
-VERBOSE_FLAG="--verbose"
+RUN_SMOKE=true
+SMOKE_SECONDS=8
 
 usage() {
-    sed -n '2,20p' "$0"
+    sed -n '2,28p' "$0"
 }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --scenario)          SCENARIO_NUM="$2"; shift ;;
-        --scenario-config)   SCENARIO_CONFIG="$2"; shift ;;
-        --headless)          GUI_FLAG="" ;;
-        --gui)               GUI_FLAG="--gui" ;;
-        --quiet)             VERBOSE_FLAG="" ;;
-        --no-tests)          RUN_TESTS=false ;;
-        --asan)              SANITIZER="asan" ;;
+        --no-tests)      RUN_TESTS=false ;;
+        --no-smoke)      RUN_SMOKE=false ;;
+        --smoke-seconds) SMOKE_SECONDS="$2"; shift ;;
+        --asan)          SANITIZER="asan" ;;
         --tsan)
             echo "ERROR: --tsan is not supported (false-positives in zenohc internal threading)."
             echo "  Use --asan or --ubsan instead."
             exit 1
             ;;
-        --ubsan)             SANITIZER="ubsan" ;;
-        --coverage)          ENABLE_COVERAGE="ON" ;;
-        -h|--help)           usage; exit 0 ;;
+        --ubsan)         SANITIZER="ubsan" ;;
+        --coverage)      ENABLE_COVERAGE="ON" ;;
+        -h|--help)       usage; exit 0 ;;
         *)
             echo "Unknown argument: $1"
             usage
@@ -69,26 +74,7 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-# Resolve scenario config path
-if [[ -z "$SCENARIO_CONFIG" ]]; then
-    # Match scenario number prefix against config/scenarios/<N>_*.json
-    matches=( "${PROJECT_DIR}/config/scenarios/${SCENARIO_NUM}_"*.json )
-    if [[ ${#matches[@]} -ne 1 || ! -f "${matches[0]}" ]]; then
-        echo "ERROR: Could not resolve scenario '${SCENARIO_NUM}' in config/scenarios/"
-        echo "  Try --scenario-config <path> or list with:"
-        echo "    ls config/scenarios/ | head"
-        exit 1
-    fi
-    SCENARIO_CONFIG="${matches[0]}"
-fi
-if [[ ! -f "$SCENARIO_CONFIG" ]]; then
-    echo "ERROR: Scenario config not found: ${SCENARIO_CONFIG}"
-    exit 1
-fi
-
-# Build type: Debug if sanitizer or coverage requested, Release otherwise
-# Use arrays for cmake flags so paths with spaces or shell metacharacters
-# (e.g. ZENOH_CONFIG_PATH="/has space") don't break the invocation.
+# Build type: Debug if sanitizer or coverage requested, Release otherwise.
 BUILD_TYPE="Release"
 EXTRA_CMAKE_FLAGS=()
 if [[ -n "$SANITIZER" ]]; then
@@ -116,11 +102,11 @@ echo "[OK] zenohc ${ZENOH_VER} found"
 # ── Step 1: Kill leftover processes ───────────────────────────
 echo ""
 echo "═══ [1/4] Cleaning up old processes ═══"
-# UE5 / Cosys-AirSim
+# UE5 / Cosys-AirSim (defensive — scripts like this often run after a failed scenario)
 pkill -9 -f "UnrealEditor"   2>/dev/null || true
 pkill -9 -f "Blocks-Linux"   2>/dev/null || true
 pkill -9 -f "AirSimEnv"      2>/dev/null || true
-# PX4 (defensive: Tier 3 uses SimpleFlight, but stale PX4 could still hold ports)
+# PX4 (defensive)
 pkill -9 -f "px4_sitl"                   2>/dev/null || true
 pkill -9 -f "PX4-Autopilot/build/px4"    2>/dev/null || true
 # Companion stack
@@ -136,8 +122,7 @@ echo ""
 echo "═══ [2/4] Clean build (${BUILD_TYPE}) ═══"
 [[ -n "$SANITIZER" ]]            && echo "  Sanitizer: ${SANITIZER}"
 [[ "$ENABLE_COVERAGE" == "ON" ]] && echo "  Coverage : ON"
-# Determine Zenoh security configuration.  Use an array so paths with spaces
-# survive the cmake invocation without re-splitting.
+# Zenoh security configuration — array so paths with spaces survive the cmake invocation.
 ZENOH_SECURITY_FLAGS=()
 if [[ -n "${ZENOH_CONFIG_PATH:-}" ]]; then
     if [[ ! -f "$ZENOH_CONFIG_PATH" ]]; then
@@ -172,21 +157,80 @@ else
     echo "═══ [3/4] Skipping unit tests (--no-tests) ═══"
 fi
 
-# ── Step 4: Launch Cosys-AirSim scenario ─────────────────────
-echo ""
-echo "═══ [4/4] Launching Cosys-AirSim scenario ═══"
-if [[ -n "$GUI_FLAG" ]]; then
-    echo "  Mode     : GUI (UE5 3-D viewport)"
-else
-    echo "  Mode     : Headless (-RenderOffScreen)"
+# ── Step 4: Smoke-test the 7 companion processes ─────────────
+if [[ "$RUN_SMOKE" != "true" ]]; then
+    echo ""
+    echo "═══ [4/4] Skipping smoke test (--no-smoke) ═══"
+    echo ""
+    echo "DONE — clean build + ctest.  To run a scenario:"
+    echo "  ./tests/run_scenario_cosys.sh config/scenarios/33_non_coco_obstacles.json --gui --verbose"
+    exit 0
 fi
-echo "  Scenario : ${SCENARIO_CONFIG}"
-echo "  Logs     : drone_logs/scenarios_cosys/<scenario>/..."
-echo "  Press Ctrl+C to stop."
+
+echo ""
+echo "═══ [4/4] Smoke test: start 7 processes (simulated backends) ═══"
+SMOKE_LOG="${PROJECT_DIR}/drone_logs/smoke_test_$(date +%Y-%m-%d_%H%M%S).log"
+mkdir -p "$(dirname "$SMOKE_LOG")"
+echo "  Log   : ${SMOKE_LOG}"
+echo "  Wait  : ${SMOKE_SECONDS}s for the stack to settle"
 echo ""
 
-# Use exec so SIGINT from the user goes straight to the runner's trap
-exec bash "${PROJECT_DIR}/tests/run_scenario_cosys.sh" \
-    "$SCENARIO_CONFIG" \
-    $GUI_FLAG \
-    $VERBOSE_FLAG
+# Launch the 7 processes.  launch_all.sh uses simulated backends by default —
+# no UE5, no Gazebo, no external simulator — exactly what we want to verify
+# that the stack compiled cleanly and every binary starts without crashing.
+bash "${SCRIPT_DIR}/launch_all.sh" > "$SMOKE_LOG" 2>&1 &
+LAUNCH_PID=$!
+
+cleanup_smoke() {
+    # Stop launch_all and any lingering process it spawned.
+    kill -INT "$LAUNCH_PID" 2>/dev/null || true
+    sleep 2
+    pkill -9 -f "build/bin/(video_capture|perception|slam_vio_nav|mission_planner|comms|payload_manager|system_monitor)" 2>/dev/null || true
+    wait "$LAUNCH_PID" 2>/dev/null || true
+    # Clean up stale Zenoh shm (safe — we just killed everything that would hold them).
+    rm -f /dev/shm/zenoh_shm_* 2>/dev/null || true
+}
+trap cleanup_smoke EXIT INT TERM
+
+# Poll for every 0.5s until every process is alive or we time out.
+SMOKE_DEADLINE=$(( $(date +%s) + SMOKE_SECONDS ))
+PROCS=(video_capture perception slam_vio_nav mission_planner comms payload_manager system_monitor)
+while true; do
+    ALL_UP=true
+    for p in "${PROCS[@]}"; do
+        if ! pgrep -f "build/bin/$p" >/dev/null; then
+            ALL_UP=false; break
+        fi
+    done
+    if [[ "$ALL_UP" == "true" ]]; then break; fi
+    if [[ $(date +%s) -ge $SMOKE_DEADLINE ]]; then break; fi
+    sleep 0.5
+done
+
+# Final check + per-process report.
+echo "  ┌─────────────────────────────────────────────────"
+MISSING=0
+for p in "${PROCS[@]}"; do
+    if pgrep -f "build/bin/$p" >/dev/null; then
+        echo "  │  ✓ $p"
+    else
+        echo "  │  ✗ $p NOT RUNNING"
+        MISSING=$((MISSING + 1))
+    fi
+done
+echo "  └─────────────────────────────────────────────────"
+echo ""
+
+if [[ $MISSING -eq 0 ]]; then
+    echo "SMOKE TEST: PASS — all 7 processes are alive."
+    echo ""
+    echo "Next: run a scenario"
+    echo "  ./tests/run_scenario_cosys.sh config/scenarios/33_non_coco_obstacles.json --gui --verbose"
+    exit 0
+else
+    echo "SMOKE TEST: FAIL — ${MISSING}/7 processes did not start."
+    echo ""
+    echo "Last 30 lines of ${SMOKE_LOG}:"
+    tail -30 "$SMOKE_LOG" 2>/dev/null || true
+    exit 1
+fi

--- a/docs/guides/DEVELOPMENT_WORKFLOW.md
+++ b/docs/guides/DEVELOPMENT_WORKFLOW.md
@@ -423,7 +423,34 @@ Before merging, update the project's tracking documents:
    - Update suite/test counts in the summary table
    - Document what each new suite validates
 
-7. **When to update:** Include doc updates in the same PR branch, committed before merge.
+7. **`DESIGN_RATIONALE.md`** — Add a new `DR-NNN` entry when:
+   - You are **declining or disagreeing with a review comment** (from a review agent, Copilot, or a human reviewer) based on a justified rationale. This creates the audit trail showing the comment was evaluated intentionally, not missed.
+   - You made a **gray-area design decision where both sides are defensible** — e.g. "opt-in observability on a flight-critical thread is OK because the default is off and the gate is config-driven."
+   - You marked an item **deferred** in a PR's Review Fixes table — the DR is where the reasoning lives. Every deferral must cite a DR-NNN reference.
+   - You need to document a **revisit trigger** — a condition under which the decision should be reconsidered (e.g. "if a production config ever wants this enabled, promote to SPSC-ring").
+   - Format each entry as: Question / For-X / For-Y / Decision / Revisit when / Date. See existing DR-001 through DR-034 for style.
+   - DR entries are append-only. If a decision is superseded, keep the old entry and add a new one referencing it.
+
+8. **`IMPROVEMENTS.md`** — Add an entry when:
+   - You notice a **proactive improvement yourself** (not in response to a review comment) — infrastructure cleanups, architecture nits, code-quality nice-to-haves, missing tests, documentation gaps, stale numbers, tool ergonomics, etc.
+   - The improvement is **worth doing but not worth interrupting current work** — quiet-window backlog for when a PR is waiting on review or a test is running.
+   - You batched minor suggestions at the end of a task summary — anything that would otherwise "float in conversation only" belongs here instead.
+   - Entries must include: date, priority (P1/P2/P3), category (Infra / Arch / CodeQual / Functional / Tests / Docs / Scripts), file/area, what/why, suggested approach.
+   - Move completed entries to a **Resolved** section at the bottom, with the PR or commit reference.
+
+   **Critical distinction — which file gets the entry?**
+
+   | Origin of the item | Destination |
+   |---|---|
+   | A review agent / Copilot / human reviewer flagged it *and* we are declining to fix it | `DESIGN_RATIONALE.md` (new DR-NNN) |
+   | A review agent / Copilot / human reviewer flagged it *and* we are fixing it now | Nothing — just fix it in the PR |
+   | A review agent / Copilot / human reviewer flagged it *and* we are deferring | `DESIGN_RATIONALE.md` (new DR-NNN); cite the DR number in the PR's Review Fixes table |
+   | We noticed it ourselves and it's outside the current PR's scope | `IMPROVEMENTS.md` |
+   | We noticed it ourselves and we're fixing it now | Nothing — just fix it in the PR |
+
+   Never mix the two destinations. `IMPROVEMENTS.md` is a backlog of nice-to-haves; `DESIGN_RATIONALE.md` is the audit trail for evaluated-and-declined review comments. They serve different readers (backlog groomers vs future PR reviewers checking why X wasn't fixed).
+
+9. **When to update:** Include doc updates in the same PR branch, committed before merge.
 
 #### Step 8: Merge to Main
 

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -812,6 +812,202 @@ The first version of `validate_model_path()` used `std::filesystem::weakly_canon
 
 ---
 
+### Fix #55 — PATH A Camera→Body Extrinsic Rotation Missing (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** Critical
+**Files:** `process2_perception/src/main.cpp`
+
+**What:** After PR #611 merged, live scenario-33 runs showed the PATH A pipeline alive end-to-end — FastSAM produced masks, `MaskDepthProjector` back-projected, `/semantic_voxels` flowed to P4, and the grid grew. But the drone still collided with `TemplateCube_Rounded_9` because every back-projected voxel was rotated by a constant 90° error before landing in the world frame. The plotter (`tools/plot_voxel_trace.py`) showed voxel scatter clustered in the wrong quadrant from the drone, with zero voxels near the cube even when FastSAM clearly segmented it.
+
+**Error messages (searchable):**
+
+- No explicit error — silent frame-convention bug. Diagnostic signal was "voxel world positions 8–12m offset from GT scene-object positions".
+- `[Grid] N static (promoted=N)` numbers grew but were in the wrong cells, so `[D*Lite]` never saw the cube obstacle.
+
+**Reproduce:**
+1. Check out commit `992b888` (PR #611 merge, scenario-33 baseline).
+2. `bash deploy/clean_run_build_cosys.sh --scenario 33`
+3. Grep `path_a_voxel_trace.jsonl` for voxel `world[x,y,z]` vs GT cube position `(10, 20, 2.5)` from `config/scenes/cosys_static.json` — offsets of 8–12m are the symptom.
+
+**Why (Root Cause):**
+In `mask_projection_thread`, the camera pose passed to `MaskDepthProjector::project()` was built as:
+
+```cpp
+cam_pose.linear() = q.toRotationMatrix();   // q = body quaternion from SLAM
+```
+
+The projector interprets that rotation as the *camera* frame's orientation in world coordinates. Cosys's camera optical frame is OpenCV convention (`cam_X=right`, `cam_Y=down`, `cam_Z=forward`); the drone body frame is FRD (`body_X=forward`, `body_Y=right`, `body_Z=down`). Without the body→cam rotation, every pixel's bearing from the drone was wrong by this constant 90° yaw/roll.
+
+**Fix:** Introduced `R_body_from_cam` as a `static const Eigen::Matrix3f` and right-multiplied it into the body rotation before building the camera pose:
+
+```cpp
+static const Eigen::Matrix3f R_body_from_cam = (Eigen::Matrix3f() <<
+     0,  0,  1,   // body_X ← cam_Z (forward)
+    -1,  0,  0,   // body_Y ← −cam_X (left)
+     0, -1,  0    // body_Z ← −cam_Y (up)
+).finished();
+cam_pose.linear() = q.toRotationMatrix() * R_body_from_cam;
+```
+
+**Found by:** `tools/plot_voxel_trace.py` cross-referencing per-batch voxel world XYZ (from `path_a_voxel_trace.jsonl`) against scene ground-truth positions (from `config/scenes/cosys_static.json`). This was the exact failure mode row from the diagnostic hypothesis table in the issue body.
+
+**Regression test:** Run scenario 33; confirm ≥20% of voxels cluster near the cube's altitude band (not the drone's altitude). Before fix: 0%. After fix: 34%.
+
+---
+
+### Fix #56 — `CpuSemanticProjector` Mask-Convention Mismatch (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** High
+**Files:** `common/hal/include/hal/cpu_semantic_projector.h`
+
+**What:** `CpuSemanticProjector::project()` assumed masks were bbox-local (`mask_width ≈ bbox.w`, indexed with bbox-local `(u, v)`). `SimulatedSAMBackend` happened to produce bbox-local masks, so the assumption held accidentally. When `EdgeContourSAMBackend` or `FastSAMInferenceBackend` plugged in — both produce full-image masks (input-frame resolution) — the projector indexed the full mask with bbox-local coordinates, reading the top-left 32×32 patch of the whole frame instead of the masked region inside the bbox.
+
+**Why (Root Cause):** Undocumented interface: `SAMBackend::run()` returns a mask buffer but does not specify whether its dimensions are bbox-local or full-image, and the downstream projector baked in the simulated backend's convention.
+
+**Fix:** Auto-detect the mask convention inside the projector: if `mask_width >= bbox.w * 1.5f`, treat the mask as full-image and index with global `(u, v)`; otherwise preserve the bbox-local path for backward compatibility. Ratio of 1.5 chosen so small rounding gaps don't trigger the full-image path.
+
+**Found by:** `path_a_voxel_trace.jsonl` — for the same mask set, voxel count per batch was ~3 with the wrong interpretation vs ~25 with the correct one.
+
+**Regression test:** Scenario 33 logs `[MaskProj] Published N voxels (batch_size=M)` with N consistently in the 20–30 range per batch for FastSAM output.
+
+---
+
+### Fix #57 — SAM Backend Factory Hard-Coded Simulated Backend (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** High
+**Files:** `process2_perception/src/main.cpp`
+
+**What:** The PATH A construction block in P2 always constructed `SimulatedSAMBackend` even when `perception.path_a.sam.backend` was set to `fastsam` or `edge_contour`. Config was silently ignored — no warning, no error. Users flipping the backend field saw no effect on behaviour.
+
+**Why (Root Cause):** Early scaffolding left a hard-coded `auto sam = std::make_unique<SimulatedSAMBackend>(...);` line behind the PATH A enabled gate. The `InferenceBackendFactory::create_inference_backend(cfg, sam_section)` function existed but wasn't called.
+
+**Fix:** Route through the factory:
+
+```cpp
+auto sam = InferenceBackendFactory::create_inference_backend(cfg, sam_section);
+```
+
+Process-startup logs now identify the selected backend so the user sees which one actually loaded.
+
+**Found by:** Log inspection after confirming `sam.backend=fastsam` in the merged config but no `[FastSAM]` initialisation line appeared in `perception.log`.
+
+**Regression test:** `perception.log` contains `[SAM] Backend initialised: <backend_name>` matching `perception.path_a.sam.backend` in the merged config.
+
+---
+
+### Fix #58 — FastSAM ONNX Has `Floor` Node OpenCV DNN 4.10 Can't Parse (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** Medium
+**Files:** `models/download_fastsam.sh`
+
+**What:** `cv::dnn::readNetFromONNX("models/fastsam_s.onnx")` threw on load. The Ultralytics FastSAM-s export includes a `Floor` node at `/model.10/Floor` (a type coercion for the proposal decoder) that OpenCV DNN's ONNX importer doesn't support.
+
+**Error messages (searchable):**
+
+- `OpenCV(4.10.0) Error: Can't create layer "/model.10/Floor" of type "Floor" in function 'getLayerInstance'`
+
+**Why (Root Cause):** OpenCV DNN's ONNX op coverage lags PyTorch's export graph. `onnxsim` (onnx-simplifier) constant-folds the Floor node into its static inputs, eliminating it from the runtime graph.
+
+**Fix:** `models/download_fastsam.sh` pipes the Ultralytics PT→ONNX export through `onnxsim` before writing `models/fastsam_s.onnx`:
+
+```bash
+python3 -c "from ultralytics import FastSAM; FastSAM('FastSAM-s.pt').export(format='onnx', opset=12)"
+onnxsim FastSAM-s.onnx models/fastsam_s.onnx
+```
+
+**Found by:** First attempt to load the FastSAM ONNX in `perception.log` — crash was deterministic on load.
+
+**Regression test:** `bash models/download_fastsam.sh` succeeds, and a subsequent `cv::dnn::readNetFromONNX` load does not throw. (Covered end-to-end by scenario 33.)
+
+---
+
+### Fix #59 — `FastSAMInferenceBackend::kMaxProposals` Too Small at 1024 Input (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** High
+**Files:** `common/hal/include/hal/fastsam_inference_backend.h`
+
+**What:** `FastSAMInferenceBackend::parse_raw_output()` rejected every FastSAM inference as `INVALID_ARGUMENT` because the ONNX model's proposal-decoder head emits 21504 proposals at 1024×1024 input, and the hard-coded bounds check was 16384.
+
+**Error messages (searchable):**
+
+- `[FastSAM] parse_raw_output: cols=21504 exceeds kMaxProposals=16384 — refusing`
+
+**Why (Root Cause):** `kMaxProposals = 16384` was sized for YOLOv8-seg at 640 input (~8400 proposals, doubled for safety). FastSAM-s at 1024 input emits ~2.5× more proposals. Single-point constant, never revisited after upping the input resolution.
+
+**Fix:** Raise to `static constexpr int kMaxProposals = 65536`. Keep the cap so a malformed ONNX still can't trigger a huge allocation.
+
+**Found by:** `perception.log` repeatedly emitting `[FastSAM] parse_raw_output: cols=21504 exceeds ...` on every frame, resulting in zero masks handed to the projector.
+
+**Regression test:** Scenario 33 logs `[FastSAM] Parsed N masks` with N in the 200–500 range per frame for the Blocks environment.
+
+---
+
+### Fix #60 — Ground-Texture Ghost Voxels Pollute Static Grid Layer (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** High
+**Files:** `common/hal/include/hal/cpu_semantic_projector.h`, `process4_mission_planner/include/planner/occupancy_grid_3d.h`
+
+**What:** Depth Anything V2's metric depth drifts noticeably past ~15m; combined with a 3D inflation radius of 2 cells (a 5×5×5 = 125-cell neighbourhood), distant ground-texture pixels produced phantom voxels at `z≈0` that the grid permanently promoted. The D\* Lite planner's start-cell kept ending up inside inflated phantom obstacles, forcing reverse-only replans and eventually `STUCK count 4 exceeded cap 3`.
+
+**Symptom:** Scenario 33 logs showed `[Grid]` static cell count climbing past 800 during survey, `[D*Lite] No path` warnings, and the drone repeatedly reversing without lateral motion.
+
+**Why (Root Cause):** Three layered defects that amplified each other:
+
+1. `CpuSemanticProjector::sample_depth()` accepted any depth value DA V2 returned, including the multi-metre drifts at the horizon.
+2. `OccupancyGrid3D` had no ground-plane filter, so any voxel with `z` near zero got promoted.
+3. 3D inflation radius 2 meant one noisy voxel contaminated 125 cells instead of 27.
+
+**Fix (three layers, all conservative):**
+1. `sample_depth()` — clamp depth > 20m to zero (skip the sample) via `constexpr float kMaxObstacleDepth = 20.0f`.
+2. `OccupancyGrid3D::insert_voxels()` — reject voxels with `z < 0.3f` (ground) and clamp `|x|, |y|, |z| ≤ position_clamp_m` (new config key `mission_planner.occupancy_grid.voxel_input.position_clamp_m`, default 1000m).
+3. Lowered inflation radius from 2 → 1 cell in `insert_voxels()` (3×3×3 neighbourhood).
+
+**Found by:** `[Grid] 800+ static` combined with top-down plotter showing voxel scatter at ground level along the drone's trajectory (not at scene objects).
+
+**Regression test:** Scenario 33 — static cell growth capped at ~180 at survey-end; zero `[D*Lite] No path` warnings in the working run.
+
+---
+
+### Fix #61 — Drone Yawed Toward Waypoint, Never Faced Detour Obstacle (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** Medium
+**Files:** `process4_mission_planner/include/planner/grid_planner_base.h`, `process4_mission_planner/src/main.cpp`, `common/util/include/util/config_keys.h`, `config/scenarios/33_non_coco_obstacles.json`
+
+**What:** With `yaw_towards_travel = true`, the drone points its nose at the next waypoint's bearing. During a potential-field-induced lateral detour around `TemplateCube_Rounded_9`, that bearing points *past* the cube, so the mission camera's frustum misses the cube's side face. PATH A gets no masks from the critical surface, the planner loses obstacle coverage, and the drone re-enters from the un-observed side and collides.
+
+**Why (Root Cause):** Yaw control was tied to the waypoint direction vector (waypoint-minus-current-position). During an active detour the actual velocity vector diverges from that direction, and the critical observation surface is on the velocity side, not the waypoint side.
+
+**Fix:** Added `yaw_towards_velocity` boolean config flag (default `false`, gated via new key `mission_planner.path_planner.yaw_towards_velocity`). When enabled and smoothed velocity magnitude exceeds 0.4 m/s, the yaw target is computed from the velocity vector instead of the waypoint-direction vector. Increased `yaw_smoothing_rate` from 0.3 → 0.5 so yaw tracks actual heading changes at detour speed.
+
+**Found by:** Observation of two consecutive failed runs — first collision on the near face of the cube, second on the far face. Cross-checked `cosys_telemetry.jsonl` GT trajectory against the voxel trace plotter: lateral motion was present, but no voxels ever landed on the face the drone was lateraling past.
+
+**Regression test:** Scenario 33 working run on 2026-04-23 — 0 `TemplateCube_Rounded_9` collisions, drone advanced past WP2 + WP3 on the detour path.
+
+---
+
+### Fix #62 — `cosys_telemetry_poller` Include Order Breaks AirSim Macro Expansion (Issue #612)
+
+**Date:** 2026-04-23
+**Severity:** Low (build-time only)
+**Files:** `tools/cosys_telemetry_poller/main.cpp`
+
+**What:** Compiling `tools/cosys_telemetry_poller/main.cpp` failed when our `hal/cosys_rpc_client.h` was included after the AirSim public headers. AirSim's headers define preprocessor symbols (`IS_ALIGNED`, macros in `common_utils/StrictMode.hpp`) that collide with identifiers used in our HAL wrapper.
+
+**Fix:** Include `hal/cosys_rpc_client.h` *first*, then the AirSim headers. Added a one-line comment in `main.cpp` flagging the ordering constraint so future edits don't re-break it.
+
+**Found by:** First compile attempt of the new binary during #612 diagnostic-infra work.
+
+**Regression test:** `cmake --build build --target cosys_telemetry_poller` succeeds with `-Werror -Wall -Wextra`.
+
+---
+
 ## SLAM / VIO (Process 3)
 
 ---

--- a/docs/tracking/BUG_FIXES.md
+++ b/docs/tracking/BUG_FIXES.md
@@ -854,74 +854,7 @@ cam_pose.linear() = q.toRotationMatrix() * R_body_from_cam;
 
 **Regression test:** Run scenario 33; confirm ≥20% of voxels cluster near the cube's altitude band (not the drone's altitude). Before fix: 0%. After fix: 34%.
 
----
-
-### Fix #56 — `CpuSemanticProjector` Mask-Convention Mismatch (Issue #612)
-
-**Date:** 2026-04-23
-**Severity:** High
-**Files:** `common/hal/include/hal/cpu_semantic_projector.h`
-
-**What:** `CpuSemanticProjector::project()` assumed masks were bbox-local (`mask_width ≈ bbox.w`, indexed with bbox-local `(u, v)`). `SimulatedSAMBackend` happened to produce bbox-local masks, so the assumption held accidentally. When `EdgeContourSAMBackend` or `FastSAMInferenceBackend` plugged in — both produce full-image masks (input-frame resolution) — the projector indexed the full mask with bbox-local coordinates, reading the top-left 32×32 patch of the whole frame instead of the masked region inside the bbox.
-
-**Why (Root Cause):** Undocumented interface: `SAMBackend::run()` returns a mask buffer but does not specify whether its dimensions are bbox-local or full-image, and the downstream projector baked in the simulated backend's convention.
-
-**Fix:** Auto-detect the mask convention inside the projector: if `mask_width >= bbox.w * 1.5f`, treat the mask as full-image and index with global `(u, v)`; otherwise preserve the bbox-local path for backward compatibility. Ratio of 1.5 chosen so small rounding gaps don't trigger the full-image path.
-
-**Found by:** `path_a_voxel_trace.jsonl` — for the same mask set, voxel count per batch was ~3 with the wrong interpretation vs ~25 with the correct one.
-
-**Regression test:** Scenario 33 logs `[MaskProj] Published N voxels (batch_size=M)` with N consistently in the 20–30 range per batch for FastSAM output.
-
----
-
-### Fix #57 — SAM Backend Factory Hard-Coded Simulated Backend (Issue #612)
-
-**Date:** 2026-04-23
-**Severity:** High
-**Files:** `process2_perception/src/main.cpp`
-
-**What:** The PATH A construction block in P2 always constructed `SimulatedSAMBackend` even when `perception.path_a.sam.backend` was set to `fastsam` or `edge_contour`. Config was silently ignored — no warning, no error. Users flipping the backend field saw no effect on behaviour.
-
-**Why (Root Cause):** Early scaffolding left a hard-coded `auto sam = std::make_unique<SimulatedSAMBackend>(...);` line behind the PATH A enabled gate. The `InferenceBackendFactory::create_inference_backend(cfg, sam_section)` function existed but wasn't called.
-
-**Fix:** Route through the factory:
-
-```cpp
-auto sam = InferenceBackendFactory::create_inference_backend(cfg, sam_section);
-```
-
-Process-startup logs now identify the selected backend so the user sees which one actually loaded.
-
-**Found by:** Log inspection after confirming `sam.backend=fastsam` in the merged config but no `[FastSAM]` initialisation line appeared in `perception.log`.
-
-**Regression test:** `perception.log` contains `[SAM] Backend initialised: <backend_name>` matching `perception.path_a.sam.backend` in the merged config.
-
----
-
-### Fix #58 — FastSAM ONNX Has `Floor` Node OpenCV DNN 4.10 Can't Parse (Issue #612)
-
-**Date:** 2026-04-23
-**Severity:** Medium
-**Files:** `models/download_fastsam.sh`
-
-**What:** `cv::dnn::readNetFromONNX("models/fastsam_s.onnx")` threw on load. The Ultralytics FastSAM-s export includes a `Floor` node at `/model.10/Floor` (a type coercion for the proposal decoder) that OpenCV DNN's ONNX importer doesn't support.
-
-**Error messages (searchable):**
-
-- `OpenCV(4.10.0) Error: Can't create layer "/model.10/Floor" of type "Floor" in function 'getLayerInstance'`
-
-**Why (Root Cause):** OpenCV DNN's ONNX op coverage lags PyTorch's export graph. `onnxsim` (onnx-simplifier) constant-folds the Floor node into its static inputs, eliminating it from the runtime graph.
-
-**Fix:** `models/download_fastsam.sh` pipes the Ultralytics PT→ONNX export through `onnxsim` before writing `models/fastsam_s.onnx`:
-
-```bash
-python3 -c "from ultralytics import FastSAM; FastSAM('FastSAM-s.pt').export(format='onnx', opset=12)"
-onnxsim FastSAM-s.onnx models/fastsam_s.onnx
-```
-
-**Found by:** First attempt to load the FastSAM ONNX in `perception.log` — crash was deterministic on load.
-
-**Regression test:** `bash models/download_fastsam.sh` succeeds, and a subsequent `cv::dnn::readNetFromONNX` load does not throw. (Covered end-to-end by scenario 33.)
+**Attribution note:** An earlier draft of this changelog included entries (Fix #56–#58, #60) attributing the mask-convention auto-detect, SAM factory routing, FastSAM ONNX `onnxsim` post-pass, and the `OccupancyGrid3D::insert_voxels()` ground-plane filter / position clamp / inflation reduction to this PR. Those changes were actually authored by PRs #609 / #611 (the integration-branch parents this PR was cut from) — `common/hal/include/hal/cpu_semantic_projector.h`, `process4_mission_planner/include/planner/occupancy_grid_3d.h`, and `models/download_fastsam.sh` are unmodified by PR #614. The entries were removed. The real #612 PATH A fixes in this PR are **Fix #55 (camera→body extrinsic), Fix #59 (kMaxProposals bump), Fix #61 (yaw_towards_velocity), Fix #62 (telemetry-poller include order)** plus the diagnostic infrastructure (PathATrace, cosys_telemetry_poller, plot_voxel_trace.py).
 
 ---
 
@@ -944,33 +877,6 @@ onnxsim FastSAM-s.onnx models/fastsam_s.onnx
 **Found by:** `perception.log` repeatedly emitting `[FastSAM] parse_raw_output: cols=21504 exceeds ...` on every frame, resulting in zero masks handed to the projector.
 
 **Regression test:** Scenario 33 logs `[FastSAM] Parsed N masks` with N in the 200–500 range per frame for the Blocks environment.
-
----
-
-### Fix #60 — Ground-Texture Ghost Voxels Pollute Static Grid Layer (Issue #612)
-
-**Date:** 2026-04-23
-**Severity:** High
-**Files:** `common/hal/include/hal/cpu_semantic_projector.h`, `process4_mission_planner/include/planner/occupancy_grid_3d.h`
-
-**What:** Depth Anything V2's metric depth drifts noticeably past ~15m; combined with a 3D inflation radius of 2 cells (a 5×5×5 = 125-cell neighbourhood), distant ground-texture pixels produced phantom voxels at `z≈0` that the grid permanently promoted. The D\* Lite planner's start-cell kept ending up inside inflated phantom obstacles, forcing reverse-only replans and eventually `STUCK count 4 exceeded cap 3`.
-
-**Symptom:** Scenario 33 logs showed `[Grid]` static cell count climbing past 800 during survey, `[D*Lite] No path` warnings, and the drone repeatedly reversing without lateral motion.
-
-**Why (Root Cause):** Three layered defects that amplified each other:
-
-1. `CpuSemanticProjector::sample_depth()` accepted any depth value DA V2 returned, including the multi-metre drifts at the horizon.
-2. `OccupancyGrid3D` had no ground-plane filter, so any voxel with `z` near zero got promoted.
-3. 3D inflation radius 2 meant one noisy voxel contaminated 125 cells instead of 27.
-
-**Fix (three layers, all conservative):**
-1. `sample_depth()` — clamp depth > 20m to zero (skip the sample) via `constexpr float kMaxObstacleDepth = 20.0f`.
-2. `OccupancyGrid3D::insert_voxels()` — reject voxels with `z < 0.3f` (ground) and clamp `|x|, |y|, |z| ≤ position_clamp_m` (new config key `mission_planner.occupancy_grid.voxel_input.position_clamp_m`, default 1000m).
-3. Lowered inflation radius from 2 → 1 cell in `insert_voxels()` (3×3×3 neighbourhood).
-
-**Found by:** `[Grid] 800+ static` combined with top-down plotter showing voxel scatter at ground level along the drone's trajectory (not at scene objects).
-
-**Regression test:** Scenario 33 — static cell growth capped at ~180 at survey-end; zero `[D*Lite] No path` warnings in the working run.
 
 ---
 

--- a/docs/tracking/DESIGN_RATIONALE.md
+++ b/docs/tracking/DESIGN_RATIONALE.md
@@ -807,3 +807,55 @@ Gray-area decisions where both sides are defensible. Each entry captures the que
 
 **Date:** 2026-04-22 (PR #604 review, E5.4 MaskDepthProjector)
 
+## DR-033: `PathATrace` JSONL Writer on Flight-Critical `mask_projection_thread`
+
+**Question:** PR #614 review (review-concurrency, P1): `PathATrace::record_batch()` performs `std::ofstream` I/O directly on `mask_projection_thread`, which is one of P2's flight-critical perception threads. Glibc's `std::ofstream` takes a streambuf sentry / write lock internally; this is the same class of hazard the "observability on flight-critical threads" rule in `docs/guides/CPP_PATTERNS_GUIDE.md` and CLAUDE.md is built to prevent. Should the diagnostic writer be reworked to buffer through an SPSC ring + dedicated IO thread before it ships?
+
+**For the SPSC-ring approach:**
+
+- Removes the (small) streambuf lock from the hot path entirely — the ring is lock-free.
+- Aligns with `LatencyTracker` / `TripleBuffer` patterns already used for hot-path telemetry.
+- Makes the production-always-safe story easier to state: "PATH A tracing is measurable-cost-free even when enabled."
+
+**For keeping the direct `ofstream` call (our decision):**
+
+- The CLAUDE.md rule reads *"SHOULD NOT be called from flight-critical threads without documented justification"*. This DR is the justification.
+- `PathATrace` is opt-in via config key `perception.path_a.diag.trace_voxels`, **default `false`** — production configs never flip it on. Scenario 33 turns it on because it's a diagnostic scenario; no other scenario enables it.
+- The `enabled_` short-circuit is a single `bool` load at the top of `record_batch()`. When disabled, cost is one load + predicted branch — zero I/O, zero allocation.
+- When the user enables the trace, they are *already opting out of the production latency envelope* — the whole point is to get visibility during diagnosis, not to measure production latency. Adding a second thread + SPSC ring for a tool that only runs under a diagnostic config is over-engineering for the use case it exists to serve.
+- Same rationale recently codified for `LatencyProfiler` wiring in DR-022 — opt-in observability on control threads is acceptable when the opt-in gate is a default-false config and the hot-path cost when disabled is zero.
+- The companion `cosys_telemetry_poller` follows the same pattern (10 Hz direct `ofstream` on a dedicated polling thread that only exists in diagnostic runs).
+
+**Decision:** Keep the direct `ofstream` call in `record_batch()`. Document the constraint in the header:
+
+- file-level comment names the rule and the DR.
+- method-level comment on `record_batch()` states single-writer / not-thread-safe.
+- code-level: the `enabled_` short-circuit is the first statement so the hot-path cost is one predicted branch.
+
+CI hygiene (follow-up): add a lint that greps non-diag scenarios' `config_overrides` for `trace_voxels: true` and fails if found.
+
+**Revisit when:** If a production config ever wants `trace_voxels=true` (e.g., black-box flight recorder for certification evidence), promote to the SPSC-ring design before shipping.
+
+**Date:** 2026-04-23 (PR #614 review, review-concurrency P1)
+
+## DR-034: Four `BUG_FIXES` Entries Removed — Attribution Belonged to Earlier PRs
+
+**Question:** PR #614 review (review-api-contract, P1): An earlier draft of `BUG_FIXES.md` added entries Fix #56, #57, #58, #60 for PATH A fixes (mask-convention auto-detect, SAM factory routing, FastSAM `onnxsim` post-pass, `OccupancyGrid3D::insert_voxels` ground-plane filter / position clamp / inflation reduction). The reviewer pointed out these don't appear in PR #614's diff. Should they be relabelled, removed, or kept with a pointer to the real authoring PR?
+
+**Audit result (confirmed by git diff against the integration-branch tip `992b888`):**
+
+- `common/hal/include/hal/cpu_semantic_projector.h` — unchanged by PR #614; the 1.5× mask-convention auto-detect and 20 m depth clamp were in place as of PR #611.
+- `common/hal/include/hal/fastsam_inference_backend.h` — PR #614 only bumps `kMaxProposals` 16384 → 65536 (Fix #59). The wider FastSAM wiring and `onnxsim` post-pass predate this branch.
+- `process4_mission_planner/include/planner/occupancy_grid_3d.h` — unchanged by PR #614. `insert_voxels()` including ground filter, position clamp, and 1-cell inflation were in place at the integration-branch tip.
+- `models/download_fastsam.sh` — unchanged by PR #614 (repo stores it as a symlink into the parent project).
+
+**For relabel-and-point-to-real-PR:** keeps a searchable record of *what* the fix was; the PR pointer tells readers where to dig if they want the commit.
+
+**For removal (our decision):** `BUG_FIXES.md` is a changelog, not a retrospective catalogue. Every other entry in the file is a thing the commit/PR it references actually did. Inserting re-descriptions of earlier work violates that convention and would let future readers wrongly cite this PR as the authoring commit. Attribution notes at the end of a single adjacent entry (Fix #55) are enough to point curious readers at where the earlier work really happened.
+
+**Decision:** Remove Fix #56, #57, #58, #60. Keep Fix #55 (camera extrinsic), #59 (kMaxProposals), #61 (yaw_towards_velocity), #62 (poller include order) — these genuinely land in PR #614. Numbering gap is consistent with pre-existing gaps elsewhere in the file.
+
+**Revisit when:** If `BUG_FIXES.md` ever grows a "Changes inherited from integration branch" section, the removed entries could be moved there with their real PR references.
+
+**Date:** 2026-04-23 (PR #614 review, review-api-contract P1)
+

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -56,6 +56,22 @@ static std::atomic<bool> g_running{true};
 // ensuring in-flight data is processed rather than dropped.
 static std::atomic<int> g_shutdown_phase{0};
 
+// ── Camera → body extrinsic rotation (PR #614 / Issue #612) ─────────
+// OpenCV camera optical frame (X=right, Y=down, Z=forward) →
+// aerospace-ENU body frame (X=forward, Y=left, Z=up).  Hoisted to file
+// scope so the constant is built once at program start and reviewers
+// reading `mask_projection_thread` see the frame convention at the top
+// of the file, next to the phased-shutdown globals.  Eigen types aren't
+// constexpr-constructible, so a meyers singleton is the idiomatic fit.
+static const Eigen::Matrix3f& R_body_from_cam() {
+    static const Eigen::Matrix3f kMatrix = (Eigen::Matrix3f() << 0, 0, 1,  //
+                                            -1, 0, 0,                      //
+                                            0, -1, 0                       //
+                                            )
+                                               .finished();
+    return kMatrix;
+}
+
 // ── Inference thread ────────────────────────────────────────
 // Stops when shutdown_phase >= 1.  No drain needed — inference is the
 // pipeline source; stopping it is what triggers downstream drains.
@@ -286,18 +302,10 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
         }
         q.normalize();
 
-        // OpenCV camera (X=right, Y=down, Z=forward) → aerospace-ENU body
-        // (X=forward, Y=left, Z=up).  Stored as `static` so the constant matrix
-        // is built once and reused across ticks.
-        static const Eigen::Matrix3f R_body_from_cam = (Eigen::Matrix3f() << 0, 0,
-                                                        1,         // body_X ← cam_Z (forward)
-                                                        -1, 0, 0,  // body_Y ← −cam_X (left)
-                                                        0, -1, 0   // body_Z ← −cam_Y (up)
-                                                        )
-                                                           .finished();
-
+        // See file-scope R_body_from_cam() — definition lives at the top of
+        // main.cpp next to the phased-shutdown globals.
         Eigen::Affine3f cam_pose = Eigen::Affine3f::Identity();
-        cam_pose.linear()        = q.toRotationMatrix() * R_body_from_cam;
+        cam_pose.linear()        = q.toRotationMatrix() * R_body_from_cam();
         cam_pose.translation()   = Eigen::Vector3f(static_cast<float>(latest_pose->translation[0]),
                                                    static_cast<float>(latest_pose->translation[1]),
                                                    static_cast<float>(latest_pose->translation[2]));
@@ -340,6 +348,13 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
         }
         voxel_pub.publish(*batch);
         ++published_count;
+
+        // First-publish marker — short runs that fail before 50 batches still
+        // emit "[MaskProj] Published …" once, so scenario pass_criteria log
+        // greps (see config/scenarios/33_non_coco_obstacles.json) still fire.
+        if (published_count == 1) {
+            DRONE_LOG_INFO("[MaskProj] Published first batch — {} voxels", batch->num_voxels);
+        }
 
         // Diagnostic trace (Issue #612).  Inert when disabled.  Writes the
         // full pose / bboxes / voxel positions for off-line analysis of the
@@ -1126,11 +1141,21 @@ int main(int argc, char* argv[]) {
 
     // Launch PATH A threads (Epic #520, Issue #608) if enabled + initialised.
     // Each needs its own video subscriber (Zenoh SHM topology — see depth_video_sub pattern).
+    //
+    // IMPORTANT (PR #614 review): declaration order matters for exception-safety.
+    // `path_a_trace` (the unique_ptr) MUST be declared BEFORE `t_sam` / `t_mask_proj`
+    // so that at scope exit the threads destruct FIRST (std::thread dtor runs
+    // std::terminate on a still-joinable thread, so they must already be joined
+    // on the normal path — which we do at Phase 2 — but on an exception path
+    // between construction and the join the dtor order still matters).
+    // Declaring trace before the threads means: on scope exit, threads destruct
+    // first, and *their* dtor is what enforces the join-or-terminate invariant.
+    // The trace stays alive for the entire join window.
     std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::VideoFrame>> sam_video_sub;
     std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::Pose>>       pathA_pose_sub;
+    std::unique_ptr<drone::util::PathATrace>                         path_a_trace;
     std::thread                                                      t_sam;
     std::thread                                                      t_mask_proj;
-    std::unique_ptr<drone::util::PathATrace>                         path_a_trace;
     if (path_a_active) {
         sam_video_sub =
             ctx.bus.subscribe<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -21,6 +21,7 @@
 #include "util/config_keys.h"
 #include "util/diagnostic.h"
 #include "util/latency_profiler.h"
+#include "util/path_a_trace.h"
 #include "util/process_context.h"
 #include "util/scoped_timer.h"
 #include "util/sd_notify.h"
@@ -201,7 +202,8 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
                                    drone::ipc::ISubscriber<drone::ipc::Pose>& pose_sub,
                                    drone::ipc::IPublisher<drone::ipc::SemanticVoxelBatch>& voxel_pub,
                                    std::atomic<int>&                      shutdown_phase,
-                                   drone::perception::MaskDepthProjector& projector) {
+                                   drone::perception::MaskDepthProjector& projector,
+                                   drone::util::PathATrace*               trace) {
     DRONE_LOG_INFO("[MaskProj] Thread started — publishing to {}",
                    drone::ipc::topics::SEMANTIC_VOXELS);
 
@@ -263,7 +265,17 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
             det_hal.push_back(std::move(h));
         }
 
-        // Build camera pose as an Affine3f from the SLAM quaternion/translation.
+        // Build camera pose from the SLAM body pose.  Two stages:
+        //   1. T_world_body — SLAM quaternion + translation (drone body frame
+        //      in world coordinates).
+        //   2. R_body_from_cam — static camera→body extrinsic rotation.  The
+        //      projector back-projects in the OpenCV camera convention
+        //      (X=right, Y=down, Z=forward).  Without this rotation, the
+        //      camera's forward axis (depth) was landing on the body's up
+        //      axis (altitude) — every voxel ended up 5-30 m above the drone
+        //      instead of in front of it.  Diagnosed via Issue #612 voxel
+        //      trace: 10 321 voxels over a full scenario-33 run with zero
+        //      within 3 m of the actual cube-collision point.
         Eigen::Quaternionf q(static_cast<float>(latest_pose->quaternion[0]),
                              static_cast<float>(latest_pose->quaternion[1]),
                              static_cast<float>(latest_pose->quaternion[2]),
@@ -273,8 +285,19 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
             continue;
         }
         q.normalize();
+
+        // OpenCV camera (X=right, Y=down, Z=forward) → aerospace-ENU body
+        // (X=forward, Y=left, Z=up).  Stored as `static` so the constant matrix
+        // is built once and reused across ticks.
+        static const Eigen::Matrix3f R_body_from_cam = (Eigen::Matrix3f() << 0, 0,
+                                                        1,         // body_X ← cam_Z (forward)
+                                                        -1, 0, 0,  // body_Y ← −cam_X (left)
+                                                        0, -1, 0   // body_Z ← −cam_Y (up)
+                                                        )
+                                                           .finished();
+
         Eigen::Affine3f cam_pose = Eigen::Affine3f::Identity();
-        cam_pose.linear()        = q.toRotationMatrix();
+        cam_pose.linear()        = q.toRotationMatrix() * R_body_from_cam;
         cam_pose.translation()   = Eigen::Vector3f(static_cast<float>(latest_pose->translation[0]),
                                                    static_cast<float>(latest_pose->translation[1]),
                                                    static_cast<float>(latest_pose->translation[2]));
@@ -317,6 +340,15 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
         }
         voxel_pub.publish(*batch);
         ++published_count;
+
+        // Diagnostic trace (Issue #612).  Inert when disabled.  Writes the
+        // full pose / bboxes / voxel positions for off-line analysis of the
+        // "voxels aren't landing on the cube" class of bugs.
+        if (trace && trace->enabled()) {
+            trace->record_batch(masks_opt->timestamp_ns,
+                                static_cast<uint64_t>(masks_opt->frame_sequence), *latest_pose,
+                                det_hal, masks_opt->masks, voxels);
+        }
 
         if (published_count % 50 == 0) {
             DRONE_LOG_INFO("[MaskProj] Published {} batches — last batch: {} voxels, {} skipped",
@@ -1098,16 +1130,28 @@ int main(int argc, char* argv[]) {
     std::unique_ptr<drone::ipc::ISubscriber<drone::ipc::Pose>>       pathA_pose_sub;
     std::thread                                                      t_sam;
     std::thread                                                      t_mask_proj;
+    std::unique_ptr<drone::util::PathATrace>                         path_a_trace;
     if (path_a_active) {
         sam_video_sub =
             ctx.bus.subscribe<drone::ipc::VideoFrame>(drone::ipc::topics::VIDEO_MISSION_CAM);
         pathA_pose_sub = ctx.bus.subscribe<drone::ipc::Pose>(drone::ipc::topics::SLAM_POSE);
+
+        // Diagnostic voxel trace (Issue #612).  Opt-in via
+        // perception.path_a.diag.trace_voxels; output path defaults under
+        // drone_logs/ so scenario runs land trace next to the run's other logs.
+        const bool trace_enabled =
+            ctx.cfg.get<bool>(drone::cfg_key::perception::path_a::DIAG_TRACE_VOXELS, false);
+        const std::string trace_path =
+            ctx.cfg.get<std::string>(drone::cfg_key::perception::path_a::DIAG_TRACE_PATH,
+                                     "drone_logs/path_a_voxel_trace.jsonl");
+        path_a_trace = std::make_unique<drone::util::PathATrace>(trace_enabled, trace_path);
+
         t_sam       = std::thread(sam_thread, std::ref(*sam_video_sub), std::ref(sam_to_projection),
                                   std::ref(g_shutdown_phase), std::ref(*sam_backend));
-        t_mask_proj = std::thread(mask_projection_thread, std::ref(sam_to_projection),
-                                  std::ref(inference_to_projection), std::ref(depth_to_projection),
-                                  std::ref(*pathA_pose_sub), std::ref(*voxel_pub),
-                                  std::ref(g_shutdown_phase), std::ref(*mask_projector));
+        t_mask_proj = std::thread(
+            mask_projection_thread, std::ref(sam_to_projection), std::ref(inference_to_projection),
+            std::ref(depth_to_projection), std::ref(*pathA_pose_sub), std::ref(*voxel_pub),
+            std::ref(g_shutdown_phase), std::ref(*mask_projector), path_a_trace.get());
     }
 
     // ── Thread watchdog + health publisher ──────────────────

--- a/process4_mission_planner/include/planner/grid_planner_base.h
+++ b/process4_mission_planner/include/planner/grid_planner_base.h
@@ -59,9 +59,16 @@ struct GridPlannerConfig {
     int   max_static_cells   = 0;              // Cap on promoted static cells (0 = unlimited)
     bool  yaw_towards_travel = true;           // Face sensors toward next waypoint during NAVIGATE
     float yaw_smoothing_rate = 0.3f;  // EMA alpha for yaw transitions (0=frozen, 1=instant)
-    float snap_approach_bias = 0.5f;  // Approach-direction penalty for snap fallback
-    bool  prediction_enabled = true;  // Enable velocity-based obstacle prediction
-    float prediction_dt_s    = 2.0f;  // Prediction horizon (seconds into the future)
+    // When `yaw_towards_velocity` is true (and `yaw_towards_travel` also true),
+    // the yaw target follows the smoothed velocity command instead of the
+    // bee-line to the next waypoint. Points the camera at the actual flight
+    // direction during obstacle detours so PATH A can voxelise the obstacle's
+    // far face before the drone clips it. Default false to preserve existing
+    // behaviour; scenario 33 turns it on (Issue #612).
+    bool  yaw_towards_velocity = false;
+    float snap_approach_bias   = 0.5f;  // Approach-direction penalty for snap fallback
+    bool  prediction_enabled   = true;  // Enable velocity-based obstacle prediction
+    float prediction_dt_s      = 2.0f;  // Prediction horizon (seconds into the future)
 };
 
 // ─────────────────────────────────────────────────────────────
@@ -390,9 +397,25 @@ public:
         // Yaw-towards-travel: face sensors toward the next waypoint.
         // Uses waypoint direction (not path step) to avoid feedback loop
         // where camera view → grid → planner → yaw → camera causes circling.
+        //
+        // When `yaw_towards_velocity` is true, override the bee-line-to-goal
+        // direction with the actual smoothed velocity command — the camera
+        // tracks the *real* flight direction during obstacle detours so PATH A
+        // can voxelise the obstacle's far face before the drone clips it
+        // (Issue #612 — observed: drone routed around one cube face, then
+        // clipped the unseen face on the way back to the waypoint).  Reverts
+        // to bee-line direction when velocity magnitude is too small to
+        // estimate a heading, so we don't yaw randomly during hover.
         if (config_.yaw_towards_travel) {
-            const float ytt_dx   = target.x - px;
-            const float ytt_dy   = target.y - py;
+            float ytt_dx = target.x - px;
+            float ytt_dy = target.y - py;
+            if (config_.yaw_towards_velocity) {
+                const float vmag = std::sqrt(smooth_vx_ * smooth_vx_ + smooth_vy_ * smooth_vy_);
+                if (vmag > 0.4f) {
+                    ytt_dx = smooth_vx_;
+                    ytt_dy = smooth_vy_;
+                }
+            }
             const float ytt_dist = std::sqrt(ytt_dx * ytt_dx + ytt_dy * ytt_dy);
             if (ytt_dist > 0.5f) {
                 constexpr float kPi     = 3.14159265358979323846f;

--- a/process4_mission_planner/include/planner/grid_planner_base.h
+++ b/process4_mission_planner/include/planner/grid_planner_base.h
@@ -65,10 +65,16 @@ struct GridPlannerConfig {
     // direction during obstacle detours so PATH A can voxelise the obstacle's
     // far face before the drone clips it. Default false to preserve existing
     // behaviour; scenario 33 turns it on (Issue #612).
-    bool  yaw_towards_velocity = false;
-    float snap_approach_bias   = 0.5f;  // Approach-direction penalty for snap fallback
-    bool  prediction_enabled   = true;  // Enable velocity-based obstacle prediction
-    float prediction_dt_s      = 2.0f;  // Prediction horizon (seconds into the future)
+    bool yaw_towards_velocity = false;
+
+    // Minimum velocity magnitude (m/s) below which `yaw_towards_velocity`
+    // falls back to the bee-line-to-goal yaw.  Prevents jitter when the
+    // drone is hovering or moving slower than sensor noise.  Tuned against
+    // scenario 33 detour profile (nominal detour speed 1.5-2.5 m/s).
+    float yaw_velocity_threshold_mps = 0.4f;
+    float snap_approach_bias         = 0.5f;  // Approach-direction penalty for snap fallback
+    bool  prediction_enabled         = true;  // Enable velocity-based obstacle prediction
+    float prediction_dt_s            = 2.0f;  // Prediction horizon (seconds into the future)
 };
 
 // ─────────────────────────────────────────────────────────────
@@ -411,7 +417,7 @@ public:
             float ytt_dy = target.y - py;
             if (config_.yaw_towards_velocity) {
                 const float vmag = std::sqrt(smooth_vx_ * smooth_vx_ + smooth_vy_ * smooth_vy_);
-                if (vmag > 0.4f) {
+                if (vmag > config_.yaw_velocity_threshold_mps) {
                     ytt_dx = smooth_vx_;
                     ytt_dy = smooth_vy_;
                 }

--- a/process4_mission_planner/include/planner/occupancy_grid_3d.h
+++ b/process4_mission_planner/include/planner/occupancy_grid_3d.h
@@ -228,6 +228,17 @@ public:
 
         for (uint32_t i = 0; i < n; ++i) {
             const auto& v = voxels[i];
+            // Finite-value guard (PR #614 fault-recovery review).  `abs(NaN) >
+            // clamp` is false by IEEE-754, so NaN positions used to slip
+            // through the clamp below and land in `world_to_grid`, where
+            // `round(NaN/res)` is implementation-defined — producing phantom
+            // cells at arbitrary grid indices with no log trail.  Reject
+            // non-finite values explicitly and count under the clamp bucket.
+            if (!std::isfinite(v.position_x) || !std::isfinite(v.position_y) ||
+                !std::isfinite(v.position_z)) {
+                ++s.clamped_dropped;
+                continue;
+            }
             // Position clamp (PR #609 review P3 deferred to consumer boundary).
             // Reject voxels whose |x|, |y|, or |z| exceeds the world extent.
             if (clamp > 0.0f && (std::abs(v.position_x) > clamp || std::abs(v.position_y) > clamp ||

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -228,6 +228,9 @@ int main(int argc, char* argv[]) {
     planner_cfg.yaw_towards_velocity =
         ctx.cfg.get<bool>(drone::cfg_key::mission_planner::path_planner::YAW_TOWARDS_VELOCITY,
                           planner_cfg.yaw_towards_velocity);
+    planner_cfg.yaw_velocity_threshold_mps = ctx.cfg.get<float>(
+        drone::cfg_key::mission_planner::path_planner::YAW_VELOCITY_THRESHOLD_MPS,
+        planner_cfg.yaw_velocity_threshold_mps);
     planner_cfg.snap_approach_bias =
         ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SNAP_APPROACH_BIAS,
                            planner_cfg.snap_approach_bias);

--- a/process4_mission_planner/src/main.cpp
+++ b/process4_mission_planner/src/main.cpp
@@ -225,6 +225,9 @@ int main(int argc, char* argv[]) {
     planner_cfg.yaw_smoothing_rate =
         ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::YAW_SMOOTHING_RATE,
                            planner_cfg.yaw_smoothing_rate);
+    planner_cfg.yaw_towards_velocity =
+        ctx.cfg.get<bool>(drone::cfg_key::mission_planner::path_planner::YAW_TOWARDS_VELOCITY,
+                          planner_cfg.yaw_towards_velocity);
     planner_cfg.snap_approach_bias =
         ctx.cfg.get<float>(drone::cfg_key::mission_planner::path_planner::SNAP_APPROACH_BIAS,
                            planner_cfg.snap_approach_bias);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -353,6 +353,9 @@ endif()
 # ── D* Lite Path Planner tests (Issue #158) ────────────────
 add_drone_test(test_dstar_lite_planner test_dstar_lite_planner.cpp)
 
+# ── PATH A Diagnostic Trace tests (Issue #612, PR #614) ──────
+add_drone_test(test_path_a_trace test_path_a_trace.cpp)
+
 # ── Dynamic Obstacle Prediction tests (Issue #256) ───────
 add_drone_test(test_obstacle_prediction test_obstacle_prediction.cpp)
 

--- a/tests/run_scenario_cosys.sh
+++ b/tests/run_scenario_cosys.sh
@@ -14,7 +14,13 @@
 #   ./tests/run_scenario_cosys.sh config/scenarios/29_cosys_perception.json --gui --verbose
 #
 # Options:
-#   --base-config <path>    Base config (default: config/cosys_airsim.json)
+#   --base-config <path>    Base config (default: resolved from the scenario).
+#                           Resolution precedence:
+#                             1. this flag, if given
+#                             2. scenario.base_config inside the scenario JSON
+#                             3. config/cosys_airsim_dev.json, if it exists
+#                             4. config/cosys_airsim.json (cloud profile fallback)
+#                           Paths must stay within PROJECT_DIR (no ../ escape).
 #   --log-dir <path>        Log output directory (default: drone_logs/scenarios_cosys)
 #   --timeout <seconds>     Override scenario timeout
 #   --dry-run               Parse scenario, show plan, don't execute
@@ -23,6 +29,17 @@
 #   --json-logs             Enable structured JSON log output
 #   --ipc <shm|zenoh>       Override IPC backend (default: from base config)
 #   --env <name>            UE5 environment name (default: Blocks)
+#
+# Scenario JSON fields (auto-detected by the runner):
+#   scenario.base_config    Optional hint pointing at the base config overlay
+#                           that best matches this scenario (e.g.
+#                           "config/cosys_airsim_dev.json" for the dev profile).
+#                           Lets a scenario be launched without --base-config.
+#                           Path must stay inside PROJECT_DIR.
+#   perception.path_a.diag.trace_voxels   Opt-in voxel trace (Issue #612).
+#                           The runner rewrites trace_path to
+#                           <scenario_log_dir>/path_a_voxel_trace.jsonl so every
+#                           run is self-contained.
 #
 # Environment variables:
 #   COSYS_DIR    Path to Cosys-AirSim (default: third_party/cosys-airsim if present)
@@ -201,12 +218,39 @@ with open(sys.argv[4], 'w') as f:
 PYEOF
 }
 
+confine_to_project() {
+    # Return 0 iff $1 resolves to a path under $PROJECT_DIR.  Rejects symlink
+    # escapes and ../-escapes even if the intermediate path doesn't exist yet.
+    # Portable realpath(1) may not support --relative-base; use Python instead.
+    local candidate="$1"
+    python3 - "$candidate" "$PROJECT_DIR" <<'PYEOF' >/dev/null 2>&1
+import os, sys
+candidate, root = sys.argv[1], sys.argv[2]
+root_real = os.path.realpath(root)
+# Use realpath so symlink targets are evaluated; fall back to normpath if the
+# candidate does not exist yet (realpath still resolves parents).
+cand_real = os.path.realpath(candidate)
+if not (cand_real == root_real or cand_real.startswith(root_real + os.sep)):
+    sys.exit(1)
+PYEOF
+}
+
 resolve_base_config() {
     # Resolve the base config path against a scenario file.
     # Precedence: caller-provided override → scenario.base_config → dev → cloud.
+    #
+    # Security: the `scenario.base_config` hint is read from a JSON file we do
+    # NOT control (users can ship arbitrary scenarios).  A malicious hint like
+    # `"base_config": "../../etc/passwd"` would otherwise be parsed by
+    # merge_configs() and passed into every companion process.  Confine all
+    # resolved paths to $PROJECT_DIR; reject anything that escapes.
     local scenario_file="$1"
     local override="$2"
     if [[ -n "$override" ]]; then
+        if ! confine_to_project "$override"; then
+            echo -e "${RED}ERROR: --base-config '${override}' escapes project root${NC}" >&2
+            return 2
+        fi
         echo "$override"
         return 0
     fi
@@ -217,6 +261,10 @@ resolve_base_config() {
     if [[ -n "$hint" && "$hint" != "None" ]]; then
         if [[ "$hint" != /* ]]; then
             hint="${PROJECT_DIR}/${hint}"
+        fi
+        if ! confine_to_project "$hint"; then
+            echo -e "${RED}ERROR: scenario.base_config '${hint}' escapes project root${NC}" >&2
+            return 2
         fi
         echo "$hint"
         return 0
@@ -395,8 +443,12 @@ if [[ ! -f "$SCENARIO_FILE" ]]; then
     fi
 fi
 
-# Resolve base config now that we know which scenario is running
-BASE_CONFIG=$(resolve_base_config "$SCENARIO_FILE" "$BASE_CONFIG")
+# Resolve base config now that we know which scenario is running.
+# resolve_base_config returns exit code 2 on path-confinement failure; the
+# error message has already gone to stderr.
+if ! BASE_CONFIG=$(resolve_base_config "$SCENARIO_FILE" "$BASE_CONFIG"); then
+    exit 2
+fi
 if [[ ! -f "$BASE_CONFIG" ]]; then
     echo -e "${RED}ERROR: Base config not found: ${BASE_CONFIG}${NC}"
     exit 2
@@ -988,6 +1040,29 @@ if kill -0 "$UE5_PID" 2>/dev/null; then
     check "Cosys-AirSim (UE5) still running" 0
 else
     check "Cosys-AirSim (UE5) still running" 1
+fi
+
+# ── PATH A voxel-on-target regression check (PR #614 review) ──
+# Addresses the review-test-quality P1: without this check, a Fix #55
+# regression (wrong camera extrinsic → voxels 8–12 m off) would not fail
+# the scenario — every `pass_criteria.log_contains` marker fires at init,
+# so a broken pipeline still "passes" until the LANDED gate.
+VOXEL_TRACE="${SCENARIO_LOG_DIR}/path_a_voxel_trace.jsonl"
+VOXEL_CHECK="${PROJECT_DIR}/tools/check_voxel_on_target.py"
+if [[ -f "$VOXEL_TRACE" && -x "$VOXEL_CHECK" && -n "$SCENE_FILE" && -f "$SCENE_FILE" ]]; then
+    echo ""
+    echo "PATH A voxel-on-target check:"
+    # Pull threshold from scenario JSON if present; otherwise use the default.
+    VOX_MIN_RATIO=$(json_get "$SCENARIO_FILE" "pass_criteria.voxel_on_target_ratio_min")
+    VOX_RADIUS=$(json_get "$SCENARIO_FILE" "pass_criteria.voxel_on_target_radius_m")
+    VOX_ARGS=(--trace "$VOXEL_TRACE" --scene "$SCENE_FILE")
+    [[ -n "$VOX_MIN_RATIO" && "$VOX_MIN_RATIO" != "None" ]] && VOX_ARGS+=(--min-ratio "$VOX_MIN_RATIO")
+    [[ -n "$VOX_RADIUS"    && "$VOX_RADIUS"    != "None" ]] && VOX_ARGS+=(--radius-m "$VOX_RADIUS")
+    if python3 "$VOXEL_CHECK" "${VOX_ARGS[@]}" 2>&1 | tee "${SCENARIO_LOG_DIR}/voxel_on_target.log"; then
+        check "Voxel-on-target ratio within threshold" 0
+    else
+        check "Voxel-on-target ratio within threshold" 1
+    fi
 fi
 if ss -tlnp 2>/dev/null | grep -q ":${COSYS_RPC_PORT}"; then
     check "RPC port ${COSYS_RPC_PORT} still open" 0

--- a/tests/run_scenario_cosys.sh
+++ b/tests/run_scenario_cosys.sh
@@ -42,7 +42,12 @@ BIN_DIR="${PROJECT_DIR}/build/bin"
 SCENARIOS_DIR="${PROJECT_DIR}/config/scenarios"
 DEPLOY_DIR="${PROJECT_DIR}/deploy"
 FAULT_INJECTOR="${BIN_DIR}/fault_injector"
-DEFAULT_BASE_CONFIG="${PROJECT_DIR}/config/cosys_airsim.json"
+# Default base config: picked at scenario-load time.  Order of precedence:
+#   1. --base-config CLI flag (explicit override)
+#   2. scenario.base_config field inside the scenario JSON (self-describing)
+#   3. config/cosys_airsim_dev.json  (dev profile — preferred for local runs)
+#   4. config/cosys_airsim.json      (cloud profile — fallback)
+DEFAULT_BASE_CONFIG=""   # populated after SCENARIO_FILE is resolved
 DEFAULT_LOG_DIR="${PROJECT_DIR}/drone_logs/scenarios_cosys"
 COSYS_RPC_PORT="${COSYS_RPC_PORT:-41451}"
 PX4_DIR="${PX4_DIR:-${HOME}/PX4-Autopilot}"
@@ -74,7 +79,7 @@ SCENARIO_NAME=""
 
 # ── Parse args ────────────────────────────────────────────────
 SCENARIO_FILE=""
-BASE_CONFIG="$DEFAULT_BASE_CONFIG"
+BASE_CONFIG=""   # empty = auto-resolve after scenario file is known
 LOG_DIR="$DEFAULT_LOG_DIR"
 TIMEOUT_OVERRIDE=""
 DRY_RUN=false
@@ -196,6 +201,33 @@ with open(sys.argv[4], 'w') as f:
 PYEOF
 }
 
+resolve_base_config() {
+    # Resolve the base config path against a scenario file.
+    # Precedence: caller-provided override → scenario.base_config → dev → cloud.
+    local scenario_file="$1"
+    local override="$2"
+    if [[ -n "$override" ]]; then
+        echo "$override"
+        return 0
+    fi
+    local hint=""
+    if [[ -f "$scenario_file" ]]; then
+        hint=$(json_get "$scenario_file" "scenario.base_config" 2>/dev/null || echo "")
+    fi
+    if [[ -n "$hint" && "$hint" != "None" ]]; then
+        if [[ "$hint" != /* ]]; then
+            hint="${PROJECT_DIR}/${hint}"
+        fi
+        echo "$hint"
+        return 0
+    fi
+    if [[ -f "${PROJECT_DIR}/config/cosys_airsim_dev.json" ]]; then
+        echo "${PROJECT_DIR}/config/cosys_airsim_dev.json"
+        return 0
+    fi
+    echo "${PROJECT_DIR}/config/cosys_airsim.json"
+}
+
 check() {
     local desc="$1"
     local result="$2"
@@ -226,7 +258,7 @@ check_prerequisites() {
         echo -e "${RED}ERROR: Build directory not found. Run: bash deploy/build.sh${NC}"
         ok=false
     fi
-    if [[ ! -f "$BASE_CONFIG" ]]; then
+    if [[ -n "$BASE_CONFIG" && ! -f "$BASE_CONFIG" ]]; then
         echo -e "${RED}ERROR: Base config not found: ${BASE_CONFIG}${NC}"
         ok=false
     fi
@@ -320,7 +352,10 @@ if [[ "$RUN_ALL" == "true" ]]; then
         echo -e "${BOLD}  Running: ${scenario_name}${NC}"
         echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
-        args=("$f" --base-config "$BASE_CONFIG" --log-dir "$LOG_DIR")
+        args=("$f" --log-dir "$LOG_DIR")
+        # Only forward --base-config if user explicitly set one; otherwise let
+        # the recursive call resolve per-scenario (scenario.base_config → dev → cloud).
+        [[ -n "$BASE_CONFIG" ]] && args+=(--base-config "$BASE_CONFIG")
         [[ -n "$TIMEOUT_OVERRIDE" ]] && args+=(--timeout "$TIMEOUT_OVERRIDE")
         [[ -n "$IPC_BACKEND" ]] && args+=(--ipc "$IPC_BACKEND")
         [[ "$GUI" == "true" ]] && args+=(--gui)
@@ -360,6 +395,14 @@ if [[ ! -f "$SCENARIO_FILE" ]]; then
     fi
 fi
 
+# Resolve base config now that we know which scenario is running
+BASE_CONFIG=$(resolve_base_config "$SCENARIO_FILE" "$BASE_CONFIG")
+if [[ ! -f "$BASE_CONFIG" ]]; then
+    echo -e "${RED}ERROR: Base config not found: ${BASE_CONFIG}${NC}"
+    exit 2
+fi
+echo -e "${CYAN}  Base config: ${BASE_CONFIG}${NC}"
+
 # Extract scenario metadata
 SCENARIO_NAME=$(json_get "$SCENARIO_FILE" "scenario.name")
 SCENARIO_DESC=$(json_get "$SCENARIO_FILE" "scenario.description")
@@ -385,8 +428,19 @@ if [[ -z "$SCENARIO_NAME" ]]; then
     exit 2
 fi
 
+# Prefix the log-dir name with the scenario number pulled from the filename
+# (e.g. "33_non_coco_obstacles.json" → "33_non_coco_obstacles").  Makes run
+# directories immediately grep-able / sortable by scenario number.
+SCENARIO_FILE_BASE=$(basename "$SCENARIO_FILE" .json)
+SCENARIO_NUM_PREFIX=$(echo "$SCENARIO_FILE_BASE" | grep -oE '^[0-9]+' || true)
+if [[ -n "$SCENARIO_NUM_PREFIX" && "$SCENARIO_NAME" != "${SCENARIO_NUM_PREFIX}_"* ]]; then
+    SCENARIO_DIR_NAME="${SCENARIO_NUM_PREFIX}_${SCENARIO_NAME}"
+else
+    SCENARIO_DIR_NAME="$SCENARIO_NAME"
+fi
+
 RUN_START_EPOCH=$(date +%s)
-SCENARIO_LOG_DIR=$(create_run_dir "$LOG_DIR" "$SCENARIO_NAME")
+SCENARIO_LOG_DIR=$(create_run_dir "$LOG_DIR" "$SCENARIO_DIR_NAME")
 
 echo ""
 echo -e "${BOLD}════════════════════════════════════════════════════${NC}"
@@ -418,6 +472,20 @@ with open(sys.argv[1], 'w') as f:
 PYEOF
 fi
 echo -e "  ${GREEN}✓${NC} Config merged → ${MERGED_CONFIG} (ipc=${IPC_BACKEND:-default})"
+
+# Route per-run diagnostic artifacts into the scenario log directory so every
+# run stays self-contained (#612). Only rewrites fields the scenario opted in.
+python3 - "$MERGED_CONFIG" "$SCENARIO_LOG_DIR" <<'PYEOF'
+import json, os, sys
+cfg_path, log_dir = sys.argv[1], sys.argv[2]
+with open(cfg_path) as f:
+    cfg = json.load(f)
+diag = cfg.get("perception", {}).get("path_a", {}).get("diag")
+if isinstance(diag, dict) and diag.get("trace_voxels"):
+    diag["trace_path"] = os.path.join(log_dir, "path_a_voxel_trace.jsonl")
+with open(cfg_path, "w") as f:
+    json.dump(cfg, f, indent=4)
+PYEOF
 
 EFFECTIVE_IPC="${IPC_BACKEND}"
 if [[ -z "$EFFECTIVE_IPC" ]]; then
@@ -501,6 +569,12 @@ cleanup_scenario() {
     echo "Cleaning up Cosys-AirSim scenario..."
     if [[ -n "${SCENARIO_LOG_DIR:-}" && "$SCENARIO_LOG_DIR" == *_RUNNING ]]; then
         SCENARIO_LOG_DIR=$(abort_run_dir "$SCENARIO_LOG_DIR")
+    fi
+    # Stop telemetry poller first so its JSONL flushes before UE5 goes away.
+    if [[ -n "${TELEMETRY_PID:-}" ]] && kill -0 "$TELEMETRY_PID" 2>/dev/null; then
+        kill -SIGTERM "$TELEMETRY_PID" 2>/dev/null || true
+        sleep 1
+        kill -SIGKILL "$TELEMETRY_PID" 2>/dev/null || true
     fi
     # Destroy RPC-spawned scene objects while UE5 is still alive.
     # Best-effort: failures are non-fatal (stamp file left behind for manual cleanup).
@@ -794,6 +868,26 @@ check_deadline() {
     fi
 }
 
+# ── Sim-side telemetry poller (Issue #607 / #612) ────────────
+# Polls simGetCollisionInfo + simGetGroundTruthKinematics at 10 Hz and
+# writes JSONL alongside the other run logs.  Complements the perception-
+# side voxel trace: `cosys_telemetry.jsonl` carries ground-truth drone pose
+# (vs SLAM estimate) and UE5 physics collision events (vs no-collision-log-
+# at-all today).
+TELEMETRY_POLLER="${BIN_DIR}/cosys_telemetry_poller"
+TELEMETRY_PID=""
+if [[ -x "$TELEMETRY_POLLER" ]]; then
+    "$TELEMETRY_POLLER" \
+        --out "${SCENARIO_LOG_DIR}/cosys_telemetry.jsonl" \
+        --collisions "${SCENARIO_LOG_DIR}/collisions.log" \
+        --host "127.0.0.1" --port "${COSYS_RPC_PORT}" --rate_hz 10 \
+        > "${SCENARIO_LOG_DIR}/cosys_telemetry_poller.log" 2>&1 &
+    TELEMETRY_PID=$!
+    echo -e "  ${CYAN}Telemetry poller launched (pid=${TELEMETRY_PID})${NC}"
+else
+    echo -e "  ${YELLOW}WARNING: ${TELEMETRY_POLLER} not built — no collision / GT-pose logs${NC}"
+fi
+
 # ── Phase 4: Fault injection ──────────────────────────────────
 check_deadline
 echo ""
@@ -918,7 +1012,7 @@ echo -e "${BOLD}═════════════════════�
 RUN_END_EPOCH=$(date +%s)
 SCENARIO_LOG_DIR=$(finalize_run_dir "$SCENARIO_LOG_DIR" "$PASS" "$FAIL")
 
-SCENARIO_BASE_DIR="${LOG_DIR}/${SCENARIO_NAME}"
+SCENARIO_BASE_DIR="${LOG_DIR}/${SCENARIO_DIR_NAME}"
 update_latest_symlink "$SCENARIO_BASE_DIR" "$(basename "$SCENARIO_LOG_DIR")"
 
 write_run_metadata "${SCENARIO_LOG_DIR}/run_metadata.json" \
@@ -931,7 +1025,7 @@ REPORT_FILE=$(generate_run_report "$SCENARIO_LOG_DIR" "$SCENARIO_NAME" "cosys_ai
 
 append_to_index "${LOG_DIR}/runs.jsonl" \
     "${SCENARIO_LOG_DIR}/run_metadata.json" \
-    "${SCENARIO_NAME}/$(basename "$SCENARIO_LOG_DIR")"
+    "${SCENARIO_DIR_NAME}/$(basename "$SCENARIO_LOG_DIR")"
 
 echo ""
 echo -e "  ${CYAN}Report : ${REPORT_FILE}${NC}"

--- a/tests/test_path_a_trace.cpp
+++ b/tests/test_path_a_trace.cpp
@@ -1,0 +1,172 @@
+// tests/test_path_a_trace.cpp
+// Tests for the PathATrace diagnostic JSONL writer (Issue #612, PR #614).
+//
+// Covers:
+//   - disabled path is a no-op (no file created, no allocations, no crashes)
+//   - enabled writes one JSONL line per record_batch() call
+//   - path confinement rejects absolute paths and ../-escapes
+//   - R_body_from_cam extrinsic constants are self-consistent (Fix #55)
+
+#include "util/path_a_trace.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+namespace {
+
+std::filesystem::path temp_path(const std::string& name) {
+    auto p = std::filesystem::temp_directory_path() /
+             ("path_a_trace_test_" + std::to_string(::getpid()) + "_" + name);
+    std::filesystem::remove_all(p);
+    return p;
+}
+
+void fill_batch(std::vector<drone::hal::InferenceDetection>& dets,
+                std::vector<drone::hal::InferenceDetection>& masks,
+                std::vector<drone::hal::VoxelUpdate>&        voxels) {
+    drone::hal::InferenceDetection d{};
+    d.bbox.x     = 10;
+    d.bbox.y     = 20;
+    d.bbox.w     = 30;
+    d.bbox.h     = 40;
+    d.class_id   = 1;
+    d.confidence = 0.9f;
+    dets.push_back(d);
+    masks.push_back(d);
+
+    drone::hal::VoxelUpdate v{};
+    v.position_m     = Eigen::Vector3f(1.0f, 2.0f, 3.0f);
+    v.occupancy      = 0.8f;
+    v.confidence     = 0.7f;
+    v.semantic_label = 42;
+    voxels.push_back(v);
+}
+
+}  // namespace
+
+TEST(PathATraceTest, DisabledPathIsNoop) {
+    const auto p = temp_path("disabled");
+    // Even with an invalid absolute path, `enabled=false` should short-circuit.
+    drone::util::PathATrace trace(false, "/nonexistent/path/that/would/fail.jsonl");
+    EXPECT_FALSE(trace.enabled());
+    // No file should have been created at the path passed in.
+    EXPECT_FALSE(std::filesystem::exists("/nonexistent/path/that/would/fail.jsonl"));
+    // Calling record_batch on a disabled trace must not crash.
+    std::vector<drone::hal::InferenceDetection> dets, masks;
+    std::vector<drone::hal::VoxelUpdate>        voxels;
+    fill_batch(dets, masks, voxels);
+    drone::ipc::Pose pose{};
+    trace.record_batch(/*t_ns=*/1, /*seq=*/1, pose, dets, masks, voxels);
+    SUCCEED();
+}
+
+TEST(PathATraceTest, EnabledWritesOneJsonlLinePerBatch) {
+    const auto        p   = temp_path("write.jsonl");
+    const std::string rel = std::string("drone_logs/") +
+                            p.filename().string();  // relative → confined
+    const auto abs = std::filesystem::current_path() / rel;
+    std::filesystem::create_directories(abs.parent_path());
+    std::filesystem::remove(abs);
+
+    {
+        drone::util::PathATrace trace(true, rel);
+        ASSERT_TRUE(trace.enabled());
+
+        std::vector<drone::hal::InferenceDetection> dets, masks;
+        std::vector<drone::hal::VoxelUpdate>        voxels;
+        fill_batch(dets, masks, voxels);
+        drone::ipc::Pose pose{};
+        pose.translation[0] = 1.0;
+        pose.translation[1] = 2.0;
+        pose.translation[2] = 3.0;
+        pose.quaternion[0]  = 1.0;  // identity
+
+        trace.record_batch(100, 7, pose, dets, masks, voxels);
+        trace.record_batch(200, 8, pose, dets, masks, voxels);
+    }  // dtor flushes + closes
+
+    std::ifstream in(abs);
+    ASSERT_TRUE(in.is_open()) << "expected trace file at " << abs;
+    std::string              line;
+    std::vector<std::string> lines;
+    while (std::getline(in, line)) lines.push_back(line);
+    ASSERT_EQ(lines.size(), 2u);
+    // Each line must be valid JSON with the documented top-level keys.
+    for (const auto& ln : lines) {
+        auto j = nlohmann::json::parse(ln);
+        EXPECT_TRUE(j.contains("t_ns"));
+        EXPECT_TRUE(j.contains("seq"));
+        EXPECT_TRUE(j.contains("pose_t"));
+        EXPECT_TRUE(j.contains("pose_q"));
+        EXPECT_TRUE(j.contains("voxels"));
+        EXPECT_EQ(j["voxels"].size(), 1u);
+    }
+    std::filesystem::remove(abs);
+}
+
+TEST(PathATraceTest, PathConfinementRejectsAbsolute) {
+    // Absolute path (even under /tmp) must be rejected — force the writer inert.
+    drone::util::PathATrace trace(true, "/tmp/absolute_escape.jsonl");
+    EXPECT_FALSE(trace.enabled());
+    EXPECT_FALSE(std::filesystem::exists("/tmp/absolute_escape.jsonl"));
+}
+
+TEST(PathATraceTest, PathConfinementRejectsDotDotEscape) {
+    // Even a relative path that lexically normalises to escape the project
+    // root must be rejected.  `../../etc/foo.jsonl` normalises to start
+    // with `..`.
+    drone::util::PathATrace trace(true, "../../etc/evil_trace.jsonl");
+    EXPECT_FALSE(trace.enabled());
+}
+
+TEST(PathATraceTest, PathConfinementStaticHelper) {
+    // Exhaust the is_path_confined() truth table in one place.
+    using drone::util::PathATrace;
+    EXPECT_TRUE(PathATrace::is_path_confined("drone_logs/foo.jsonl"));
+    EXPECT_TRUE(PathATrace::is_path_confined("foo.jsonl"));
+    EXPECT_TRUE(PathATrace::is_path_confined("build/test/a.jsonl"));
+    EXPECT_FALSE(PathATrace::is_path_confined(""));
+    EXPECT_FALSE(PathATrace::is_path_confined("/etc/passwd"));
+    EXPECT_FALSE(PathATrace::is_path_confined("/tmp/something.jsonl"));
+    EXPECT_FALSE(PathATrace::is_path_confined("../foo.jsonl"));
+    EXPECT_FALSE(PathATrace::is_path_confined("../../etc/foo"));
+    // Paths that contain "..", but normalise to staying within the tree,
+    // are fine (e.g. "foo/../bar.jsonl" normalises to "bar.jsonl").
+    EXPECT_TRUE(PathATrace::is_path_confined("foo/../bar.jsonl"));
+}
+
+// ── R_body_from_cam frame-convention invariants (Fix #55) ───────────────
+// The camera→body rotation applied in mask_projection_thread must map:
+//   cam Z-axis (forward)   → body X-axis (forward)
+//   cam X-axis (right)     → body -Y-axis (right-of-body is negative Y)
+//   cam Y-axis (down)      → body -Z-axis (up-of-body is negative Y-cam)
+// This test locks in those invariants so a future refactor that flips a
+// sign (the exact class of bug Fix #55 addressed) fails loudly.
+TEST(PathATraceTest, RBodyFromCamFrameConventionInvariants) {
+    // Rebuild the constant matching process2_perception/src/main.cpp.
+    const Eigen::Matrix3f R = (Eigen::Matrix3f() << 0, 0, 1,  //
+                               -1, 0, 0,                      //
+                               0, -1, 0                       //
+                               )
+                                  .finished();
+    // Unit vectors in the camera optical frame.
+    const Eigen::Vector3f cam_x(1, 0, 0);  // right
+    const Eigen::Vector3f cam_y(0, 1, 0);  // down
+    const Eigen::Vector3f cam_z(0, 0, 1);  // forward
+    // After applying R, they must land on the expected body axes.
+    EXPECT_TRUE((R * cam_z).isApprox(Eigen::Vector3f(1, 0, 0), 1e-6f))
+        << "cam +Z (forward) must map to body +X (forward)";
+    EXPECT_TRUE((R * cam_x).isApprox(Eigen::Vector3f(0, -1, 0), 1e-6f))
+        << "cam +X (right) must map to body -Y (body Y is left-positive)";
+    EXPECT_TRUE((R * cam_y).isApprox(Eigen::Vector3f(0, 0, -1), 1e-6f))
+        << "cam +Y (down) must map to body -Z (body Z is up-positive)";
+    // Should be a proper rotation — det(R) = +1, R^T R = I.
+    EXPECT_NEAR(R.determinant(), 1.0f, 1e-6f);
+    EXPECT_TRUE((R.transpose() * R).isApprox(Eigen::Matrix3f::Identity(), 1e-6f));
+}

--- a/tools/check_voxel_on_target.py
+++ b/tools/check_voxel_on_target.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+check_voxel_on_target.py — post-run regression check for PATH A.
+
+Compares the voxel positions in a scenario run's
+`path_a_voxel_trace.jsonl` against the ground-truth object positions
+from the scene JSON (typically `config/scenes/cosys_static.json`).
+Fails (exit code 1) if the fraction of voxels landing within the
+specified XY radius of any scene object falls below a threshold.
+
+Addresses the test-quality P1 from PR #614 review:
+  "Scenario 33 pass_criteria `log_contains` strings all fire at init,
+   so Fix #55 (camera extrinsic rotation) could silently regress and
+   the scenario would still match every log check. We need a post-run
+   assertion that ties cube-collision-free behaviour to voxel positions
+   actually landing on scene objects."
+
+Called from `tests/run_scenario_cosys.sh` (Phase 6 verification) when
+`scenario.pass_criteria.voxel_on_target_ratio_min` is present. Defaults
+are tuned for the 2026-04-23 scenario-33 working run:
+  - radius_m = 3.0 (voxels within 3 m XY of a scene object count as "on target")
+  - min_ratio = 0.20 (≥ 20 % — the before-fix was 0 %, after-fix 34 %)
+  - min_voxels = 100 (below this count, run is too short to assess — exit 0)
+
+Usage:
+  python3 tools/check_voxel_on_target.py \
+      --trace drone_logs/scenarios_cosys/33_*/latest/path_a_voxel_trace.jsonl \
+      --scene config/scenes/cosys_static.json \
+      --radius-m 3.0 --min-ratio 0.20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+
+def load_scene_xy(scene_path: Path) -> list[tuple[float, float, str]]:
+    with scene_path.open() as f:
+        scene = json.load(f)
+    objects = scene.get("objects", [])
+    out = []
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        if "x" in obj and "y" in obj:
+            out.append((float(obj["x"]), float(obj["y"]), obj.get("name", "?")))
+    return out
+
+
+def iter_voxels(trace_path: Path):
+    with trace_path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for v in rec.get("voxels", []):
+                # schema: [wx, wy, wz, label, conf]
+                if len(v) >= 3:
+                    yield float(v[0]), float(v[1]), float(v[2])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--trace", required=True, type=Path, help="path_a_voxel_trace.jsonl from a scenario run")
+    ap.add_argument("--scene", required=True, type=Path, help="scene JSON (e.g. config/scenes/cosys_static.json)")
+    ap.add_argument("--radius-m", type=float, default=3.0, help="XY radius around each scene object counted as 'on target'")
+    ap.add_argument("--min-ratio", type=float, default=0.20, help="minimum fraction of voxels that must land within --radius-m")
+    ap.add_argument("--min-voxels", type=int, default=100, help="skip the check if fewer total voxels than this (run too short to assess)")
+    args = ap.parse_args()
+
+    if not args.trace.exists():
+        print(f"[check_voxel_on_target] ERROR: trace file not found: {args.trace}", file=sys.stderr)
+        return 2
+    if not args.scene.exists():
+        print(f"[check_voxel_on_target] ERROR: scene file not found: {args.scene}", file=sys.stderr)
+        return 2
+
+    scene_xy = load_scene_xy(args.scene)
+    if not scene_xy:
+        print(f"[check_voxel_on_target] ERROR: scene {args.scene} has no objects with x/y — nothing to check against",
+              file=sys.stderr)
+        return 2
+
+    r2 = args.radius_m * args.radius_m
+    total = 0
+    on_target = 0
+    for vx, vy, _vz in iter_voxels(args.trace):
+        total += 1
+        for (ox, oy, _name) in scene_xy:
+            dx = vx - ox
+            dy = vy - oy
+            if dx * dx + dy * dy <= r2:
+                on_target += 1
+                break
+
+    if total == 0:
+        print(f"[check_voxel_on_target] WARN: trace has zero voxels — PATH A did not publish anything")
+        return 1
+
+    if total < args.min_voxels:
+        print(f"[check_voxel_on_target] SKIP: only {total} voxels (< --min-voxels={args.min_voxels}); "
+              f"run too short to assess on-target ratio")
+        return 0
+
+    ratio = on_target / total
+    verdict = "PASS" if ratio >= args.min_ratio else "FAIL"
+    print(f"[check_voxel_on_target] {verdict}: {on_target}/{total} voxels "
+          f"({ratio * 100:.1f} %) landed within {args.radius_m:.1f} m XY of a scene object "
+          f"(threshold {args.min_ratio * 100:.0f} %)")
+    print(f"[check_voxel_on_target] scene objects checked: {len(scene_xy)} from {args.scene}")
+    if verdict == "FAIL":
+        print(f"[check_voxel_on_target] Fix #55 regression indicator — see PR #614 / Issue #612", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/cosys_telemetry_poller/CMakeLists.txt
+++ b/tools/cosys_telemetry_poller/CMakeLists.txt
@@ -1,0 +1,24 @@
+# tools/cosys_telemetry_poller/CMakeLists.txt
+# Cosys-AirSim sim-side telemetry poller for scenario runs (Issue #612 / #607).
+# Polls simGetCollisionInfo + simGetGroundTruthKinematics at 10 Hz, writes
+# JSONL alongside the other run logs.  Consumed by tools/plot_voxel_trace.py
+# to overlay true drone pose + collision events on the perception-side
+# voxel trace.
+
+add_executable(cosys_telemetry_poller main.cpp)
+
+target_link_libraries(cosys_telemetry_poller PRIVATE
+    AirSim::All
+    nlohmann_json::nlohmann_json
+    spdlog::spdlog
+    Threads::Threads
+)
+
+target_include_directories(cosys_telemetry_poller PRIVATE
+    ${PROJECT_SOURCE_DIR}/common/hal/include
+    ${PROJECT_SOURCE_DIR}/common/util/include
+)
+
+target_compile_definitions(cosys_telemetry_poller PRIVATE HAVE_COSYS_AIRSIM=1)
+
+install(TARGETS cosys_telemetry_poller DESTINATION bin)

--- a/tools/cosys_telemetry_poller/main.cpp
+++ b/tools/cosys_telemetry_poller/main.cpp
@@ -39,6 +39,7 @@ STRICT_MODE_OFF
 STRICT_MODE_ON
 
 #include <atomic>
+#include <charconv>
 #include <chrono>
 #include <csignal>
 #include <cstdint>
@@ -46,7 +47,9 @@ STRICT_MODE_ON
 #include <cstring>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include <nlohmann/json.hpp>
@@ -55,10 +58,25 @@ using json = nlohmann::json;
 
 namespace {
 
+// Lock-free across the signal handler / main loop boundary.
+static_assert(std::atomic<bool>::is_always_lock_free,
+              "cosys_telemetry_poller requires a lock-free atomic<bool> for the signal handler");
 std::atomic<bool> g_running{true};
 
 void on_signal(int) {
     g_running.store(false, std::memory_order_release);
+}
+
+/// Parse an integer from a C string with range validation.  Replaces
+/// `std::atoi` (forbidden by CLAUDE.md — silent 0 on bad input).
+std::optional<int> parse_int(const char* s, int min_val, int max_val) {
+    if (s == nullptr || *s == '\0') return std::nullopt;
+    std::string_view sv(s);
+    int              out{0};
+    auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out);
+    if (ec != std::errc{} || ptr != sv.data() + sv.size()) return std::nullopt;
+    if (out < min_val || out > max_val) return std::nullopt;
+    return out;
 }
 
 uint64_t now_ns() {
@@ -107,15 +125,23 @@ bool parse_args(int argc, char** argv, Args& a) {
             else
                 return false;
         } else if (s == "--port") {
-            if (auto v = next("--port"))
-                a.port = static_cast<uint16_t>(std::atoi(v));
-            else
+            auto v = next("--port");
+            if (!v) return false;
+            auto parsed = parse_int(v, 1, 65535);
+            if (!parsed) {
+                std::cerr << "error: --port must be an integer in [1, 65535]: " << v << "\n";
                 return false;
+            }
+            a.port = static_cast<uint16_t>(*parsed);
         } else if (s == "--rate_hz") {
-            if (auto v = next("--rate_hz"))
-                a.rate_hz = std::max(1, std::atoi(v));
-            else
+            auto v = next("--rate_hz");
+            if (!v) return false;
+            auto parsed = parse_int(v, 1, 1000);
+            if (!parsed) {
+                std::cerr << "error: --rate_hz must be an integer in [1, 1000]: " << v << "\n";
                 return false;
+            }
+            a.rate_hz = *parsed;
         } else if (s == "-h" || s == "--help") {
             std::cout << "cosys_telemetry_poller — collision + ground-truth kinematics telemetry\n"
                       << "Options:\n"

--- a/tools/cosys_telemetry_poller/main.cpp
+++ b/tools/cosys_telemetry_poller/main.cpp
@@ -1,0 +1,254 @@
+// tools/cosys_telemetry_poller/main.cpp
+// ═══════════════════════════════════════════════════════════════════
+// Cosys-AirSim sim-side telemetry poller for scenario runs.
+//
+// Polls, via the Cosys-AirSim RPC, at 10 Hz:
+//   - simGetCollisionInfo(vehicle)     → collision events (has_collided,
+//                                          impact point, normal, object hit,
+//                                          penetration depth, count)
+//   - simGetGroundTruthKinematics(..)  → true drone pose (position +
+//                                          orientation + linear/angular vel),
+//                                          independent of SLAM drift
+//
+// Output: JSONL, one record per tick, to a file given on the command line.
+// Complements the perception-side voxel trace (Issue #612) by giving us
+// the ground-truth frame to compare SLAM pose against AND the UE5 physics-
+// level collision ledger.
+//
+// Usage:
+//   cosys_telemetry_poller --out drone_logs/<run>/cosys_telemetry.jsonl
+//                          [--collisions drone_logs/<run>/collisions.log]
+//                          [--vehicle Drone0] [--host 127.0.0.1]
+//                          [--port 41451] [--rate_hz 10]
+//
+// Stops on SIGINT/SIGTERM — scenario runner sends SIGTERM at shutdown.
+// Exit codes: 0 normal, 1 RPC setup failure, 2 bad args.
+// ═══════════════════════════════════════════════════════════════════
+#define HAVE_COSYS_AIRSIM 1
+// Include order matters — cosys_rpc_client.h pulls in the base header set
+// AirLib's RpcLibAdaptorsBase depends on.  Same pattern as
+// tools/cosys_populate_scene/main.cpp.
+#include "hal/cosys_rpc_client.h"
+
+#include <common/common_utils/StrictMode.hpp>
+STRICT_MODE_OFF
+#include "api/RpcLibAdaptorsBase.hpp"
+
+#include <rpc/client.h>
+#include <vehicles/multirotor/api/MultirotorRpcLibClient.hpp>
+STRICT_MODE_ON
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace {
+
+std::atomic<bool> g_running{true};
+
+void on_signal(int) {
+    g_running.store(false, std::memory_order_release);
+}
+
+uint64_t now_ns() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                     std::chrono::steady_clock::now().time_since_epoch())
+                                     .count());
+}
+
+struct Args {
+    std::string out_path{"drone_logs/cosys_telemetry.jsonl"};
+    std::string collisions_path;  // optional — no path = no log
+    std::string vehicle{"Drone0"};
+    std::string host{"127.0.0.1"};
+    uint16_t    port{41451};
+    int         rate_hz{10};
+};
+
+bool parse_args(int argc, char** argv, Args& a) {
+    for (int i = 1; i < argc; ++i) {
+        std::string s    = argv[i];
+        auto        next = [&](const char* name) -> const char* {
+            if (i + 1 >= argc) {
+                std::cerr << "error: " << name << " requires an argument\n";
+                return nullptr;
+            }
+            return argv[++i];
+        };
+        if (s == "--out") {
+            if (auto v = next("--out"))
+                a.out_path = v;
+            else
+                return false;
+        } else if (s == "--collisions") {
+            if (auto v = next("--collisions"))
+                a.collisions_path = v;
+            else
+                return false;
+        } else if (s == "--vehicle") {
+            if (auto v = next("--vehicle"))
+                a.vehicle = v;
+            else
+                return false;
+        } else if (s == "--host") {
+            if (auto v = next("--host"))
+                a.host = v;
+            else
+                return false;
+        } else if (s == "--port") {
+            if (auto v = next("--port"))
+                a.port = static_cast<uint16_t>(std::atoi(v));
+            else
+                return false;
+        } else if (s == "--rate_hz") {
+            if (auto v = next("--rate_hz"))
+                a.rate_hz = std::max(1, std::atoi(v));
+            else
+                return false;
+        } else if (s == "-h" || s == "--help") {
+            std::cout << "cosys_telemetry_poller — collision + ground-truth kinematics telemetry\n"
+                      << "Options:\n"
+                      << "  --out <path>         JSONL output (default "
+                         "drone_logs/cosys_telemetry.jsonl)\n"
+                      << "  --collisions <path>  Optional compact human-readable collision log\n"
+                      << "  --vehicle <name>     Vehicle name (default Drone0)\n"
+                      << "  --host <ip>          (default 127.0.0.1)\n"
+                      << "  --port <port>        (default 41451)\n"
+                      << "  --rate_hz <n>        Poll rate (default 10)\n";
+            std::exit(0);
+        } else {
+            std::cerr << "warning: unknown arg: " << s << "\n";
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Args a;
+    if (!parse_args(argc, argv, a)) return 2;
+
+    std::signal(SIGINT, on_signal);
+    std::signal(SIGTERM, on_signal);
+
+    std::ofstream out(a.out_path, std::ios::out | std::ios::trunc);
+    if (!out.is_open()) {
+        std::cerr << "[cosys_telemetry_poller] cannot open output '" << a.out_path << "'\n";
+        return 2;
+    }
+
+    std::ofstream coll_log;
+    if (!a.collisions_path.empty()) {
+        coll_log.open(a.collisions_path, std::ios::out | std::ios::trunc);
+    }
+
+    // Connect to Cosys-AirSim RPC.
+    msr::airlib::MultirotorRpcLibClient client(a.host, a.port, /*timeout_sec=*/5);
+    try {
+        client.confirmConnection();
+    } catch (const std::exception& e) {
+        std::cerr << "[cosys_telemetry_poller] RPC connect failed: " << e.what() << "\n";
+        return 1;
+    }
+    std::cerr << "[cosys_telemetry_poller] Connected " << a.host << ":" << a.port << " vehicle='"
+              << a.vehicle << "' rate=" << a.rate_hz << " Hz\n"
+              << "[cosys_telemetry_poller] out=" << a.out_path;
+    if (!a.collisions_path.empty()) std::cerr << " collisions=" << a.collisions_path;
+    std::cerr << "\n";
+
+    const auto period           = std::chrono::milliseconds(1000 / a.rate_hz);
+    uint64_t   collision_count  = 0;
+    uint64_t   last_coll_tstamp = 0;
+    uint64_t   tick             = 0;
+    auto       next_tick        = std::chrono::steady_clock::now();
+
+    while (g_running.load(std::memory_order_acquire)) {
+        json rec;
+        rec["t_ns"] = now_ns();
+        rec["tick"] = tick;
+
+        // Collision info.  Cosys time_stamp is nanoseconds since engine start;
+        // a fresh impact bumps the timestamp and has_collided stays true while
+        // contact continues, so gate "new collision" on a timestamp change.
+        try {
+            auto       ci    = client.simGetCollisionInfo(a.vehicle);
+            const bool fresh = (ci.time_stamp != last_coll_tstamp) && ci.has_collided;
+            if (fresh) {
+                ++collision_count;
+                last_coll_tstamp = ci.time_stamp;
+                if (coll_log.is_open()) {
+                    coll_log << "[" << now_ns() << "] collision #" << collision_count << " with '"
+                             << ci.object_name << "' (id=" << ci.object_id << ")"
+                             << " at (" << ci.impact_point.x() << ", " << ci.impact_point.y()
+                             << ", " << ci.impact_point.z() << ") pen=" << ci.penetration_depth
+                             << "\n";
+                    coll_log.flush();
+                }
+            }
+            rec["coll"] = {
+                {"has", ci.has_collided},
+                {"count", collision_count},
+                {"fresh", fresh},
+                {"ts", static_cast<uint64_t>(ci.time_stamp)},
+                {"obj", ci.object_name},
+                {"id", ci.object_id},
+                {"pt", {ci.impact_point.x(), ci.impact_point.y(), ci.impact_point.z()}},
+                {"nrm", {ci.normal.x(), ci.normal.y(), ci.normal.z()}},
+                {"pen", ci.penetration_depth},
+            };
+        } catch (const std::exception& e) {
+            rec["coll_err"] = e.what();
+        }
+
+        // Ground-truth kinematics.  Independent of SLAM drift — lets us
+        // cross-check the `camera_pose` the perception pipeline uses against
+        // the simulator's real-world pose.
+        try {
+            auto k    = client.simGetGroundTruthKinematics(a.vehicle);
+            rec["gt"] = {
+                {"pos", {k.pose.position.x(), k.pose.position.y(), k.pose.position.z()}},
+                {"q",
+                 {k.pose.orientation.w(), k.pose.orientation.x(), k.pose.orientation.y(),
+                  k.pose.orientation.z()}},
+                {"lv", {k.twist.linear.x(), k.twist.linear.y(), k.twist.linear.z()}},
+                {"av", {k.twist.angular.x(), k.twist.angular.y(), k.twist.angular.z()}},
+                {"la",
+                 {k.accelerations.linear.x(), k.accelerations.linear.y(),
+                  k.accelerations.linear.z()}},
+                {"aa",
+                 {k.accelerations.angular.x(), k.accelerations.angular.y(),
+                  k.accelerations.angular.z()}},
+            };
+        } catch (const std::exception& e) {
+            rec["gt_err"] = e.what();
+        }
+
+        out << rec.dump() << '\n';
+        if ((tick % 20) == 0) out.flush();  // flush every ~2 s so `tail -f` works
+        ++tick;
+
+        next_tick += period;
+        auto now = std::chrono::steady_clock::now();
+        if (now > next_tick) next_tick = now;  // reset if we fell behind
+        std::this_thread::sleep_until(next_tick);
+    }
+
+    out.flush();
+    out.close();
+    if (coll_log.is_open()) coll_log.close();
+    std::cerr << "[cosys_telemetry_poller] Stopped — " << tick << " ticks, " << collision_count
+              << " collisions\n";
+    return 0;
+}

--- a/tools/cosys_telemetry_poller/main.cpp
+++ b/tools/cosys_telemetry_poller/main.cpp
@@ -189,11 +189,11 @@ int main(int argc, char** argv) {
                 ++collision_count;
                 last_coll_tstamp = ci.time_stamp;
                 if (coll_log.is_open()) {
-                    coll_log << "[" << now_ns() << "] collision #" << collision_count << " with '"
-                             << ci.object_name << "' (id=" << ci.object_id << ")"
-                             << " at (" << ci.impact_point.x() << ", " << ci.impact_point.y()
-                             << ", " << ci.impact_point.z() << ") pen=" << ci.penetration_depth
-                             << "\n";
+                    coll_log << "[" << now_ns() << "] collision #" << collision_count;
+                    coll_log << " with '" << ci.object_name << "' (id=" << ci.object_id << ")";
+                    coll_log << " at (" << ci.impact_point.x() << ", " << ci.impact_point.y();
+                    coll_log << ", " << ci.impact_point.z() << ")";
+                    coll_log << " pen=" << ci.penetration_depth << "\n";
                     coll_log.flush();
                 }
             }

--- a/tools/plot_voxel_trace.py
+++ b/tools/plot_voxel_trace.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""tools/plot_voxel_trace.py — visualise PATH A voxel trace vs scene ground truth.
+
+Inputs (any subset; at least the voxel trace is required):
+  --voxel-trace    path_a_voxel_trace.jsonl produced by the P2 mask_projection_thread
+                   when `perception.path_a.diag.trace_voxels` is true.
+  --cosys-telemetry cosys_telemetry.jsonl  — ground-truth drone pose + collision ledger
+                   produced by tools/cosys_telemetry_poller.
+  --scene          config/scenes/*.json    — spawned-object ground truth.
+  --out-prefix     prefix for output PNG files (e.g. drone_logs/.../analysis)
+
+Produces:
+  <prefix>_topdown.png    — top-down scatter of voxels + SLAM + Cosys-GT trajectories
+                            + scene-object positions + collision points.
+  <prefix>_depth_hist.png — depth distribution per batch (from voxel world pos vs
+                            pose translation).
+  <prefix>_pose_error.png — SLAM pose vs Cosys-GT pose error over time (if both
+                            inputs present).
+
+Usage:
+  python3 tools/plot_voxel_trace.py \
+      --voxel-trace drone_logs/.../path_a_voxel_trace.jsonl \
+      --cosys-telemetry drone_logs/.../cosys_telemetry.jsonl \
+      --scene config/scenes/cosys_static.json \
+      --out-prefix drone_logs/.../analysis
+
+Issue #612.  Reads JSONL line-by-line so it works on in-progress traces too.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+from typing import Iterable, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def _read_jsonl(path: pathlib.Path) -> List[dict]:
+    records: List[dict] = []
+    with path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"{path}:{line_no}: JSON error: {e}", file=sys.stderr)
+    return records
+
+
+def _voxels(trace: Iterable[dict]) -> np.ndarray:
+    """Stack all voxel world positions across the trace. Shape (N, 3)."""
+    rows = []
+    for rec in trace:
+        for v in rec.get("voxels", []):
+            # [wx, wy, wz, label, conf]
+            rows.append((v[0], v[1], v[2]))
+    return np.asarray(rows, dtype=float).reshape(-1, 3)
+
+
+def _trajectory(trace: Iterable[dict], pose_key: str = "pose_t") -> np.ndarray:
+    """Drone trajectory from one of the traces.  Shape (T, 3)."""
+    pts = []
+    for rec in trace:
+        p = rec.get(pose_key)
+        if p:
+            pts.append(p)
+    return np.asarray(pts, dtype=float).reshape(-1, 3)
+
+
+def _collisions(telemetry: Iterable[dict]) -> np.ndarray:
+    """Impact points from fresh collision events. Shape (K, 3)."""
+    pts = []
+    for rec in telemetry:
+        coll = rec.get("coll")
+        if coll and coll.get("fresh"):
+            pts.append(coll["pt"])
+    return np.asarray(pts, dtype=float).reshape(-1, 3)
+
+
+def _gt_trajectory(telemetry: Iterable[dict]) -> np.ndarray:
+    pts = []
+    for rec in telemetry:
+        gt = rec.get("gt")
+        if gt:
+            pts.append(gt["pos"])
+    return np.asarray(pts, dtype=float).reshape(-1, 3)
+
+
+def _scene_objects(scene_path: pathlib.Path) -> List[Tuple[str, float, float, float]]:
+    with scene_path.open() as f:
+        data = json.load(f)
+    out = []
+    for obj in data.get("objects", []):
+        out.append((obj.get("name", "?"), float(obj.get("x", 0)), float(obj.get("y", 0)),
+                    float(obj.get("z", 0))))
+    return out
+
+
+def _plot_topdown(voxels: np.ndarray, slam_traj: np.ndarray, gt_traj: np.ndarray,
+                  collisions: np.ndarray, scene: List[Tuple[str, float, float, float]],
+                  out_path: pathlib.Path) -> None:
+    fig, ax = plt.subplots(figsize=(12, 10))
+    if voxels.size:
+        ax.scatter(voxels[:, 0], voxels[:, 1], c="tab:gray", s=3, alpha=0.25,
+                   label=f"PATH A voxels ({len(voxels)})")
+    if slam_traj.size:
+        ax.plot(slam_traj[:, 0], slam_traj[:, 1], "b-", linewidth=1.5, alpha=0.7,
+                label=f"SLAM trajectory ({len(slam_traj)} pts)")
+        ax.scatter(slam_traj[0, 0], slam_traj[0, 1], c="blue", marker="o", s=60,
+                   edgecolors="k", label="SLAM start")
+    if gt_traj.size:
+        ax.plot(gt_traj[:, 0], gt_traj[:, 1], "g--", linewidth=1.2, alpha=0.8,
+                label=f"Cosys GT trajectory ({len(gt_traj)} pts)")
+    if collisions.size:
+        ax.scatter(collisions[:, 0], collisions[:, 1], c="red", marker="X", s=120,
+                   edgecolors="k", zorder=5, label=f"Collision events ({len(collisions)})")
+    for name, x, y, _z in scene:
+        ax.scatter(x, y, c="orange", marker="s", s=150, edgecolors="k", zorder=4)
+        ax.annotate(name, (x, y), xytext=(5, 5), textcoords="offset points", fontsize=8,
+                    color="darkorange")
+    ax.set_xlabel("X (world, m)")
+    ax.set_ylabel("Y (world, m)")
+    ax.set_title("PATH A voxel distribution — top-down view")
+    ax.set_aspect("equal", adjustable="datalim")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    print(f"  wrote {out_path}")
+
+
+def _plot_depth_hist(trace: List[dict], out_path: pathlib.Path) -> None:
+    """Distance of each voxel from the drone at that frame — proxy for DA V2 depth."""
+    depths: List[float] = []
+    for rec in trace:
+        pose_t = rec.get("pose_t")
+        if not pose_t:
+            continue
+        px, py, pz = pose_t
+        for v in rec.get("voxels", []):
+            dx = v[0] - px
+            dy = v[1] - py
+            dz = v[2] - pz
+            depths.append(math.sqrt(dx * dx + dy * dy + dz * dz))
+    fig, ax = plt.subplots(figsize=(10, 6))
+    if depths:
+        ax.hist(depths, bins=60, color="tab:blue", edgecolor="k")
+        ax.axvline(20.0, color="red", linestyle="--",
+                   label="kMaxObstacleDepth (20 m filter)")
+    ax.set_xlabel("||voxel − drone|| (m)")
+    ax.set_ylabel("Voxel count")
+    ax.set_title("PATH A voxel range distribution (sanity check on depth + filter)")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    print(f"  wrote {out_path}")
+
+
+def _plot_pose_error(trace: List[dict], telemetry: List[dict],
+                     out_path: pathlib.Path) -> Optional[pathlib.Path]:
+    """SLAM pose vs Cosys GT pose — Euclidean error over time."""
+    if not trace or not telemetry:
+        print("  pose-error plot skipped (needs both voxel trace + cosys telemetry)")
+        return None
+
+    # Simple nearest-neighbour time alignment on t_ns.
+    slam = sorted((r["t_ns"], r.get("pose_t")) for r in trace if r.get("pose_t"))
+    gt   = sorted((r["t_ns"], r["gt"]["pos"])  for r in telemetry if r.get("gt"))
+    if not slam or not gt:
+        print("  pose-error plot skipped (no timestamped poses)")
+        return None
+
+    slam_arr = np.asarray([(t, *p) for t, p in slam], dtype=float)
+    gt_arr   = np.asarray([(t, *p) for t, p in gt], dtype=float)
+
+    t0 = min(slam_arr[0, 0], gt_arr[0, 0])
+    slam_t = (slam_arr[:, 0] - t0) / 1e9
+    gt_t   = (gt_arr[:, 0] - t0) / 1e9
+    errors: List[float] = []
+    for i, t in enumerate(slam_t):
+        j = int(np.argmin(np.abs(gt_t - t)))
+        dp = slam_arr[i, 1:4] - gt_arr[j, 1:4]
+        errors.append(float(np.linalg.norm(dp)))
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+    ax.plot(slam_t, errors, "r-", linewidth=1.2)
+    ax.set_xlabel("Time since first sample (s)")
+    ax.set_ylabel("|SLAM − GT| (m)")
+    ax.set_title("SLAM vs Cosys ground-truth pose error")
+    ax.grid(True, alpha=0.3)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=140)
+    plt.close(fig)
+    print(f"  wrote {out_path}")
+    return out_path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Visualise PATH A voxel trace against scene ground truth.")
+    ap.add_argument("--voxel-trace", required=True, type=pathlib.Path,
+                    help="JSONL from P2 mask_projection_thread (perception.path_a.diag.trace_voxels)")
+    ap.add_argument("--cosys-telemetry", type=pathlib.Path,
+                    help="JSONL from cosys_telemetry_poller (GT pose + collisions)")
+    ap.add_argument("--scene", type=pathlib.Path,
+                    help="config/scenes/*.json with spawned-object positions")
+    ap.add_argument("--out-prefix", type=pathlib.Path, default=pathlib.Path("voxel_trace"),
+                    help="Prefix for output PNG files")
+    args = ap.parse_args()
+
+    if not args.voxel_trace.exists():
+        print(f"error: voxel trace not found: {args.voxel_trace}", file=sys.stderr)
+        return 2
+
+    trace = _read_jsonl(args.voxel_trace)
+    print(f"voxel trace: {len(trace)} batches, {sum(len(r.get('voxels', [])) for r in trace)} "
+          "voxels total")
+
+    telemetry: List[dict] = []
+    if args.cosys_telemetry and args.cosys_telemetry.exists():
+        telemetry = _read_jsonl(args.cosys_telemetry)
+        print(f"cosys telemetry: {len(telemetry)} ticks, "
+              f"{sum(1 for r in telemetry if r.get('coll', {}).get('fresh'))} fresh collisions")
+    elif args.cosys_telemetry:
+        print(f"warn: cosys telemetry not found: {args.cosys_telemetry}", file=sys.stderr)
+
+    scene: List[Tuple[str, float, float, float]] = []
+    if args.scene and args.scene.exists():
+        scene = _scene_objects(args.scene)
+        print(f"scene: {len(scene)} objects")
+    elif args.scene:
+        print(f"warn: scene file not found: {args.scene}", file=sys.stderr)
+
+    args.out_prefix.parent.mkdir(parents=True, exist_ok=True)
+
+    voxels      = _voxels(trace)
+    slam_traj   = _trajectory(trace, pose_key="pose_t")
+    gt_traj     = _gt_trajectory(telemetry)
+    collisions  = _collisions(telemetry)
+
+    _plot_topdown(voxels, slam_traj, gt_traj, collisions, scene,
+                  pathlib.Path(str(args.out_prefix) + "_topdown.png"))
+    _plot_depth_hist(trace, pathlib.Path(str(args.out_prefix) + "_depth_hist.png"))
+    _plot_pose_error(trace, telemetry,
+                     pathlib.Path(str(args.out_prefix) + "_pose_error.png"))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #612 (PATH A voxel-trace diagnostics + 8 perception fixes) and closes #613 (Cosys runner/deploy UX).

The diagnostic infrastructure filed in #612 exposed a stack of eight compounding perception bugs between PATH A's mask producer and the occupancy grid. All eight are fixed here and recorded in `docs/tracking/BUG_FIXES.md` as Fix #55 – Fix #62. The user-facing side-effects (runner UX, deploy script, log-folder naming, scenario JSON self-description) were split out into #613 so the perception commits stay focused.

### What landed

**Diagnostic infra (#612)**
- `common/util/include/util/path_a_trace.h` — header-only JSONL writer, opt-in via `perception.path_a.diag.trace_voxels`.
- `tools/cosys_telemetry_poller/` — 10 Hz Cosys GT pose + collision poller (emits per-scenario `cosys_telemetry.jsonl` + compact `collisions.log`).
- `tools/plot_voxel_trace.py` — top-down voxel scatter + SLAM vs GT trajectories, depth histogram, pose-error plots.

**PATH A perception fixes (#612)**

| Fix # | Bug | Severity |
|-------|-----|----------|
| #55   | Camera→body extrinsic rotation missing — voxels 8–12 m offset | Critical |
| #56   | `CpuSemanticProjector` mask-convention mismatch (bbox-local vs full-image) | High |
| #57   | SAM factory hard-coded `SimulatedSAMBackend`, ignoring config | High |
| #58   | FastSAM ONNX `Floor` node unparseable by OpenCV DNN 4.10 | Medium |
| #59   | `kMaxProposals = 16384` too small (FastSAM@1024 emits 21504) | High |
| #60   | Ground-texture ghost voxels polluting the static grid layer | High |
| #61   | Drone yawed toward waypoint, never faced detour obstacle | Medium |
| #62   | `cosys_telemetry_poller` include-order broke AirSim macro expansion | Low |

**Runner / deploy UX (#613)**
- `deploy/clean_run_build_cosys.sh` — kill/build/test/launch one-shot for Cosys (mirrors `clean_build_and_run.sh` for Gazebo).
- `tests/run_scenario_cosys.sh` — `resolve_base_config()` precedence: CLI flag → `scenario.base_config` JSON field → `cosys_airsim_dev.json` → `cosys_airsim.json`.
- Scenario log folders now prefixed with the scenario number (`scenarios_cosys/33_non_coco_obstacles/<timestamp>/`).
- PATH A voxel trace redirected per-run inside the scenario log folder.
- `config/scenarios/33_non_coco_obstacles.json` declares `base_config` hint, enables `path_a`, `voxel_input`, `yaw_towards_velocity`, and adds real `pass_criteria`.

### New config keys

- `perception.path_a.diag.{trace_voxels, trace_path}`
- `mission_planner.path_planner.yaw_towards_velocity`
- `mission_planner.occupancy_grid.voxel_input.{enabled, position_clamp_m, min_confidence}`
- `scenario.base_config` (self-describing hint used by the runner)

### Verification

- `bash -n` on both shell scripts; scenario JSON parses.
- `clang-format-18 --dry-run --Werror` clean on all modified C++ files.
- Live scenario-33 run on 2026-04-23: drone advanced past WP2 + WP3 with **0 `TemplateCube_Rounded_9` collisions** — the regression this whole investigation was filed to fix.

### User-facing invocation (post-change)

```bash
./tests/run_scenario_cosys.sh config/scenarios/33_non_coco_obstacles.json --gui --verbose
```

or, from a clean tree:

```bash
bash deploy/clean_run_build_cosys.sh           # default: scenario 33, GUI
```

## Test plan

- [x] `bash -n deploy/clean_run_build_cosys.sh`
- [x] `bash -n tests/run_scenario_cosys.sh`
- [x] `python3 -c "import json; json.load(open('config/scenarios/33_non_coco_obstacles.json'))"`
- [x] `clang-format-18 --dry-run --Werror` on all modified C++ files
- [x] Live scenario-33 Cosys SITL run — 0 cube collisions, WP2 + WP3 advanced
- [ ] CI — build + unit tests on push (automated)

## Known issue (out of scope, filing separately)

Second scenario-33 run on the same day froze SLAM pose after a STUCK recovery — VIO reported the same pose repeatedly, mission-planner stopped sending commands, SimpleFlight safety-hover triggered, drone drifted into `TemplateCube_Rounded_66`. Flight-control-cascade bug in VIO/SimpleFlight state transition, orthogonal to PATH A. Will file as a fresh issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
