### PR TITLE
feat(#513): brake-in-close-regime — avoider cancels forward motion into obstacles

### DIFF
--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -341,6 +341,14 @@ inline constexpr const char* LOG_CORRECTIONS = "mission_planner.obstacle_avoidan
 // scenarios that want pure-deflection semantics can set it false.
 inline constexpr const char* BRAKE_IN_CLOSE_REGIME =
     "mission_planner.obstacle_avoidance.brake_in_close_regime";
+// Floor on the proximity-based brake scale.  A single spurious short-range
+// detection (radar noise at 0.05 m against min_distance_m=2.0 m) would
+// otherwise zero the velocity command for one tick — worse than the
+// pre-#513 deflection-only behaviour for noisy detectors.  The floor caps
+// the worst single-tick response at `min_brake_scale × cruise_speed`.
+// Persistent obstacles still drive the scale to this floor over multiple
+// ticks, so the safety property is preserved.  Default 0.1 (10 %).
+inline constexpr const char* MIN_BRAKE_SCALE = "mission_planner.obstacle_avoidance.min_brake_scale";
 // Per-class overrides (Epic #519 — per-class config schema)
 inline constexpr const char* PER_CLASS_INFLUENCE_RADIUS_M =
     "mission_planner.obstacle_avoidance.per_class.influence_radius_m";

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -333,6 +333,14 @@ inline constexpr const char* PATH_AWARE      = "mission_planner.obstacle_avoidan
 inline constexpr const char* PATH_AWARE_BYPASS_HYSTERESIS_M =
     "mission_planner.obstacle_avoidance.path_aware_bypass_hysteresis_m";
 inline constexpr const char* LOG_CORRECTIONS = "mission_planner.obstacle_avoidance.log_corrections";
+// When close_regime_active_ triggers (nearest obstacle < min_distance_m),
+// cancel the component of the planned velocity pointing at the obstacle
+// and scale total magnitude by proximity.  Fixes the additive-correction
+// gap where a planner cruise vector + a modest lateral deflection still
+// drives the drone forward into the obstacle (Issue #513).  Default true;
+// scenarios that want pure-deflection semantics can set it false.
+inline constexpr const char* BRAKE_IN_CLOSE_REGIME =
+    "mission_planner.obstacle_avoidance.brake_in_close_regime";
 // Per-class overrides (Epic #519 — per-class config schema)
 inline constexpr const char* PER_CLASS_INFLUENCE_RADIUS_M =
     "mission_planner.obstacle_avoidance.per_class.influence_radius_m";

--- a/process4_mission_planner/include/planner/obstacle_avoider_3d.h
+++ b/process4_mission_planner/include/planner/obstacle_avoider_3d.h
@@ -60,6 +60,15 @@ struct ObstacleAvoider3DConfig {
     // modest lateral deflection (e.g. |delta|=0.98 m/s) was insufficient
     // against 2 m/s cruise pointed at an obstacle.  Default true.
     bool brake_in_close_regime = true;
+    // Floor on the proximity-based brake scale (PR #617 fault-recovery P2).
+    // Without this floor, a single spurious detection at 0.05 m (radar
+    // noise) against min_distance_m=2.0 produces brake_scale=0.025 — a
+    // near-stop command for one full planner tick.  Capping the worst
+    // single-tick output preserves the safety property (persistent
+    // obstacles still drive the scale to the floor over multiple ticks)
+    // while rejecting one-tick noise events.  Default 0.1 (= 10 % of
+    // cruise).
+    float min_brake_scale = 0.1f;
 
     // Per-class overrides (Epic #519).  Indexed by ObjectClass enum value (0-7).
     // Zero-initialized here; the ObstacleAvoider3D constructor fills them
@@ -131,6 +140,16 @@ public:
         config_.brake_in_close_regime = cfg.get<bool>(
             drone::cfg_key::mission_planner::obstacle_avoidance::BRAKE_IN_CLOSE_REGIME,
             config_.brake_in_close_regime);
+        config_.min_brake_scale =
+            cfg.get<float>(drone::cfg_key::mission_planner::obstacle_avoidance::MIN_BRAKE_SCALE,
+                           config_.min_brake_scale);
+        // PR #617 fault-recovery P3: a config mistake of min_distance_m=0 silently
+        // disables the brake — warn loudly so operators notice before scenario time.
+        if (config_.brake_in_close_regime && config_.min_distance_m <= 0.0f) {
+            DRONE_LOG_WARN("[ObstacleAvoider3D] brake_in_close_regime enabled but "
+                           "min_distance_m={:.3f} <= 0 — brake path will be skipped.",
+                           config_.min_distance_m);
+        }
 
         // Per-class overrides — fall back to the global scalar loaded above.
         namespace oa                       = drone::cfg_key::mission_planner::obstacle_avoidance;
@@ -361,7 +380,19 @@ public:
             // (2) Scale magnitude by proximity — linear ramp 0→1 over 0→min_distance_m.
             //     At d = min_distance_m, scale = 1 (full commanded speed).
             //     At d = 0, scale = 0 (stop at the obstacle surface).
+            //     Clamp BELOW by `min_brake_scale` (PR #617 fault-recovery P2) so a
+            //     single-frame spurious short-range detection can't zero the
+            //     command for a full tick.  Persistent obstacles still pin the
+            //     scale to this floor over consecutive ticks.
+            //     NOTE: `min_distance_m` here is the global scalar — the same
+            //     value that gates close_regime_active_ hysteresis above.  If
+            //     per-class min_distance_per_class overrides are set (Epic #519)
+            //     they affect the per-class repulsion loop upstream, not the
+            //     brake scale denominator.  Keeping the denominator global keeps
+            //     the brake semantics independent of which class happened to be
+            //     the nearest obstacle this tick.
             brake_scale = std::min(1.0f, min_active_dist / config_.min_distance_m);
+            brake_scale = std::max(config_.min_brake_scale, brake_scale);
             cmd.velocity_x *= brake_scale;
             cmd.velocity_y *= brake_scale;
             cmd.velocity_z *= brake_scale;

--- a/process4_mission_planner/include/planner/obstacle_avoider_3d.h
+++ b/process4_mission_planner/include/planner/obstacle_avoider_3d.h
@@ -53,6 +53,13 @@ struct ObstacleAvoider3DConfig {
     // Per-obstacle INFO log when its contribution exceeds ~0.5 m/s.  Gated so
     // scenarios that want quiet avoider output can disable it (Issue #503).
     bool log_corrections = true;
+    // Brake arbitration in close-regime — Issue #513.
+    // When close_regime_active_ fires, cancel the component of planned
+    // velocity pointing at the nearest obstacle and scale total commanded
+    // magnitude by proximity.  Fixes the additive-correction gap where a
+    // modest lateral deflection (e.g. |delta|=0.98 m/s) was insufficient
+    // against 2 m/s cruise pointed at an obstacle.  Default true.
+    bool brake_in_close_regime = true;
 
     // Per-class overrides (Epic #519).  Indexed by ObjectClass enum value (0-7).
     // Zero-initialized here; the ObstacleAvoider3D constructor fills them
@@ -121,6 +128,9 @@ public:
         config_.log_corrections =
             cfg.get<bool>(drone::cfg_key::mission_planner::obstacle_avoidance::LOG_CORRECTIONS,
                           config_.log_corrections);
+        config_.brake_in_close_regime = cfg.get<bool>(
+            drone::cfg_key::mission_planner::obstacle_avoidance::BRAKE_IN_CLOSE_REGIME,
+            config_.brake_in_close_regime);
 
         // Per-class overrides — fall back to the global scalar loaded above.
         namespace oa                       = drone::cfg_key::mission_planner::obstacle_avoidance;
@@ -169,6 +179,12 @@ public:
         // Track nearest active obstacle for the path-aware bypass hysteresis
         // (Issue #503).  Only updated when an obstacle is within influence.
         float min_active_dist = std::numeric_limits<float>::infinity();
+        // Direction vector from drone to the nearest active obstacle —
+        // captured for Issue #513's brake arbitration.  Unit-less; normalised
+        // only when we actually use it.
+        float nearest_dx = 0.0f;
+        float nearest_dy = 0.0f;
+        float nearest_dz = 0.0f;
 
         for (uint32_t i = 0; i < objects.num_objects; ++i) {
             const auto& obj = objects.objects[i];
@@ -193,7 +209,12 @@ public:
 
             if (dist < config_.influence_radius_per_class[ci] && dist > 0.01f) {
                 ++active;
-                if (dist < min_active_dist) min_active_dist = dist;
+                if (dist < min_active_dist) {
+                    min_active_dist = dist;
+                    nearest_dx      = dx;
+                    nearest_dy      = dy;
+                    nearest_dz      = dz;
+                }
                 // Inverse-square repulsive force (decays with distance)
                 float repulsion = config_.repulsive_gain_per_class[ci] / (dist * dist);
 
@@ -309,6 +330,43 @@ public:
             }
         }
 
+        // ── Brake arbitration in close regime (Issue #513) ─────────────
+        // Additive lateral correction alone is insufficient when the planner's
+        // cruise vector points at an obstacle.  In the close regime:
+        //   (1) cancel the component of cmd.velocity pointing INTO the nearest
+        //       obstacle (drone's own forward momentum stops driving it in), and
+        //   (2) scale total commanded magnitude by proximity so the drone
+        //       decelerates linearly to a stop at the obstacle surface.
+        // Then fall through to the existing repulsion-add, which contributes
+        // the lateral push.  Gated by `brake_in_close_regime` (default true);
+        // scenarios that want pure-deflection semantics set it to false.
+        bool  brake_applied = false;
+        float brake_scale   = 1.0f;
+        float v_toward      = 0.0f;
+        if (close_regime_active_ && config_.brake_in_close_regime &&
+            std::isfinite(min_active_dist) && min_active_dist > 0.01f &&
+            config_.min_distance_m > 0.0f) {
+            const float inv = 1.0f / min_active_dist;
+            const float nx  = nearest_dx * inv;
+            const float ny  = nearest_dy * inv;
+            const float nz  = nearest_dz * inv;
+            // (1) Cancel component heading INTO the obstacle.
+            v_toward = cmd.velocity_x * nx + cmd.velocity_y * ny + cmd.velocity_z * nz;
+            if (v_toward > 0.0f) {
+                cmd.velocity_x -= v_toward * nx;
+                cmd.velocity_y -= v_toward * ny;
+                cmd.velocity_z -= v_toward * nz;
+                brake_applied = true;
+            }
+            // (2) Scale magnitude by proximity — linear ramp 0→1 over 0→min_distance_m.
+            //     At d = min_distance_m, scale = 1 (full commanded speed).
+            //     At d = 0, scale = 0 (stop at the obstacle surface).
+            brake_scale = std::min(1.0f, min_active_dist / config_.min_distance_m);
+            cmd.velocity_x *= brake_scale;
+            cmd.velocity_y *= brake_scale;
+            cmd.velocity_z *= brake_scale;
+        }
+
         cmd.velocity_x += total_rep_x;
         cmd.velocity_y += total_rep_y;
         cmd.velocity_z += total_rep_z;
@@ -321,10 +379,15 @@ public:
             const float delta_mag = std::sqrt(
                 total_rep_x * total_rep_x + total_rep_y * total_rep_y + total_rep_z * total_rep_z);
             if (active > 0 || delta_mag > 0.1f) {
-                DRONE_LOG_INFO("[Avoider] considered={} active={} |delta|={:.2f} m/s "
-                               "path_aware_strip={} close_regime={}",
-                               considered, active, delta_mag, path_aware_strip_count,
-                               close_regime_active_ ? 1 : 0);
+                // brake=1 means brake arbitration reduced forward motion this tick
+                // (Issue #513).  v_toward is the forward velocity component that
+                // was cancelled; brake_scale is the proximity-based magnitude
+                // scaler applied after cancellation.
+                DRONE_LOG_INFO(
+                    "[Avoider] considered={} active={} |delta|={:.2f} m/s "
+                    "path_aware_strip={} close_regime={} brake={} v_toward={:.2f} scale={:.2f}",
+                    considered, active, delta_mag, path_aware_strip_count,
+                    close_regime_active_ ? 1 : 0, brake_applied ? 1 : 0, v_toward, brake_scale);
             }
         }
 

--- a/process4_mission_planner/include/planner/obstacle_avoider_3d.h
+++ b/process4_mission_planner/include/planner/obstacle_avoider_3d.h
@@ -81,6 +81,20 @@ struct ObstacleAvoider3DConfig {
     std::array<float, drone::util::kPerClassCount> min_confidence_per_class{};
 };
 
+// ── Named constants (PR #617 code-quality review) ──────────────────────────
+// The 0.01f dist gate and 0.01f velocity-magnitude gate are both "minimum
+// non-zero scalar to prevent div-by-zero on degenerate geometry", but they
+// guard different quantities — distance vs velocity — so they get distinct
+// names.  The log thresholds live here because they govern when [Avoider]
+// lines are promoted to INFO; unlike `min_distance_m`, they are not physics
+// values and don't belong in per-scenario config.
+namespace avoider_constants {
+inline constexpr float kMinDistGateM               = 0.01f;  // geometry dead-zone
+inline constexpr float kMinVelMagnitude            = 0.01f;  // velocity dead-zone (normalisation)
+inline constexpr float kLogPerObstacleThresholdMps = 0.5f;   // promote per-obstacle log to INFO
+inline constexpr float kLogDeltaThresholdMps       = 0.1f;   // promote summary log to INFO
+}  // namespace avoider_constants
+
 class ObstacleAvoider3D final : public IObstacleAvoider {
 public:
     explicit ObstacleAvoider3D(const ObstacleAvoider3DConfig& config = {}) : config_(config) {
@@ -143,11 +157,15 @@ public:
         config_.min_brake_scale =
             cfg.get<float>(drone::cfg_key::mission_planner::obstacle_avoidance::MIN_BRAKE_SCALE,
                            config_.min_brake_scale);
-        // PR #617 fault-recovery P3: a config mistake of min_distance_m=0 silently
-        // disables the brake — warn loudly so operators notice before scenario time.
+        // PR #617 review: a config mistake of min_distance_m=0 silently disables
+        // BOTH the brake path (guarded by `min_distance_m > 0` inside avoid())
+        // AND the close_regime_active_ hysteresis (entry condition is
+        // `dist < min_distance_m`, which can never be true when it's 0).
+        // Warn loudly so operators notice before scenario time.
         if (config_.brake_in_close_regime && config_.min_distance_m <= 0.0f) {
             DRONE_LOG_WARN("[ObstacleAvoider3D] brake_in_close_regime enabled but "
-                           "min_distance_m={:.3f} <= 0 — brake path will be skipped.",
+                           "min_distance_m={:.3f} <= 0 — brake path will be skipped and "
+                           "close_regime_active_ hysteresis will also be suppressed.",
                            config_.min_distance_m);
         }
 
@@ -226,7 +244,8 @@ public:
 
             float dist = std::sqrt(dx * dx + dy * dy + dz * dz);
 
-            if (dist < config_.influence_radius_per_class[ci] && dist > 0.01f) {
+            if (dist < config_.influence_radius_per_class[ci] &&
+                dist > avoider_constants::kMinDistGateM) {
                 ++active;
                 if (dist < min_active_dist) {
                     min_active_dist = dist;
@@ -256,7 +275,7 @@ public:
                 // so quiet scenarios can disable it (Issue #503).
                 if (config_.log_corrections) {
                     const float cmag = std::sqrt(cx * cx + cy * cy + cz * cz);
-                    if (cmag > 0.5f) {
+                    if (cmag > avoider_constants::kLogPerObstacleThresholdMps) {
                         DRONE_LOG_DEBUG("[Avoider] obstacle d={:.1f}m rep={:.2f} |c|={:.2f}m/s "
                                         "at ({:.1f},{:.1f},{:.1f})",
                                         dist, repulsion, cmag, ox, oy, oz);
@@ -313,7 +332,7 @@ public:
                 // planned command has a vertical component.
                 const float mag_xy =
                     std::sqrt(cmd.velocity_x * cmd.velocity_x + cmd.velocity_y * cmd.velocity_y);
-                if (mag_xy > 0.01f) {
+                if (mag_xy > avoider_constants::kMinVelMagnitude) {
                     const float inv   = 1.0f / mag_xy;
                     const float dx    = cmd.velocity_x * inv;
                     const float dy    = cmd.velocity_y * inv;
@@ -330,7 +349,7 @@ public:
                 const float planned_mag = std::sqrt(cmd.velocity_x * cmd.velocity_x +
                                                     cmd.velocity_y * cmd.velocity_y +
                                                     cmd.velocity_z * cmd.velocity_z);
-                if (planned_mag > 0.01f) {
+                if (planned_mag > avoider_constants::kMinVelMagnitude) {
                     const float inv_mag = 1.0f / planned_mag;
                     const float dir_x   = cmd.velocity_x * inv_mag;
                     const float dir_y   = cmd.velocity_y * inv_mag;
@@ -363,7 +382,7 @@ public:
         float brake_scale   = 1.0f;
         float v_toward      = 0.0f;
         if (close_regime_active_ && config_.brake_in_close_regime &&
-            std::isfinite(min_active_dist) && min_active_dist > 0.01f &&
+            std::isfinite(min_active_dist) && min_active_dist > avoider_constants::kMinDistGateM &&
             config_.min_distance_m > 0.0f) {
             const float inv = 1.0f / min_active_dist;
             const float nx  = nearest_dx * inv;
@@ -406,19 +425,37 @@ public:
         // INFO-gated on log_corrections + meaningful delta so quiet ticks stay
         // at DEBUG.  Magnitude is the Euclidean size of the total correction
         // applied to the planned velocity.
+        //
+        // Log-field reference (for operators parsing [Avoider] lines):
+        //   considered      = objects passing min_confidence filter
+        //   active          = objects within influence_radius_m
+        //   |delta|         = Euclidean magnitude of repulsion correction (m/s)
+        //   path_aware_strip= times path-aware stripping removed an opposing component
+        //   close_regime    = 1 if nearest obstacle < min_distance_m (hysteresis)
+        //   brake           = 1 if PR #617 brake arbitration cancelled forward motion
+        //   v_toward        = forward-velocity component that was cancelled (m/s)
+        //   scale           = proximity-based magnitude scaler applied after cancel
         if (config_.log_corrections) {
             const float delta_mag = std::sqrt(
                 total_rep_x * total_rep_x + total_rep_y * total_rep_y + total_rep_z * total_rep_z);
-            if (active > 0 || delta_mag > 0.1f) {
-                // brake=1 means brake arbitration reduced forward motion this tick
-                // (Issue #513).  v_toward is the forward velocity component that
-                // was cancelled; brake_scale is the proximity-based magnitude
-                // scaler applied after cancellation.
-                DRONE_LOG_INFO(
-                    "[Avoider] considered={} active={} |delta|={:.2f} m/s "
-                    "path_aware_strip={} close_regime={} brake={} v_toward={:.2f} scale={:.2f}",
-                    considered, active, delta_mag, path_aware_strip_count,
-                    close_regime_active_ ? 1 : 0, brake_applied ? 1 : 0, v_toward, brake_scale);
+            if (active > 0 || delta_mag > avoider_constants::kLogDeltaThresholdMps) {
+                // Emit brake fields only when the brake path was entered — on quiet
+                // ticks the three defaults (0, 0.0, 1.0) aren't informative.  This
+                // saves one fmt::format + alloc per active tick when the brake is
+                // idle (PR #617 perf review).
+                if (brake_applied || brake_scale < 1.0f) {
+                    DRONE_LOG_INFO("[Avoider] considered={} active={} |delta|={:.2f} m/s "
+                                   "path_aware_strip={} close_regime={} brake={} v_toward={:.2f} "
+                                   "scale={:.2f}",
+                                   considered, active, delta_mag, path_aware_strip_count,
+                                   close_regime_active_ ? 1 : 0, brake_applied ? 1 : 0, v_toward,
+                                   brake_scale);
+                } else {
+                    DRONE_LOG_INFO("[Avoider] considered={} active={} |delta|={:.2f} m/s "
+                                   "path_aware_strip={} close_regime={}",
+                                   considered, active, delta_mag, path_aware_strip_count,
+                                   close_regime_active_ ? 1 : 0);
+                }
             }
         }
 

--- a/tests/test_obstacle_avoider_3d.cpp
+++ b/tests/test_obstacle_avoider_3d.cpp
@@ -321,6 +321,12 @@ TEST(ObstacleAvoider3DTest, VeryCloseObjectMaxRepulsion) {
     config.max_correction_mps = 3.0f;
     config.min_confidence     = 0.3f;
     config.path_aware         = false;  // test isotropic base repulsion
+    // Disable brake arbitration so this test isolates the max-repulsion clamp.
+    // The #513 brake path cancels forward velocity before repulsion is added,
+    // which would change the total correction magnitude and obscure what this
+    // test is pinning (the Euclidean clamp on the repulsion vector alone).
+    // Dedicated brake tests live further down the file.
+    config.brake_in_close_regime = false;
 
     ObstacleAvoider3D avoider(config);
 
@@ -793,4 +799,157 @@ TEST(ObstacleAvoider3DTest, PathAwareDisabledFallback) {
 
     // Old behavior: obstacle ahead → backwards push applied → vx reduced.
     EXPECT_LT(result.velocity_x, cmd.velocity_x);
+}
+
+// ═════════════════════════════════════════════════════════════
+// Issue #513 — brake arbitration in close regime
+// Regression: the avoider must cancel forward velocity heading INTO a
+// close-regime obstacle, not merely add a lateral deflection.  Scenario-30
+// live-run evidence (see #513 body) showed a 0.98 m/s lateral correction
+// against a 2 m/s forward cruise = ~30° deflection, not a brake.  The
+// drone overshot.  This test pins the correct behaviour.
+// ═════════════════════════════════════════════════════════════
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_CancelsForwardComponent) {
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 2.0f;
+    config.min_distance_m        = 3.0f;
+    config.max_correction_mps    = 5.0f;
+    config.brake_in_close_regime = true;
+    config.path_aware            = false;  // avoid path-aware interaction in this test
+    config.vertical_gain         = 0.0f;   // 2D scenario
+    ObstacleAvoider3D avoider(config);
+
+    // Drone at origin cruising +X at 2 m/s.
+    auto cmd  = make_cmd(2.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Obstacle 2 m ahead — inside min_distance_m so close_regime_active_ fires.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 2.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // With brake_in_close_regime=true and d=2, min_distance=3:
+    //   1. Forward (toward-obstacle) component cancelled: planned 2 m/s → 0.
+    //   2. Proximity scale = d/min_distance = 2/3 ≈ 0.67 applied to residual.
+    //   3. Repulsion adds negative-X push (away from obstacle) so final vx < 0.
+    // Key assertion: the forward motion was REVERSED, not merely deflected.
+    EXPECT_LT(result.velocity_x, 0.0f)
+        << "Forward velocity should be cancelled AND pushed backward by repulsion; "
+        << "got vx=" << result.velocity_x << " (additive-only correction would leave vx > 0)";
+    EXPECT_TRUE(avoider.close_regime_active());
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_DisabledLeavesForwardMotion) {
+    // Regression guard: with brake_in_close_regime=false, the pre-#513 additive-
+    // only behaviour must be preserved.  Same geometry as above — verify vx is
+    // only lightly reduced, not reversed.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 0.5f;  // weak to isolate brake-vs-deflect
+    config.min_distance_m        = 3.0f;
+    config.max_correction_mps    = 1.5f;   // limit correction authority
+    config.brake_in_close_regime = false;  // pre-#513 behaviour
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(2.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 2.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Pre-#513: avoider adds repulsion but doesn't cancel forward component.
+    // With max_correction capped at 1.5 and cruise at 2.0, vx stays positive.
+    EXPECT_GT(result.velocity_x, 0.0f)
+        << "With brake_in_close_regime=false, pre-#513 additive behaviour "
+        << "should leave forward motion above zero; got vx=" << result.velocity_x;
+    EXPECT_TRUE(avoider.close_regime_active());
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_ProximityScalingLinear) {
+    // Verify the proximity scaler: at d = min_distance, scale = 1 (no extra
+    // slowdown beyond forward-cancellation).  At d = min_distance/2, scale = 0.5
+    // applied to what's left of cmd.velocity (lateral component survives).
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 0.0f;  // no repulsion — isolate brake math
+    config.min_distance_m        = 4.0f;
+    config.max_correction_mps    = 10.0f;
+    config.brake_in_close_regime = true;
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    // Drone cruising +X 2 m/s, also +Y 1 m/s (lateral component).
+    auto cmd  = make_cmd(2.0f, 1.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Obstacle 2 m straight ahead — toward-component = 2, lateral = 1.
+    // After forward cancellation: cmd = (0, 1, 0).
+    // Proximity scale = 2/4 = 0.5 → cmd = (0, 0.5, 0).
+    // No repulsion added.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 2.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Forward component cancelled, proximity-scaled lateral survives.
+    EXPECT_NEAR(result.velocity_x, 0.0f, 1e-4f);
+    EXPECT_NEAR(result.velocity_y, 0.5f, 1e-4f);
+    EXPECT_NEAR(result.velocity_z, 0.0f, 1e-4f);
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_NoEffectOutsideCloseRegime) {
+    // When nearest obstacle is inside influence_radius but outside min_distance,
+    // close_regime_active_ should be false and brake should NOT apply.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 0.5f;
+    config.min_distance_m        = 2.0f;
+    config.max_correction_mps    = 1.0f;
+    config.brake_in_close_regime = true;
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(2.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Obstacle 5 m ahead — well outside min_distance (2 m).
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 5.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Close regime should NOT be active.
+    EXPECT_FALSE(avoider.close_regime_active());
+    // Forward motion should still be largely intact — only weak repulsion applied.
+    EXPECT_GT(result.velocity_x, 0.5f)
+        << "Outside close regime, brake should not apply; vx=" << result.velocity_x;
 }

--- a/tests/test_obstacle_avoider_3d.cpp
+++ b/tests/test_obstacle_avoider_3d.cpp
@@ -312,9 +312,12 @@ TEST(ObstacleAvoider3DTest, VerticalGainOne_ProducesZRepulsion) {
 // Dead zone fix: very close objects (Issue #225)
 // ═════════════════════════════════════════════════════════════
 
-TEST(ObstacleAvoider3DTest, VeryCloseObjectMaxRepulsion) {
+TEST(ObstacleAvoider3DTest, VeryCloseObjectMaxRepulsion_BrakeDisabled) {
     // Objects at distance 0.05m (between old 0.1m threshold and new 0.01m)
     // should now receive maximum repulsion (clamped by max_correction_mps).
+    // _BrakeDisabled suffix: this test isolates the Euclidean max-correction
+    // clamp on the repulsion vector, not the #513 brake path.  See the
+    // `brake_in_close_regime=false` setter below for the full rationale.
     ObstacleAvoider3DConfig config;
     config.influence_radius_m = 5.0f;
     config.repulsive_gain     = 2.0f;
@@ -838,15 +841,18 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_CancelsForwardComponent) {
 
     // With brake_in_close_regime=true and d=2, min_distance=3:
     //   1. Forward (toward-obstacle) component cancelled: planned 2 m/s → 0.
-    //   2. Proximity scale = d/min_distance = 2/3 ≈ 0.67 applied to residual.
-    //   3. Repulsion adds negative-X push (away from obstacle) so final vx < 0.
-    // Key assertion: the forward motion was REVERSED, not merely deflected.
-    EXPECT_LT(result.velocity_x, 0.0f)
-        << "Forward velocity should be cancelled AND pushed backward by repulsion; "
-        << "got vx=" << result.velocity_x << " (additive-only correction would leave vx > 0)";
-    // Upper bound — runaway repulsion regression guard (PR #617 test-unit review).
-    // max_correction_mps clamps the repulsion vector to 5 m/s; with the 0.01
-    // clamp-path tolerance, output vx cannot drop below -5.01.
+    //   2. Proximity scale = d/min_distance = 2/3 ≈ 0.667 applied to residual (0).
+    //   3. Repulsion: gain=2 at dist=2 → |rep|=0.5 in -X direction.
+    //   4. Final vx = 0 - 0.5 = -0.5 (below max_correction_mps clamp of 5, so
+    //      no clamping).
+    // Tight assertion (PR #617 Pass 2 test-quality review): pin the exact
+    // value.  A half-plane EXPECT_LT would let a repulsion-doubling regression
+    // pass; EXPECT_NEAR catches both direction AND magnitude regressions.
+    EXPECT_NEAR(result.velocity_x, -0.5f, 0.05f)
+        << "Expected forward-cancel + repulsion in -X = -0.5 m/s; got vx=" << result.velocity_x
+        << " — check brake cancellation or repulsion magnitude.";
+    // Belt-and-braces guard for the max_correction_mps clamp path: even if
+    // the tight assertion above drifts, we must never exceed the clamp.
     EXPECT_GT(result.velocity_x, -config.max_correction_mps - 0.01f)
         << "Output exceeded max_correction clamp — repulsion vector "
         << "magnitude regression? Got vx=" << result.velocity_x;
@@ -881,10 +887,15 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_DisabledLeavesForwardMotion) {
     auto result = avoider.avoid(cmd, pose, objects);
 
     // Pre-#513: avoider adds repulsion but doesn't cancel forward component.
-    // With max_correction capped at 1.5 and cruise at 2.0, vx stays positive.
-    EXPECT_GT(result.velocity_x, 0.0f)
-        << "With brake_in_close_regime=false, pre-#513 additive behaviour "
-        << "should leave forward motion above zero; got vx=" << result.velocity_x;
+    // Repulsion: gain=0.5 at dist=2 → raw mag = 0.5 / 4 = 0.125 in -X.
+    // Below max_correction_mps clamp (1.5), so no clamping; final vx = 2 - 0.125.
+    // Tight assertion (PR #617 Pass 2 test-quality review): a regression that
+    // reduces vx from 2.0 to 0.01 (still > 0) would slip past a half-plane
+    // EXPECT_GT; EXPECT_NEAR pins the additive-only magnitude exactly.
+    EXPECT_NEAR(result.velocity_x, 1.875f, 0.05f)
+        << "Pre-#513 additive behaviour: expected vx = 2.0 - 0.125 ≈ 1.875; got "
+        << result.velocity_x
+        << " — did repulsion magnitude change, or did brake-disable path break?";
     EXPECT_TRUE(avoider.close_regime_active());
 }
 
@@ -955,18 +966,26 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_NoEffectOutsideCloseRegime) {
 
     // Close regime should NOT be active.
     EXPECT_FALSE(avoider.close_regime_active());
-    // Forward motion should still be largely intact — only weak repulsion applied.
-    EXPECT_GT(result.velocity_x, 0.5f)
-        << "Outside close regime, brake should not apply; vx=" << result.velocity_x;
+    // Repulsion: gain=0.5 at dist=5 → raw mag = 0.5 / 25 = 0.02 in -X.
+    // Below max_correction clamp (1.0), final vx = 2.0 - 0.02 = 1.98.
+    // Tight assertion (PR #617 Pass 2 test-quality review): a silent regression
+    // that applied brake scale here would bring vx to ≈ 1 or less — EXPECT_NEAR
+    // catches it where half-plane EXPECT_GT(vx, 0.5) would not.
+    EXPECT_NEAR(result.velocity_x, 1.98f, 0.05f)
+        << "Outside close regime: expected vx ≈ 2.0 - 0.02 = 1.98 (weak repulsion only). "
+        << "Got vx=" << result.velocity_x
+        << " — if close to 1.0, brake scale leaked outside close regime.";
 }
 
-TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_ObstacleBehind_NoForwardCancel) {
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_ObstacleBehind_SkipsCancelAppliesScale) {
     // Coverage for the `v_toward <= 0` branch (PR #617 test-unit review).
     // Drone is IN close regime (obstacle 1 m behind) but moving AWAY from it.
     // The forward-cancellation step must be skipped (brake=0 path), while the
     // proximity scale still applies to whatever lateral / forward motion is
     // commanded — a persistent retreat obstacle should not suddenly amplify
-    // the drone's command just because the drone is retreating.
+    // the drone's command just because the drone is retreating.  The suffix
+    // "_SkipsCancelAppliesScale" spells out both halves of the observable
+    // behaviour for this branch.
     ObstacleAvoider3DConfig config;
     config.influence_radius_m    = 10.0f;
     config.repulsive_gain        = 0.0f;  // isolate brake math from repulsion
@@ -1055,5 +1074,98 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_MinBrakeScaleFloor) {
         << "Lateral velocity after floor: expected cruise_y=1.0 × min_brake_scale=0.1 "
         << "= 0.1. Got " << result.velocity_y
         << " — min_brake_scale floor failed (check std::max ordering).";
+    EXPECT_NEAR(result.velocity_z, 0.0f, 1e-4f);
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_HysteresisExitDisengagesBrake) {
+    // Boundary case (PR #617 Pass 2 test-quality review): the brake is gated
+    // by `close_regime_active_`, which is itself hysteresis-gated.  Enter
+    // close regime with an obstacle inside min_distance_m, then on the next
+    // call move the obstacle beyond `min_distance + hysteresis` — brake must
+    // disengage AND the output must revert to additive-only semantics.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m             = 10.0f;
+    config.repulsive_gain                 = 0.5f;
+    config.min_distance_m                 = 2.0f;
+    config.path_aware_bypass_hysteresis_m = 0.5f;  // exit threshold = 2.5 m
+    config.max_correction_mps             = 5.0f;
+    config.brake_in_close_regime          = true;
+    config.path_aware                     = false;
+    config.vertical_gain                  = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(2.0f, 0.0f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Tick 1 — obstacle at 1.5 m, brake MUST engage.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 1.5f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+    auto tick1                    = avoider.avoid(cmd, pose, objects);
+    ASSERT_TRUE(avoider.close_regime_active())
+        << "Tick 1 should enter close regime at d=1.5 < min_distance=2.0.";
+    EXPECT_LT(tick1.velocity_x, 1.0f)
+        << "Brake should have cancelled most of the forward velocity on tick 1.";
+
+    // Tick 2 — obstacle moved to 3.0 m (well beyond the 2.5 m exit threshold).
+    // close_regime should deactivate; additive-only behaviour returns.
+    objects.objects[0].position_x = 3.0f;
+    objects.timestamp_ns          = now_ns();
+    auto tick2                    = avoider.avoid(cmd, pose, objects);
+    EXPECT_FALSE(avoider.close_regime_active())
+        << "Tick 2 should exit close regime at d=3.0 > min_distance + hysteresis = 2.5.";
+    // Expected (additive-only): gain=0.5 / 9 ≈ 0.056; vx = 2 - 0.056 ≈ 1.944.
+    EXPECT_NEAR(tick2.velocity_x, 1.944f, 0.05f)
+        << "After hysteresis exit, brake must disengage completely; "
+        << "expected additive-only vx ≈ 1.944, got " << tick2.velocity_x;
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_ZeroVelocityInput_NoNaN) {
+    // Boundary case (PR #617 Pass 2 test-quality review): defensive check
+    // that `v_toward = cmd · n̂ = 0` doesn't propagate NaN or divide by
+    // anything.  The brake block's forward-cancel branch is guarded by
+    // `v_toward > 0.0f`, so zero velocity should skip step 1 cleanly.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 2.0f;
+    config.min_distance_m        = 2.0f;
+    config.max_correction_mps    = 5.0f;
+    config.brake_in_close_regime = true;
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(0.0f, 0.0f, 0.0f);  // stationary cruise (hover)
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Obstacle 1 m ahead — brake armed but cruise is zero.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 1.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Expected:
+    //  - v_toward = 0 · n̂ = 0 → step 1 (forward cancel) SKIPPED.
+    //  - brake_scale = 1/2 = 0.5; applied to (0,0,0) yields (0,0,0).
+    //  - Repulsion: gain=2 at dist=1 → raw mag 2.0, clamped to max=5 → stays 2.0.
+    //  - Direction: -X from obstacle → total_rep_x = -2.0.
+    //  - Final: (0,0,0) + (-2.0, 0, 0) = (-2.0, 0, 0).
+    ASSERT_TRUE(std::isfinite(result.velocity_x));
+    ASSERT_TRUE(std::isfinite(result.velocity_y));
+    ASSERT_TRUE(std::isfinite(result.velocity_z));
+    EXPECT_TRUE(avoider.close_regime_active());
+    EXPECT_NEAR(result.velocity_x, -2.0f, 0.05f)
+        << "Zero-cruise + close-regime should leave cmd at 0, repulsion alone "
+        << "pushes -X; expected vx ≈ -2.0, got " << result.velocity_x;
+    EXPECT_NEAR(result.velocity_y, 0.0f, 1e-4f);
     EXPECT_NEAR(result.velocity_z, 0.0f, 1e-4f);
 }

--- a/tests/test_obstacle_avoider_3d.cpp
+++ b/tests/test_obstacle_avoider_3d.cpp
@@ -844,6 +844,12 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_CancelsForwardComponent) {
     EXPECT_LT(result.velocity_x, 0.0f)
         << "Forward velocity should be cancelled AND pushed backward by repulsion; "
         << "got vx=" << result.velocity_x << " (additive-only correction would leave vx > 0)";
+    // Upper bound — runaway repulsion regression guard (PR #617 test-unit review).
+    // max_correction_mps clamps the repulsion vector to 5 m/s; with the 0.01
+    // clamp-path tolerance, output vx cannot drop below -5.01.
+    EXPECT_GT(result.velocity_x, -config.max_correction_mps - 0.01f)
+        << "Output exceeded max_correction clamp — repulsion vector "
+        << "magnitude regression? Got vx=" << result.velocity_x;
     EXPECT_TRUE(avoider.close_regime_active());
 }
 
@@ -952,4 +958,102 @@ TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_NoEffectOutsideCloseRegime) {
     // Forward motion should still be largely intact — only weak repulsion applied.
     EXPECT_GT(result.velocity_x, 0.5f)
         << "Outside close regime, brake should not apply; vx=" << result.velocity_x;
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_ObstacleBehind_NoForwardCancel) {
+    // Coverage for the `v_toward <= 0` branch (PR #617 test-unit review).
+    // Drone is IN close regime (obstacle 1 m behind) but moving AWAY from it.
+    // The forward-cancellation step must be skipped (brake=0 path), while the
+    // proximity scale still applies to whatever lateral / forward motion is
+    // commanded — a persistent retreat obstacle should not suddenly amplify
+    // the drone's command just because the drone is retreating.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 0.0f;  // isolate brake math from repulsion
+    config.min_distance_m        = 2.0f;
+    config.max_correction_mps    = 5.0f;
+    config.brake_in_close_regime = true;
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    // Drone moving -X (retreating).  Cruise = (-1, 0.5, 0) (retreat + slight
+    // lateral drift).
+    auto cmd  = make_cmd(-1.0f, 0.5f, 0.0f);
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Obstacle BEHIND the drone at (+1, 0, 5) — relative vector +X, drone
+    // cmd is -X, so v_toward = cmd · n̂ = (-1)*(+1) + 0 + 0 = -1 < 0.
+    // Forward-cancel path MUST be skipped.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 1.0f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Expected behaviour:
+    //  - close_regime_active_ = true (dist=1 < min_distance=2)
+    //  - v_toward = -1 (drone retreating)
+    //  - Forward-cancel branch NOT taken: cmd untouched by step 1.
+    //  - Proximity scale = min(1, 1/2) = 0.5, floored by min_brake_scale=0.1
+    //    (not hit, 0.5 > 0.1) → 0.5 applied to whole vector.
+    //  - Final: (-0.5, 0.25, 0).
+    EXPECT_TRUE(avoider.close_regime_active());
+    EXPECT_NEAR(result.velocity_x, -0.5f, 1e-4f)
+        << "Retreating drone in close regime: forward-cancel should skip and "
+        << "proximity scale alone should halve the retreat velocity.";
+    EXPECT_NEAR(result.velocity_y, 0.25f, 1e-4f)
+        << "Lateral command should also be halved by proximity scale.";
+    EXPECT_NEAR(result.velocity_z, 0.0f, 1e-4f);
+}
+
+TEST(ObstacleAvoider3DTest, BrakeInCloseRegime_MinBrakeScaleFloor) {
+    // Spurious-detection regression guard (PR #617 fault-recovery P2).  A
+    // single radar return at 0.05 m against min_distance_m=2.0 would naively
+    // compute brake_scale = 0.025 — a near-full-stop command for one tick.
+    // The min_brake_scale floor must clamp the output to `min_brake_scale ×
+    // cruise` regardless of how close the spurious detection reports.
+    ObstacleAvoider3DConfig config;
+    config.influence_radius_m    = 10.0f;
+    config.repulsive_gain        = 0.0f;  // isolate brake from repulsion
+    config.min_distance_m        = 2.0f;
+    config.max_correction_mps    = 5.0f;
+    config.brake_in_close_regime = true;
+    config.min_brake_scale       = 0.1f;  // floor = 10 %
+    config.path_aware            = false;
+    config.vertical_gain         = 0.0f;
+    ObstacleAvoider3D avoider(config);
+
+    auto cmd  = make_cmd(2.0f, 1.0f, 0.0f);  // cruise + lateral
+    auto pose = make_pose(0.0f, 0.0f, 5.0f);
+
+    // Spurious detection 5 cm ahead — well below the > 0.01 m gate so it
+    // enters the loop and drives close_regime_active_.  Without a floor,
+    // proximity scale would be 0.025.
+    drone::ipc::DetectedObjectList objects{};
+    objects.num_objects           = 1;
+    objects.objects[0].position_x = 0.05f;
+    objects.objects[0].position_y = 0.0f;
+    objects.objects[0].position_z = 5.0f;
+    objects.objects[0].confidence = 0.9f;
+    objects.timestamp_ns          = now_ns();
+
+    auto result = avoider.avoid(cmd, pose, objects);
+
+    // Expected:
+    //  - Forward-cancel zeroes the +X component of cmd (cmd becomes (0, 1, 0)).
+    //  - Raw scale = 0.05 / 2.0 = 0.025.
+    //  - Floor (0.1) wins: scale = max(0.025, 0.1) = 0.1.
+    //  - Output = (0, 0.1, 0) — NOT (0, 0.025, 0).
+    EXPECT_TRUE(avoider.close_regime_active());
+    EXPECT_NEAR(result.velocity_x, 0.0f, 1e-4f);
+    EXPECT_NEAR(result.velocity_y, 0.1f, 1e-4f)
+        << "Lateral velocity after floor: expected cruise_y=1.0 × min_brake_scale=0.1 "
+        << "= 0.1. Got " << result.velocity_y
+        << " — min_brake_scale floor failed (check std::max ordering).";
+    EXPECT_NEAR(result.velocity_z, 0.0f, 1e-4f);
 }


### PR DESCRIPTION
## Summary

Closes #513.

Implements the "Primary — avoider brake arbitration" fix from the issue body. When `close_regime_active_` fires, the avoider now:

1. Cancels the component of `cmd.velocity` pointing at the nearest obstacle (forward momentum no longer drives the drone into the obstacle).
2. Scales total commanded magnitude by proximity — linear ramp from zero at the obstacle surface to full speed at `min_distance_m`.
3. Adds the existing repulsive lateral correction unchanged.

Result: the ~30° additive deflection of the old code becomes a true brake + deflect.

## Config

New key: `mission_planner.obstacle_avoidance.brake_in_close_regime` (default **true**). Scenarios wanting pure-deflection semantics set it to `false`.

## Non-scope (tracked elsewhere)

- Active retreat / reverse-velocity + forced `invalidate_path()` — filed as **#615** (radar-only collision reflex, depends on this PR merging first).

## Test plan

- [x] 4 new unit tests in `test_obstacle_avoider_3d.cpp`:
  - `BrakeInCloseRegime_CancelsForwardComponent`
  - `BrakeInCloseRegime_DisabledLeavesForwardMotion`
  - `BrakeInCloseRegime_ProximityScalingLinear`
  - `BrakeInCloseRegime_NoEffectOutsideCloseRegime`
- [x] Updated `VeryCloseObjectMaxRepulsion` to isolate the max-clamp property it was written to pin (sets `brake_in_close_regime=false`).
- [x] 28/28 tests in the avoider suite pass.
- [x] 1589/1589 total tests pass via ctest.
- [x] clang-format-18 clean.
- [ ] Scenario 30 Cosys live run verifies the overshoot from the #513 body is resolved (requires desktop — will run after CI passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
