### PR TITLE
feat(#616): DA V2 anchored-scale calibration + texture-gated sampling

### DIFF
--- a/common/hal/include/hal/cpu_semantic_projector.h
+++ b/common/hal/include/hal/cpu_semantic_projector.h
@@ -59,9 +59,24 @@ public:
 
     [[nodiscard]] std::string name() const override { return "CpuSemanticProjector"; }
 
+    /// Texture gate (Issue #616) — reject depth samples in low-gradient regions
+    /// of the depth map.  Flat depth regions correspond to DA V2's weakest
+    /// failure mode (cube faces, sky, textureless walls) where the network
+    /// has no features to latch onto.  Threshold is depth-gradient magnitude
+    /// (metres per pixel).  0.0 = disabled (backward-compatible default).
+    /// Operators tune this against scenario 33's `check_voxel_on_target.py`
+    /// output; 0.05-0.2 m/px is a reasonable starting range for DA V2 at
+    /// 518x518 input.
+    void set_texture_gate_threshold(float threshold) {
+        texture_gate_threshold_ = std::max(0.0f, threshold);
+    }
+
+    [[nodiscard]] float texture_gate_threshold() const { return texture_gate_threshold_; }
+
 private:
     CameraIntrinsics intrinsics_{};
     bool             initialized_{false};
+    float            texture_gate_threshold_{0.0f};
 
     // Back-project pixel (u,v) at depth Z to a world-frame 3D point
     [[nodiscard]] Eigen::Vector3f backproject(float u, float v, float z,
@@ -90,7 +105,51 @@ private:
         // 50-100 m depth, filling the grid far past `max_static_cells`.)
         constexpr float kMaxObstacleDepth = 20.0f;
         if (d > kMaxObstacleDepth) return 0.0f;
+        // Texture gate (Issue #616) — reject samples where the local depth
+        // gradient is below threshold.  Cube faces, sky, untextured walls
+        // produce nearly-flat depth output from DA V2 (the network has no
+        // features to latch onto); voxelising them pollutes the grid.
+        // Computing the gradient on the *depth* map (not RGB) is a proxy
+        // for DA V2 confidence — if the model couldn't see variation, we
+        // shouldn't trust the metres it reports.  Disabled by default
+        // (threshold=0 short-circuits at the top of the check).
+        if (texture_gate_threshold_ > 0.0f &&
+            depth_gradient_magnitude(depth, dx, dy) < texture_gate_threshold_) {
+            return 0.0f;
+        }
         return d;
+    }
+
+    /// Sobel-style gradient magnitude on the depth map at pixel (dx, dy).
+    /// Returns the magnitude in metres-per-pixel (depth units).  Safely
+    /// clamps the 3x3 stencil at the map boundary.  Used by the texture
+    /// gate above.
+    [[nodiscard]] float depth_gradient_magnitude(const DepthMap& depth, uint32_t dx,
+                                                 uint32_t dy) const {
+        if (depth.width < 3 || depth.height < 3) return 0.0f;
+        const uint32_t x1 = dx == 0 ? 0 : dx - 1;
+        const uint32_t x2 = std::min<uint32_t>(dx + 1, depth.width - 1);
+        const uint32_t y1 = dy == 0 ? 0 : dy - 1;
+        const uint32_t y2 = std::min<uint32_t>(dy + 1, depth.height - 1);
+
+        const auto at = [&](uint32_t x, uint32_t y) {
+            return depth.data[y * depth.width + x] * depth.scale;
+        };
+
+        // 3x3 Sobel stencil — standard kernels for Gx and Gy.  Non-finite
+        // samples anywhere in the stencil poison the whole gradient (return
+        // 0 so the texture gate fails closed — a safe default).
+        const float p00 = at(x1, y1), p01 = at(dx, y1), p02 = at(x2, y1);
+        const float p10 = at(x1, dy), p12 = at(x2, dy);
+        const float p20 = at(x1, y2), p21 = at(dx, y2), p22 = at(x2, y2);
+        if (!std::isfinite(p00) || !std::isfinite(p01) || !std::isfinite(p02) ||
+            !std::isfinite(p10) || !std::isfinite(p12) || !std::isfinite(p20) ||
+            !std::isfinite(p21) || !std::isfinite(p22)) {
+            return 0.0f;
+        }
+        const float gx = (p02 + 2.0f * p12 + p22) - (p00 + 2.0f * p10 + p20);
+        const float gy = (p20 + 2.0f * p21 + p22) - (p00 + 2.0f * p01 + p02);
+        return std::sqrt(gx * gx + gy * gy);
     }
 
     void project_bbox_centre(const InferenceDetection& det, const DepthMap& depth,

--- a/common/hal/include/hal/cpu_semantic_projector.h
+++ b/common/hal/include/hal/cpu_semantic_projector.h
@@ -62,21 +62,40 @@ public:
     /// Texture gate (Issue #616) — reject depth samples in low-gradient regions
     /// of the depth map.  Flat depth regions correspond to DA V2's weakest
     /// failure mode (cube faces, sky, textureless walls) where the network
-    /// has no features to latch onto.  Threshold is depth-gradient magnitude
-    /// (metres per pixel).  0.0 = disabled (backward-compatible default).
-    /// Operators tune this against scenario 33's `check_voxel_on_target.py`
-    /// output; 0.05-0.2 m/px is a reasonable starting range for DA V2 at
-    /// 518x518 input.
+    /// has no features to latch onto.
+    ///
+    /// Threshold is compared against the **un-normalised 3×3 Sobel magnitude**
+    /// on the depth map at the sample pixel — that is, `sqrt(Gx^2 + Gy^2)`
+    /// without dividing by the kernel sum of 8.  Units are "depth units
+    /// summed across the Sobel stencil", not strict metres-per-pixel.  A
+    /// flat 1 m/px depth step produces a magnitude of ~8, not 1.  Operators
+    /// tune empirically against scenario voxel-on-target output rather than
+    /// computing a theoretical threshold.  0.3-1.0 is a reasonable starting
+    /// range for DA V2 @ 518×518 on the Blocks environment.
+    ///
+    /// 0.0 = disabled (backward-compatible default).
     void set_texture_gate_threshold(float threshold) {
         texture_gate_threshold_ = std::max(0.0f, threshold);
     }
 
     [[nodiscard]] float texture_gate_threshold() const { return texture_gate_threshold_; }
 
+    /// Upper metric depth cutoff (PR #620 code-quality review).  Samples
+    /// beyond this are rejected as horizon / sky contours.  Must match
+    /// `perception.depth_estimator.max_depth_m` to avoid an asymmetric
+    /// config where the estimator reports depths the projector then
+    /// silently drops.  Default 20 m (matches pre-#620 hardcoded value).
+    void set_max_obstacle_depth_m(float max_depth_m) {
+        max_obstacle_depth_m_ = std::max(0.1f, max_depth_m);
+    }
+
+    [[nodiscard]] float max_obstacle_depth_m() const { return max_obstacle_depth_m_; }
+
 private:
     CameraIntrinsics intrinsics_{};
     bool             initialized_{false};
     float            texture_gate_threshold_{0.0f};
+    float            max_obstacle_depth_m_{20.0f};
 
     // Back-project pixel (u,v) at depth Z to a world-frame 3D point
     [[nodiscard]] Eigen::Vector3f backproject(float u, float v, float z,
@@ -95,16 +114,19 @@ private:
             std::clamp(v * scale_y, 0.0f, static_cast<float>(depth.height - 1)));
         const float d = depth.data[dy * depth.width + dx] * depth.scale;
         if (!std::isfinite(d) || d <= 0.0f) return 0.0f;
-        // Reject samples beyond kMaxObstacleDepth — distant horizon / sky /
+        // Reject samples beyond max_obstacle_depth_m_ — distant horizon / sky /
         // scenery contours are not navigation-relevant and would otherwise
-        // flood the downstream occupancy grid with ghost voxels.  20 m is a
-        // conservative drone-scale cutoff; real obstacles the planner needs
-        // to route around are well within this range at scenario cruise
-        // speeds.  (#608 E5.INT — discovered when EdgeContourSAM masks
-        // picked up every image edge and back-projected them into voxels at
-        // 50-100 m depth, filling the grid far past `max_static_cells`.)
-        constexpr float kMaxObstacleDepth = 20.0f;
-        if (d > kMaxObstacleDepth) return 0.0f;
+        // flood the downstream occupancy grid with ghost voxels.  The cutoff
+        // is piped in from config by P2 main.cpp (should match
+        // `perception.depth_estimator.max_depth_m` — PR #620 code-quality
+        // review fixed the asymmetry where this was hardcoded at 20 m while
+        // the estimator's ceiling was config-driven).  Default 20 m; real
+        // obstacles the planner needs to route around are well within this
+        // range at scenario cruise speeds.  (#608 E5.INT — discovered when
+        // EdgeContourSAM masks picked up every image edge and back-projected
+        // them into voxels at 50-100 m depth, filling the grid far past
+        // `max_static_cells`.)
+        if (d > max_obstacle_depth_m_) return 0.0f;
         // Texture gate (Issue #616) — reject samples where the local depth
         // gradient is below threshold.  Cube faces, sky, untextured walls
         // produce nearly-flat depth output from DA V2 (the network has no
@@ -120,10 +142,15 @@ private:
         return d;
     }
 
-    /// Sobel-style gradient magnitude on the depth map at pixel (dx, dy).
-    /// Returns the magnitude in metres-per-pixel (depth units).  Safely
-    /// clamps the 3x3 stencil at the map boundary.  Used by the texture
-    /// gate above.
+    /// Un-normalised 3x3 Sobel magnitude on the depth map at pixel (dx, dy).
+    /// Returns `sqrt(Gx^2 + Gy^2)` where Gx, Gy use the raw Sobel kernel
+    /// without dividing by the kernel sum of 8.  Units are "depth units
+    /// summed across the stencil" — a flat 1 m/pixel ramp returns ~8.
+    /// Used by the texture gate above; the operator picks the threshold
+    /// against the actual output magnitude (not a theoretical m/px value).
+    /// Safely clamps the 3x3 stencil at the map boundary.  PR #620
+    /// api-contract review relabelled this from "metres per pixel" — the
+    /// old label was off by the kernel-sum factor.
     [[nodiscard]] float depth_gradient_magnitude(const DepthMap& depth, uint32_t dx,
                                                  uint32_t dy) const {
         if (depth.width < 3 || depth.height < 3) return 0.0f;

--- a/common/hal/include/hal/depth_anything_v2.h
+++ b/common/hal/include/hal/depth_anything_v2.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 #include <string>
 
 namespace drone::hal {
@@ -24,24 +25,45 @@ namespace drone::hal {
 /// Depth Anything V2 monocular depth estimator using OpenCV DNN.
 ///
 /// Loads a DA V2 ONNX model (ViT-S ~100MB) and produces per-pixel metric depth.
-/// The model outputs relative inverse depth which is converted to metric depth via:
-///   metric_depth = max_depth / (normalized_output + epsilon)
+///
+/// Two conversion paths (select via `dav2.calibration_enabled`):
+///
+/// - **Per-frame (default)**: compute min/max of raw output per frame, linearly
+///   remap to `[min_depth, max_depth]`.  Simplest correct conversion for a
+///   relative-depth model.  Scale shifts between frames based on scene content
+///   (looking at a near cube vs a distant horizon remaps identical raw values
+///   to different metres) — acceptable for most uses but produces drifting
+///   voxel positions in PATH A.
+///
+/// - **Calibrated (Issue #616)**: use a fitted `(raw_min_ref, raw_max_ref)`
+///   pair to anchor the normalisation across frames, then apply an optional
+///   linear fit `metric = a × metric_anchored + b`.  Produces stable scale.
+///   Fit with `tools/calibrate_depth_anything_v2.py` from a scenario run's
+///   `perception.log`.
 ///
 /// NOT thread-safe: net_ is mutated on each estimate() call.
 /// Only call from a single thread (the depth thread in P2).
 ///
 /// Config keys:
-///   perception.depth_estimator.backend      = "depth_anything_v2"
-///   perception.depth_estimator.model_path   (default "models/depth_anything_v2_vits.onnx")
-///   perception.depth_estimator.input_size   (default 518)
-///   perception.depth_estimator.max_fps      (default 15)
-///   perception.depth_estimator.max_depth_m  (default 20.0 — metric conversion ceiling)
+///   perception.depth_estimator.backend                     = "depth_anything_v2"
+///   perception.depth_estimator.model_path                  (default "models/depth_anything_v2_vits.onnx")
+///   perception.depth_estimator.input_size                  (default 518)
+///   perception.depth_estimator.max_fps                     (default 15)
+///   perception.depth_estimator.max_depth_m                 (default 20.0 — metric ceiling)
+///
+///   perception.depth_estimator.dav2.calibration_enabled    (default false — per-frame path)
+///   perception.depth_estimator.dav2.raw_min_ref            (default NaN — per-frame min used)
+///   perception.depth_estimator.dav2.raw_max_ref            (default NaN — per-frame max used)
+///   perception.depth_estimator.dav2.calibration_coef_a     (default 1.0 — identity passthrough)
+///   perception.depth_estimator.dav2.calibration_coef_b     (default 0.0 — identity passthrough)
 class DepthAnythingV2Estimator : public IDepthEstimator {
 public:
     /// Construct from config.
     explicit DepthAnythingV2Estimator(const drone::Config& cfg, const std::string& section);
 
     /// Construct with explicit parameters (for testing / direct use).
+    /// Always uses the per-frame normalisation path.  To exercise the
+    /// calibrated path in tests, use the Config-driven constructor.
     explicit DepthAnythingV2Estimator(const std::string& model_path, int input_size = 518,
                                       float max_depth_m = 20.0f);
 
@@ -56,6 +78,10 @@ public:
     /// Check if ONNX model was loaded successfully.
     [[nodiscard]] bool is_loaded() const { return model_loaded_; }
 
+    /// True if the calibrated conversion path is active.  Exposed for
+    /// diagnostics + tests.
+    [[nodiscard]] bool calibration_enabled() const { return calibration_enabled_; }
+
 private:
     void load_model(const std::string& model_path);
 
@@ -65,6 +91,15 @@ private:
     bool  model_loaded_ = false;
     int   input_size_   = 518;
     float max_depth_m_  = 20.0f;  // metric conversion: depth = max_depth / (inv_depth + eps)
+
+    // ── Calibration path (Issue #616) ──────────────────────────────
+    // All zero-valued by default; enabled only when calibration_enabled_
+    // is set via the Config-driven constructor.
+    bool  calibration_enabled_ = false;
+    float raw_min_ref_         = std::numeric_limits<float>::quiet_NaN();
+    float raw_max_ref_         = std::numeric_limits<float>::quiet_NaN();
+    float calibration_coef_a_  = 1.0f;
+    float calibration_coef_b_  = 0.0f;
 };
 
 }  // namespace drone::hal

--- a/common/hal/include/hal/depth_anything_v2.h
+++ b/common/hal/include/hal/depth_anything_v2.h
@@ -90,7 +90,8 @@ private:
 #endif
     bool  model_loaded_ = false;
     int   input_size_   = 518;
-    float max_depth_m_  = 20.0f;  // metric conversion: depth = max_depth / (inv_depth + eps)
+    float max_depth_m_  = 20.0f;  // upper metric bound (output is clamped here)
+    float min_depth_m_  = 0.1f;   // lower metric bound (closest reportable obstacle)
 
     // ── Calibration path (Issue #616) ──────────────────────────────
     // All zero-valued by default; enabled only when calibration_enabled_
@@ -101,5 +102,69 @@ private:
     float calibration_coef_a_  = 1.0f;
     float calibration_coef_b_  = 0.0f;
 };
+
+// ═══════════════════════════════════════════════════════════════════════
+// Calibration math — free functions (Issue #616, PR #620 review refactor)
+//
+// Exposed at file scope so the per-pixel math is unit-testable without
+// needing the ONNX model loaded.  `DepthAnythingV2Estimator::estimate()`
+// calls these helpers once the model has produced its raw inverse-depth
+// output.  See the class docstring for the two conversion paths.
+// ═══════════════════════════════════════════════════════════════════════
+
+struct DepthConversionParams {
+    float min_depth_m         = 0.1f;
+    float max_depth_m         = 20.0f;
+    bool  calibration_enabled = false;
+    float anchor_min          = 0.0f;
+    float anchor_max          = 1.0f;
+    float calibration_coef_a  = 1.0f;
+    float calibration_coef_b  = 0.0f;
+};
+
+/// Convert a single raw DA V2 inverse-depth sample to metric depth.
+///
+/// Preserves pre-#616 per-frame semantics when `calibration_enabled=false`:
+/// caller supplies `anchor_min`/`anchor_max` = this frame's min/max, the
+/// `range = anchor_max - anchor_min` is > eps, and no clamping is applied
+/// to the result.
+///
+/// When `calibration_enabled=true`:
+///   1. Normalise with the fitted anchor window (clamp to [0,1] so a raw
+///      sample outside the window doesn't extrapolate wildly).
+///   2. Linear-remap to [min_depth_m, max_depth_m].
+///   3. Apply the linear fit `metric = a*metric + b`.
+///   4. Clamp output to [min_depth_m, max_depth_m].
+///
+/// NaN / Inf guard (memory-safety P3 / fault-recovery P3): a non-finite raw
+/// sample fails closed — returns `max_depth_m` (far-depth), the most
+/// conservative default for obstacle avoidance.  Prevents NaN propagation
+/// into downstream voxel positions.
+[[nodiscard]] inline float convert_raw_to_metric(float raw, float range,
+                                                 const DepthConversionParams& p) {
+    // Non-finite raw output (ONNX corruption / numerical glitch) → fail
+    // closed to far-depth.  Applies to both per-frame and calibrated paths
+    // so the behaviour is consistent regardless of `calibration_enabled`.
+    if (!std::isfinite(raw)) {
+        return p.max_depth_m;
+    }
+    // Both paths compute the anchored normalisation identically; what
+    // differs is whether the anchor is per-frame or fitted, and whether
+    // the output gets a post-linear-fit clamp.
+    float normalized = (raw - p.anchor_min) / range;
+    if (p.calibration_enabled) {
+        // Raw sample outside the fitted window: clamp rather than extrapolate.
+        normalized = std::clamp(normalized, 0.0f, 1.0f);
+    }
+    float metric = p.min_depth_m + (p.max_depth_m - p.min_depth_m) * (1.0f - normalized);
+    if (p.calibration_enabled) {
+        metric = p.calibration_coef_a * metric + p.calibration_coef_b;
+        // Final safety clamp — covers degenerate `a*x+b` fits that push
+        // output outside the physical depth range (e.g. operator-supplied
+        // `coef_b` exceeds max_depth_m).
+        metric = std::clamp(metric, p.min_depth_m, p.max_depth_m);
+    }
+    return metric;
+}
 
 }  // namespace drone::hal

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -22,8 +22,33 @@ DepthAnythingV2Estimator::DepthAnythingV2Estimator(const drone::Config& cfg,
     input_size_            = cfg.get<int>(section + ".input_size", 518);
     max_depth_m_           = cfg.get<float>(section + ".max_depth_m", 20.0f);
 
-    DRONE_LOG_INFO("[DepthAnythingV2] Config: input_size={}, max_depth_m={:.1f}", input_size_,
-                   max_depth_m_);
+    // Calibration (Issue #616) — all default-off; per-frame path is still used
+    // unless all refs + coefs are explicitly provided.
+    namespace dav2       = drone::cfg_key::perception::depth_estimator::dav2;
+    calibration_enabled_ = cfg.get<bool>(dav2::CALIBRATION_ENABLED, false);
+    raw_min_ref_         = cfg.get<float>(dav2::RAW_MIN_REF, raw_min_ref_);
+    raw_max_ref_         = cfg.get<float>(dav2::RAW_MAX_REF, raw_max_ref_);
+    calibration_coef_a_  = cfg.get<float>(dav2::CALIBRATION_COEF_A, calibration_coef_a_);
+    calibration_coef_b_  = cfg.get<float>(dav2::CALIBRATION_COEF_B, calibration_coef_b_);
+
+    // Safety-check the calibration inputs.  If enabled but refs are invalid,
+    // fall back to per-frame normalisation rather than silently producing
+    // garbage metres.
+    if (calibration_enabled_) {
+        const bool refs_valid = std::isfinite(raw_min_ref_) && std::isfinite(raw_max_ref_) &&
+                                raw_max_ref_ > raw_min_ref_;
+        if (!refs_valid) {
+            DRONE_LOG_WARN("[DepthAnythingV2] calibration_enabled=true but raw_min_ref={:.3f} / "
+                           "raw_max_ref={:.3f} invalid — falling back to per-frame normalisation.",
+                           raw_min_ref_, raw_max_ref_);
+            calibration_enabled_ = false;
+        }
+    }
+
+    DRONE_LOG_INFO("[DepthAnythingV2] Config: input_size={}, max_depth_m={:.1f}, "
+                   "calibration={} (a={:.3f}, b={:.3f}, raw_ref=[{:.3f},{:.3f}])",
+                   input_size_, max_depth_m_, calibration_enabled_ ? "on" : "off",
+                   calibration_coef_a_, calibration_coef_b_, raw_min_ref_, raw_max_ref_);
     load_model(model_path);
 }
 
@@ -171,12 +196,18 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
     // ── Step 5: Convert relative inverse depth → metric depth ──
     // DA V2 outputs unnormalized inverse depth: higher raw value = closer object.
-    // We normalize to [0,1] then linearly map to metric depth:
-    //   normalized=1 (closest object, highest inverse depth) → min_depth (0.1m)
-    //   normalized=0 (farthest object, lowest inverse depth) → max_depth
-    // This provides full utilization of the [min_depth, max_depth] range.
-    // Note: DA V2 is a relative (not metric) model — the absolute scale depends
-    // on the scene. The linear mapping is the simplest correct conversion.
+    // Two conversion paths — see class docstring for the design rationale:
+    //
+    //   (a) Per-frame normalisation (default, pre-#616 behaviour):
+    //       min/max of raw_data this frame → linear map to [min_depth, max_depth].
+    //
+    //   (b) Calibrated (Issue #616, opt-in via `dav2.calibration_enabled`):
+    //       use fitted `(raw_min_ref, raw_max_ref)` to anchor normalisation
+    //       across frames, then apply linear fit `a * metric_anchored + b`.
+    //
+    // Either way we always compute per-frame min/max for the diagnostic log
+    // below (operators parse these values to fit calibration coefficients
+    // later with `tools/calibrate_depth_anything_v2.py`).
     float min_val = raw_data[0];
     float max_val = raw_data[0];
     for (size_t i = 1; i < num_pixels; ++i) {
@@ -186,7 +217,13 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
 
     constexpr float eps       = 1e-6f;
     constexpr float min_depth = 0.1f;  // Minimum metric depth (closest objects)
-    const float     range     = max_val - min_val;
+
+    // Choose which min/max pair drives the normalisation.  In calibrated mode
+    // the refs are fixed; in default mode the per-frame values are used so
+    // every frame self-scales (today's behaviour, byte-identical when off).
+    const float norm_min = calibration_enabled_ ? raw_min_ref_ : min_val;
+    const float norm_max = calibration_enabled_ ? raw_max_ref_ : max_val;
+    const float range    = norm_max - norm_min;
 
     DepthMap map;
     map.width         = static_cast<uint32_t>(out_w);
@@ -198,15 +235,31 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     map.data.resize(num_pixels);
 
     if (range < eps) {
-        // Flat output (all pixels same depth) — return uniform max_depth
+        // Flat scale range — return uniform max_depth.  Occurs when the
+        // per-frame raw output is constant (flat scene) OR when a
+        // mis-configured calibration provides near-equal refs.
         std::fill(map.data.begin(), map.data.end(), max_depth_m_);
     } else {
         for (size_t i = 0; i < num_pixels; ++i) {
-            // Normalize inverse depth to [0, 1]: 1 = closest, 0 = farthest
-            const float normalized = (raw_data[i] - min_val) / range;
+            // Normalise inverse depth to roughly [0, 1]: 1 = closest, 0 = farthest.
+            // In calibrated mode, a raw sample outside the reference window
+            // clamps to [0, 1] — that's intentional (a frame that looks closer
+            // than anything in the calibration set still reports its best
+            // metric estimate instead of extrapolating wildly).
+            float normalized = (raw_data[i] - norm_min) / range;
+            if (calibration_enabled_) {
+                normalized = std::clamp(normalized, 0.0f, 1.0f);
+            }
             // Linear map: high inverse depth (close) → small depth, low → large depth
-            const float metric = min_depth + (max_depth_m_ - min_depth) * (1.0f - normalized);
-            map.data[i]        = metric;
+            float metric = min_depth + (max_depth_m_ - min_depth) * (1.0f - normalized);
+            // Calibrated mode applies the final linear fit.  Identity (a=1,b=0)
+            // is a no-op — operators only need to provide a/b when the
+            // anchored-scale output still has a systematic bias vs ground truth.
+            if (calibration_enabled_) {
+                metric = calibration_coef_a_ * metric + calibration_coef_b_;
+                metric = std::clamp(metric, min_depth, max_depth_m_);
+            }
+            map.data[i] = metric;
         }
     }
 

--- a/common/hal/src/depth_anything_v2.cpp
+++ b/common/hal/src/depth_anything_v2.cpp
@@ -21,10 +21,15 @@ DepthAnythingV2Estimator::DepthAnythingV2Estimator(const drone::Config& cfg,
                                                   "models/depth_anything_v2_vits.onnx");
     input_size_            = cfg.get<int>(section + ".input_size", 518);
     max_depth_m_           = cfg.get<float>(section + ".max_depth_m", 20.0f);
+    // Lower metric bound — closest reportable obstacle (PR #620 code-quality
+    // review).  `max_depth_m_` was configurable but `min_depth_m_` was hardcoded
+    // at 0.1 — asymmetric.  Operators tuning tight indoor flights may want a
+    // narrower floor; symmetric tunability closes the gap.
+    namespace dav2 = drone::cfg_key::perception::depth_estimator::dav2;
+    min_depth_m_   = cfg.get<float>(dav2::MIN_DEPTH_M, 0.1f);
 
     // Calibration (Issue #616) — all default-off; per-frame path is still used
     // unless all refs + coefs are explicitly provided.
-    namespace dav2       = drone::cfg_key::perception::depth_estimator::dav2;
     calibration_enabled_ = cfg.get<bool>(dav2::CALIBRATION_ENABLED, false);
     raw_min_ref_         = cfg.get<float>(dav2::RAW_MIN_REF, raw_min_ref_);
     raw_max_ref_         = cfg.get<float>(dav2::RAW_MAX_REF, raw_max_ref_);
@@ -195,35 +200,58 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     const auto  num_pixels = static_cast<size_t>(out_h) * static_cast<size_t>(out_w);
 
     // ── Step 5: Convert relative inverse depth → metric depth ──
-    // DA V2 outputs unnormalized inverse depth: higher raw value = closer object.
+    // DA V2 outputs unnormalised inverse depth: higher raw value = closer object.
     // Two conversion paths — see class docstring for the design rationale:
     //
     //   (a) Per-frame normalisation (default, pre-#616 behaviour):
-    //       min/max of raw_data this frame → linear map to [min_depth, max_depth].
+    //       min/max of raw_data this frame → linear remap to
+    //       [min_depth_m_, max_depth_m_].
     //
     //   (b) Calibrated (Issue #616, opt-in via `dav2.calibration_enabled`):
     //       use fitted `(raw_min_ref, raw_max_ref)` to anchor normalisation
     //       across frames, then apply linear fit `a * metric_anchored + b`.
     //
-    // Either way we always compute per-frame min/max for the diagnostic log
-    // below (operators parse these values to fit calibration coefficients
-    // later with `tools/calibrate_depth_anything_v2.py`).
-    float min_val = raw_data[0];
-    float max_val = raw_data[0];
-    for (size_t i = 1; i < num_pixels; ++i) {
-        min_val = std::min(min_val, raw_data[i]);
-        max_val = std::max(max_val, raw_data[i]);
+    // Delegates per-pixel math to `convert_raw_to_metric()` (free function at
+    // file scope in depth_anything_v2.h) so the conversion is unit-testable
+    // without a loaded ONNX model (PR #620 review refactor).
+    constexpr float eps = 1e-6f;
+
+    // Per-frame min/max is required for (a) the diagnostic log emitted every
+    // 30th call and (b) the per-frame conversion path.  In calibrated mode
+    // the output doesn't need it, but we still scan every 30th frame so the
+    // log continues to fire and the calibration tool keeps working.  That
+    // saves ~29/30 × 268k FP compares when calibration is on.
+    static std::atomic<uint64_t> scan_counter{0};
+    const bool                   need_scan = !calibration_enabled_ ||
+                           (scan_counter.fetch_add(1, std::memory_order_relaxed) % 30 == 0);
+    float min_val = 0.0f;
+    float max_val = 0.0f;
+    if (need_scan) {
+        min_val = raw_data[0];
+        max_val = raw_data[0];
+        for (size_t i = 1; i < num_pixels; ++i) {
+            min_val = std::min(min_val, raw_data[i]);
+            max_val = std::max(max_val, raw_data[i]);
+        }
     }
 
-    constexpr float eps       = 1e-6f;
-    constexpr float min_depth = 0.1f;  // Minimum metric depth (closest objects)
-
-    // Choose which min/max pair drives the normalisation.  In calibrated mode
-    // the refs are fixed; in default mode the per-frame values are used so
-    // every frame self-scales (today's behaviour, byte-identical when off).
-    const float norm_min = calibration_enabled_ ? raw_min_ref_ : min_val;
-    const float norm_max = calibration_enabled_ ? raw_max_ref_ : max_val;
-    const float range    = norm_max - norm_min;
+    // Build conversion parameters — anchor choice hoisted outside the pixel
+    // loop (per PR #620 code-quality review: `calibration_enabled_` is
+    // invariant across all pixels).
+    DepthConversionParams params;
+    params.min_depth_m         = min_depth_m_;
+    params.max_depth_m         = max_depth_m_;
+    params.calibration_enabled = calibration_enabled_;
+    params.calibration_coef_a  = calibration_coef_a_;
+    params.calibration_coef_b  = calibration_coef_b_;
+    if (calibration_enabled_) {
+        params.anchor_min = raw_min_ref_;
+        params.anchor_max = raw_max_ref_;
+    } else {
+        params.anchor_min = min_val;
+        params.anchor_max = max_val;
+    }
+    const float range = params.anchor_max - params.anchor_min;
 
     DepthMap map;
     map.width         = static_cast<uint32_t>(out_w);
@@ -235,31 +263,16 @@ void DepthAnythingV2Estimator::load_model(const std::string& model_path) {
     map.data.resize(num_pixels);
 
     if (range < eps) {
-        // Flat scale range — return uniform max_depth.  Occurs when the
-        // per-frame raw output is constant (flat scene) OR when a
-        // mis-configured calibration provides near-equal refs.
+        // Flat scale range — uniform max_depth output.  Per-frame path: raw
+        // scene is constant (flat wall / unlit frame).  Calibrated path: refs
+        // are near-equal (config rounding — the constructor's `>` guard lets
+        // refs that differ by a hair through).  Either way a fall-back to
+        // "everything is far" is conservative: the grid gets no near
+        // obstacles, the planner doesn't route around phantoms.
         std::fill(map.data.begin(), map.data.end(), max_depth_m_);
     } else {
         for (size_t i = 0; i < num_pixels; ++i) {
-            // Normalise inverse depth to roughly [0, 1]: 1 = closest, 0 = farthest.
-            // In calibrated mode, a raw sample outside the reference window
-            // clamps to [0, 1] — that's intentional (a frame that looks closer
-            // than anything in the calibration set still reports its best
-            // metric estimate instead of extrapolating wildly).
-            float normalized = (raw_data[i] - norm_min) / range;
-            if (calibration_enabled_) {
-                normalized = std::clamp(normalized, 0.0f, 1.0f);
-            }
-            // Linear map: high inverse depth (close) → small depth, low → large depth
-            float metric = min_depth + (max_depth_m_ - min_depth) * (1.0f - normalized);
-            // Calibrated mode applies the final linear fit.  Identity (a=1,b=0)
-            // is a no-op — operators only need to provide a/b when the
-            // anchored-scale output still has a systematic bias vs ground truth.
-            if (calibration_enabled_) {
-                metric = calibration_coef_a_ * metric + calibration_coef_b_;
-                metric = std::clamp(metric, min_depth, max_depth_m_);
-            }
-            map.data[i] = metric;
+            map.data[i] = convert_raw_to_metric(raw_data[i], range, params);
         }
     }
 

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -121,6 +121,30 @@ inline constexpr const char* MAX_FPS         = "perception.depth_estimator.max_f
 inline constexpr const char* NOISE_STD_M     = "perception.depth_estimator.noise_std_m";
 inline constexpr const char* DEFAULT_DEPTH_M = "perception.depth_estimator.default_depth_m";
 inline constexpr const char* ENABLED         = "perception.depth_estimator.enabled";
+
+// ── DA V2 calibration (Issue #616) ─────────────────────────────────
+// DA V2 outputs relative inverse depth.  Today the model normalises per
+// frame (unstable scale across frames).  These keys opt into a globally-
+// anchored scale + optional linear fit.  All default-off — existing
+// scenarios inherit today's per-frame behaviour.
+namespace dav2 {
+inline constexpr const char* CALIBRATION_ENABLED =
+    "perception.depth_estimator.dav2.calibration_enabled";
+// `(raw_min_ref, raw_max_ref)` anchor the normalisation across frames.
+// When NaN (default), fall back to per-frame min/max.  Fit via
+// `tools/calibrate_depth_anything_v2.py` from a scenario run's
+// `perception.log`.
+inline constexpr const char* RAW_MIN_REF = "perception.depth_estimator.dav2.raw_min_ref";
+inline constexpr const char* RAW_MAX_REF = "perception.depth_estimator.dav2.raw_max_ref";
+// Linear map applied AFTER anchored normalisation:
+//   metric_final = calibration_coef_a * metric_anchored + calibration_coef_b
+// Defaults (1.0, 0.0) are identity — only matters if a proper fit against
+// ground truth (Cosys DepthCam or instrumented ground run) is provided.
+inline constexpr const char* CALIBRATION_COEF_A =
+    "perception.depth_estimator.dav2.calibration_coef_a";
+inline constexpr const char* CALIBRATION_COEF_B =
+    "perception.depth_estimator.dav2.calibration_coef_b";
+}  // namespace dav2
 }  // namespace depth_estimator
 
 namespace fusion {
@@ -167,6 +191,15 @@ inline constexpr const char* SECTION = "perception.event_camera";
 
 namespace semantic_projector {
 inline constexpr const char* SECTION = "perception.semantic_projector";
+// Texture gate (Issue #616) — reject depth samples in low-gradient regions
+// of the depth map.  Flat depth is DA V2's weakest failure mode (cube faces,
+// sky, untextured walls) — the network has no features to latch onto and
+// the output is effectively noise.  The gradient magnitude at the sample
+// pixel is a proxy: high gradient → feature-rich, low → unsafe to trust.
+// Threshold units are metres-per-pixel (depth gradient).  Default 0.0 =
+// disabled (backward-compatible with existing scenarios).
+inline constexpr const char* TEXTURE_GATE_THRESHOLD =
+    "perception.semantic_projector.texture_gate_threshold";
 }  // namespace semantic_projector
 
 // PATH A — SAM + detector fusion (Epic #520)

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -131,8 +131,13 @@ namespace dav2 {
 inline constexpr const char* CALIBRATION_ENABLED =
     "perception.depth_estimator.dav2.calibration_enabled";
 // `(raw_min_ref, raw_max_ref)` anchor the normalisation across frames.
-// When NaN (default), fall back to per-frame min/max.  Fit via
-// `tools/calibrate_depth_anything_v2.py` from a scenario run's
+// Validity rules (enforced by the constructor; any failure → fall back to
+// per-frame min/max with a WARN log):
+//   * both finite (NaN/inf rejected — NaN is the default sentinel meaning
+//     "key absent from config" and indicates calibration was never set up),
+//   * raw_max_ref > raw_min_ref (equal or inverted bounds reject — the
+//     anchored window must have positive width).
+// Fit via `tools/calibrate_depth_anything_v2.py` from a scenario run's
 // `perception.log`.
 inline constexpr const char* RAW_MIN_REF = "perception.depth_estimator.dav2.raw_min_ref";
 inline constexpr const char* RAW_MAX_REF = "perception.depth_estimator.dav2.raw_max_ref";
@@ -144,6 +149,11 @@ inline constexpr const char* CALIBRATION_COEF_A =
     "perception.depth_estimator.dav2.calibration_coef_a";
 inline constexpr const char* CALIBRATION_COEF_B =
     "perception.depth_estimator.dav2.calibration_coef_b";
+// Closest metric depth the estimator will report.  Sibling of
+// `perception.depth_estimator.max_depth_m` — the two bracket the output
+// range.  Promoted from hardcoded 0.1f per PR #620 code-quality review so
+// tight indoor calibrations can push the floor below 10 cm.  Default 0.1 m.
+inline constexpr const char* MIN_DEPTH_M = "perception.depth_estimator.dav2.min_depth_m";
 }  // namespace dav2
 }  // namespace depth_estimator
 

--- a/docs/tracking/PRODUCTION_READINESS.md
+++ b/docs/tracking/PRODUCTION_READINESS.md
@@ -77,3 +77,77 @@
 - Guards against `std::asin` domain errors on corrupt radar points
 
 **When to address:** Before hardware radar integration. Good first issue for a new contributor.
+
+---
+
+## Sim-to-Real Transition Map — What Changes on Real Hardware
+
+**Severity:** Not a bug, but a reference. Answers "what do we actually flip when we move from Cosys / Gazebo to a Jetson + real camera?"
+
+**Architectural anchor:** The HAL config-key pattern (`config/*.json → backend: "..."`) means **most changes are one-line swaps** in a hardware profile. Code doesn't know the backend changed. The hard work is on the hardware side: calibration, sensor wiring, power/thermal validation.
+
+### What changes — perception & depth
+
+| Sub-system | Sim (Cosys dev profile) | Real hardware (Jetson Orin + Holybro X500 v2) |
+|---|---|---|
+| `video_capture.mission_cam.backend` | `cosys_airsim` (UE5 RPC render) | `v4l2` (USB/CSI) or `libargus` (NVIDIA CSI) — Issue #32 |
+| `DepthCam` | Simulator's ground-truth depth, available as an oracle | **Does not exist.** No equivalent sensor on a production drone. |
+| `perception.depth_estimator.backend` | `depth_anything_v2` (or `cosys_airsim` GT in cloud profile) | `depth_anything_v2` monocular, **or** stereo SGBM if airframe has stereo, **or** time-of-flight / lidar if present |
+| DA V2 calibration coefficients | Fitted against UE5 Blocks via `DepthCam` | Must be **re-fitted against real scenes** before first flight. Blocks-trained `(a, b)` will not generalise. |
+| Texture gate | Active (config-gated) | Active — unchanged. Gradient-based, sensor-agnostic. |
+| Max-depth clamp (20 m) / ground-plane filter (z<0.3) | Defensive bandages for DA V2 drift | **More necessary** — real cameras add noise; sky/horizon pixels are still garbage |
+
+### What changes — SLAM / VIO / comms
+
+| Sub-system | Sim | Real hardware |
+|---|---|---|
+| `slam.vio.backend` | `cosys_airsim` (GT pose republisher) or `gazebo` (same pattern) | Real stereo VIO (Epic #497 SWVIO) or ORB-SLAM3 / VINS-Fusion (Issue #37) |
+| `slam.imu.backend` | Cosys simulated IMU + Gaussian noise | Real MPU6050 / BMI088 via I²C or flight-controller IMU stream |
+| `comms.mavlink.backend` | `cosys_rpc` (SimpleFlight in UE5) | `mavsdk` — real PX4 over UART / USB |
+| Collision detection | `simGetCollisionInfo` RPC (physics ground truth) | IMU jerk spike + MAVLink events (Issue #505) |
+| Camera intrinsics | Near-perfect UE5 pinhole | Real intrinsics + distortion model (Brown-Conrady / KB4) — Issue #601 |
+| Camera-body extrinsic | Declared in `cosys_settings.json` | Measured physically per airframe build. The `R_body_from_cam` rotation from Fix #55 generalises; the translational offset + fine rotation are per-unit |
+
+### The three categories of "hidden" work
+
+**1. Calibration drift between environments.** A DA V2 coefficient fit from a UE5 Blocks map won't match a real forest, warehouse, or proving ground. This requires one of:
+
+- **Pre-flight calibration procedure** — park the drone in the real environment, run a 1–2 min data-collection flight, re-fit coefficients, save per-mission config overlay.
+- **Robust-scale architecture** — use DA V2 only for relative depth; let a physical sensor (stereo / ToF) anchor absolute scale.
+- **Domain-specific fine-tune** — full retrain of DA V2 weights on real-environment data. Largest investment; highest quality.
+
+**2. Ground truth evaporates.** `DepthCam` in sim is the grading oracle — on real hardware, no pixel has a "correct answer". Validation becomes:
+
+- **Instrumented ground runs** — tape measure + marked objects at known distances.
+- **Stereo-as-reference** — if the airframe has stereo, use stereo matching as the reference-of-record and DA V2 as backup / densifier.
+- **Fleet telemetry** — collision events (per #505) become the only "grades" once flying. Painful feedback loop.
+
+**3. Environmental factors are no longer pristine.** Motion blur, vibration, lighting variation, rolling shutter, thermal noise, rain, fog — all stress-test the perception + VIO pipeline in ways UE5 does not exercise by default.
+
+### What stays the same (architectural)
+
+- The 7-process architecture + every IPC wire type.
+- Every HAL interface (`IDepthEstimator`, `ICamera`, `IObstacleAvoider`, `IVIOBackend`, etc.) — only the backends change.
+- Everything in `common/` (avoider, planner, tracker, watchdog, fault manager, grid).
+- The scenario / config / pass-criteria framework (hardware scenarios can be added the same way).
+- The DA V2 ONNX model file itself. Same weights, same code path.
+- Texture gate + max-depth clamp + ground-plane filter — defensive tuning that only gets *more* useful on real cameras.
+
+### Why this matters for currently-sim-scoped work (e.g. #616 DA V2 calibration)
+
+Work that looks like "sim polish" is often **shipping the machinery the real deploy needs**. Example: #616 adds config-driven DA V2 calibration coefficients + texture gate. On real hardware the coefficients *have to* come from config — you can't bake them into the binary because they change per-environment. The `DepthCam`-based oracle is how we grade the machinery during development; the machinery itself is what flies.
+
+### Implementation roadmap (tracked separately, listed here for context)
+
+- **#25** — Real Drone Deployment epic (phases 2 + 3: V4L2, stereo calibration, real VIO)
+- **#32** — V4L2 Camera HAL backend
+- **#37** — Real VIO backend (ORB-SLAM3 / VINS-Fusion)
+- **#38** — Stereo camera calibration pipeline
+- **#393** — Mono depth improvement survey (parent of #616)
+- **#491** — Holybro X500 v2 + Jetson Orin Nano validation tier
+- **#497** — Custom SWVIO epic
+- **#505** — Real-hardware collision detection via IMU jerk
+- **#601** — CameraIntrinsics + lens distortion model (Brown-Conrady / KB4)
+- **#251** — Production deployment: native build & run on Jetson Orin Nano
+
+**When to address:** The roadmap above is the "when" — sim-first work (PATH A, #513, #616) builds algorithms + validation infra; hardware epics (#25, #491, etc.) handle sensor wiring + calibration + deploy. Anything deferred with "real hardware" rationale should cross-reference this section and the relevant epic.

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -1012,6 +1012,18 @@ int main(int argc, char* argv[]) {
                                 intr.width, intr.height);
                 sam_backend.reset();
             } else {
+                // Issue #616 — opt-in depth-gradient texture gate.  Zero default
+                // is backward-compatible; scenarios that want to reject samples
+                // on flat/textureless surfaces set a non-zero threshold in
+                // metres-per-pixel (tuned against DA V2 output + scenario geometry).
+                const float tgate = ctx.cfg.get<float>(
+                    drone::cfg_key::perception::semantic_projector::TEXTURE_GATE_THRESHOLD, 0.0f);
+                sp->set_texture_gate_threshold(tgate);
+                if (tgate > 0.0f) {
+                    DRONE_LOG_INFO("[PathA] CpuSemanticProjector texture gate enabled: "
+                                   "threshold={:.3f} m/px",
+                                   tgate);
+                }
                 semantic_projector = std::move(sp);
                 const float iou    = ctx.cfg.get<float>(
                     drone::cfg_key::perception::path_a::MASK_CLASS_IOU_THRESHOLD, 0.5f);

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -1012,18 +1012,26 @@ int main(int argc, char* argv[]) {
                                 intr.width, intr.height);
                 sam_backend.reset();
             } else {
-                // Issue #616 — opt-in depth-gradient texture gate.  Zero default
-                // is backward-compatible; scenarios that want to reject samples
-                // on flat/textureless surfaces set a non-zero threshold in
-                // metres-per-pixel (tuned against DA V2 output + scenario geometry).
+                // Issue #616 — opt-in texture gate on the depth-map Sobel
+                // magnitude.  Zero default is backward-compatible; scenarios
+                // that want to reject samples on flat/textureless surfaces
+                // set a non-zero threshold (tuned empirically against
+                // scenario voxel-on-target output; 0.3–1.0 is a reasonable
+                // range for DA V2 @ 518×518).
                 const float tgate = ctx.cfg.get<float>(
                     drone::cfg_key::perception::semantic_projector::TEXTURE_GATE_THRESHOLD, 0.0f);
                 sp->set_texture_gate_threshold(tgate);
                 if (tgate > 0.0f) {
                     DRONE_LOG_INFO("[PathA] CpuSemanticProjector texture gate enabled: "
-                                   "threshold={:.3f} m/px",
+                                   "threshold={:.3f} (un-normalised Sobel magnitude)",
                                    tgate);
                 }
+                // Pipe the estimator's max depth through so the projector's
+                // horizon-cutoff stays in sync with the configured depth range
+                // (PR #620 code-quality review — previously hardcoded at 20 m).
+                const float max_depth = ctx.cfg.get<float>("perception.depth_estimator.max_depth_m",
+                                                           20.0f);
+                sp->set_max_obstacle_depth_m(max_depth);
                 semantic_projector = std::move(sp);
                 const float iou    = ctx.cfg.get<float>(
                     drone::cfg_key::perception::path_a::MASK_CLASS_IOU_THRESHOLD, 0.5f);

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -141,10 +141,21 @@ TEST(DepthAnythingV2Test, ConfigConstruction) {
 
 namespace {
 // Helper: build a throwaway Config with calibration fields set.
+//
+// PR #620 test-quality review P1: previously used `pid + rand()` for the
+// tmpfile name.  Under `ctest -j` (parallel test execution), an unseeded
+// `rand()` plus shared pid produces identical filenames across iterations
+// of the same test binary, leading to file-write races + cross-test
+// contamination.  `mkstemp` is the POSIX answer — it atomically opens a
+// uniquely-named file and returns the fd; we close it and only need the
+// path for `cfg.load`.
 drone::Config make_calibration_cfg(bool enabled, float raw_min, float raw_max, float a = 1.0f,
                                    float b = 0.0f) {
-    std::string path = "/tmp/test_da_v2_calib_" + std::to_string(::getpid()) + "_" +
-                       std::to_string(rand()) + ".json";
+    char tmpl[] = "/tmp/test_da_v2_calib_XXXXXX.json";
+    int  fd     = ::mkstemps(tmpl, 5);  // 5 = length of ".json" suffix
+    EXPECT_GE(fd, 0) << "mkstemps failed for tmpfile";
+    if (fd >= 0) ::close(fd);
+    std::string path(tmpl);
     {
         std::ofstream ofs(path);
         ofs << "{\n"
@@ -171,7 +182,7 @@ drone::Config make_calibration_cfg(bool enabled, float raw_min, float raw_max, f
 }
 }  // namespace
 
-TEST(DepthAnythingV2Test, CalibrationEnabledWithValidRefs) {
+TEST(DepthAnythingV2Test, CalibrationEnabled_WhenRefsValid) {
     // Real refs (min < max, both finite) → calibration stays enabled.
     auto cfg = make_calibration_cfg(/*enabled=*/true, /*raw_min=*/0.1f, /*raw_max=*/0.9f);
     DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
@@ -179,15 +190,69 @@ TEST(DepthAnythingV2Test, CalibrationEnabledWithValidRefs) {
         << "Valid refs should keep calibration on; got disabled.";
 }
 
-TEST(DepthAnythingV2Test, CalibrationFallbackOnInvalidRefs) {
-    // raw_max <= raw_min → invalid window → fall back to per-frame.  The
-    // estimator must NOT silently produce garbage metres; it should disable
-    // calibration and log a WARN (not asserted here but the fallback is
-    // observable via calibration_enabled()).
+TEST(DepthAnythingV2Test, CalibrationFallback_OnEqualRefs) {
+    // raw_max == raw_min → degenerate window → fall back to per-frame.
     auto cfg = make_calibration_cfg(/*enabled=*/true, /*raw_min=*/0.5f, /*raw_max=*/0.5f);
     DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
     EXPECT_FALSE(estimator.calibration_enabled())
-        << "Invalid refs (raw_max<=raw_min) should trigger fallback to per-frame.";
+        << "Equal refs should trigger fallback to per-frame.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationFallback_OnInvertedRefs) {
+    // raw_min > raw_max → inverted window (operator typo) → fall back.
+    // Distinct input shape from EqualRefs case; covers the strict `>` guard
+    // path (PR #620 test-quality review P2).
+    auto cfg = make_calibration_cfg(/*enabled=*/true, /*raw_min=*/0.9f, /*raw_max=*/0.1f);
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_FALSE(estimator.calibration_enabled())
+        << "Inverted refs (raw_min > raw_max) should trigger fallback to per-frame.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationFallback_OnNaNRef) {
+    // One ref NaN, other finite → fails the `isfinite` guard → fall back.
+    // Covers the `isfinite` branch independently from the ordering branch
+    // (PR #620 test-quality review P2).  We can't write NaN in JSON, so
+    // omit raw_max_ref entirely and let the struct default (NaN) take over.
+    char tmpl[] = "/tmp/test_da_v2_one_nan_XXXXXX.json";
+    int  fd     = ::mkstemps(tmpl, 5);
+    ASSERT_GE(fd, 0);
+    ::close(fd);
+    std::string path(tmpl);
+    {
+        std::ofstream ofs(path);
+        ofs << R"({
+            "perception": {
+                "depth_estimator": {
+                    "backend": "depth_anything_v2",
+                    "model_path": "nonexistent.onnx",
+                    "dav2": {
+                        "calibration_enabled": true,
+                        "raw_min_ref": 0.1
+                    }
+                }
+            }
+        })";
+    }
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    std::remove(path.c_str());
+
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_FALSE(estimator.calibration_enabled())
+        << "One NaN ref (raw_max_ref omitted from JSON) should trigger fallback.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationEnabled_AcceptsNarrowButValidWindow) {
+    // raw_max = raw_min + 1e-6f → just above the strict-`>` guard threshold.
+    // The constructor accepts it; the per-pixel `range < eps (=1e-6f)`
+    // branch in estimate() may then apply (handled separately in the math
+    // tests below).  This test pins that the *guard* lets it through —
+    // callers can decide what to do with the narrow window.
+    auto                     cfg = make_calibration_cfg(/*enabled=*/true,
+                                    /*raw_min=*/0.5f, /*raw_max=*/0.5f + 1e-5f);
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_TRUE(estimator.calibration_enabled())
+        << "Narrow-but-valid window should pass the strict-`>` guard; got disabled.";
 }
 
 TEST(DepthAnythingV2Test, CalibrationFallbackOnMissingRefs) {
@@ -236,6 +301,129 @@ TEST(DepthAnythingV2Test, CalibrationDisabledByDefault) {
 
     DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
     EXPECT_FALSE(estimator.calibration_enabled());
+}
+
+// ═══════════════════════════════════════════════════════════
+// Per-pixel calibration math (PR #620 review refactor)
+//
+// `convert_raw_to_metric()` is a file-scope free function so the
+// arithmetic that used to live inside `estimate()` is testable without
+// loading the ONNX model.  These cover the branches reviewers couldn't
+// reach: per-frame happy path, calibrated happy path, NaN guard,
+// out-of-window clamping, output clamping, and the degenerate `coef_a=0`
+// fit.
+// ═══════════════════════════════════════════════════════════
+
+namespace {
+DepthConversionParams make_per_frame_params(float min_depth = 0.1f, float max_depth = 20.0f,
+                                            float anchor_min = 0.0f, float anchor_max = 1.0f) {
+    DepthConversionParams p;
+    p.min_depth_m         = min_depth;
+    p.max_depth_m         = max_depth;
+    p.calibration_enabled = false;
+    p.anchor_min          = anchor_min;
+    p.anchor_max          = anchor_max;
+    return p;
+}
+
+DepthConversionParams make_calibrated_params(float anchor_min, float anchor_max, float a = 1.0f,
+                                             float b = 0.0f, float min_depth = 0.1f,
+                                             float max_depth = 20.0f) {
+    DepthConversionParams p;
+    p.min_depth_m         = min_depth;
+    p.max_depth_m         = max_depth;
+    p.calibration_enabled = true;
+    p.anchor_min          = anchor_min;
+    p.anchor_max          = anchor_max;
+    p.calibration_coef_a  = a;
+    p.calibration_coef_b  = b;
+    return p;
+}
+}  // namespace
+
+TEST(DepthAnythingV2MathTest, PerFrame_HighRawMapsToMinDepth) {
+    // raw at the per-frame max → normalized = 1 → metric = min_depth (closest).
+    auto        p     = make_per_frame_params(/*min*/ 0.1f, /*max*/ 20.0f, /*amin*/ 0.0f,
+                                   /*amax*/ 1.0f);
+    const float range = p.anchor_max - p.anchor_min;
+    EXPECT_NEAR(convert_raw_to_metric(1.0f, range, p), 0.1f, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, PerFrame_LowRawMapsToMaxDepth) {
+    // raw at the per-frame min → normalized = 0 → metric = max_depth (farthest).
+    auto        p     = make_per_frame_params();
+    const float range = p.anchor_max - p.anchor_min;
+    EXPECT_NEAR(convert_raw_to_metric(0.0f, range, p), 20.0f, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, PerFrame_NaN_FailsClosed_ToMaxDepth) {
+    // Memory-safety / fault-recovery P3: a NaN raw sample must not
+    // propagate to map.data.  Free function returns max_depth (far).
+    auto        p     = make_per_frame_params();
+    const float range = p.anchor_max - p.anchor_min;
+    const float nan   = std::numeric_limits<float>::quiet_NaN();
+    const float out   = convert_raw_to_metric(nan, range, p);
+    EXPECT_TRUE(std::isfinite(out)) << "NaN raw must not produce NaN metric";
+    EXPECT_FLOAT_EQ(out, 20.0f) << "NaN raw should fail closed to max_depth";
+}
+
+TEST(DepthAnythingV2MathTest, Calibrated_OutOfWindowRawClamps) {
+    // raw above the calibrated window → normalized would exceed 1 → clamp to 1
+    // → metric = min_depth.  Documents that out-of-window samples report
+    // "closer than anything in the calibration set" rather than extrapolating.
+    auto        p     = make_calibrated_params(/*amin*/ 0.2f, /*amax*/ 0.8f);
+    const float range = p.anchor_max - p.anchor_min;
+    EXPECT_NEAR(convert_raw_to_metric(1.5f, range, p), p.min_depth_m, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, Calibrated_BelowWindowRawClamps) {
+    // raw below the calibrated window → normalized < 0 → clamp to 0 →
+    // metric = max_depth.
+    auto        p     = make_calibrated_params(/*amin*/ 0.2f, /*amax*/ 0.8f);
+    const float range = p.anchor_max - p.anchor_min;
+    EXPECT_NEAR(convert_raw_to_metric(-0.5f, range, p), p.max_depth_m, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, Calibrated_LinearFitApplied) {
+    // a=2, b=1 → metric_anchored=10 → final = 21, then clamped to max_depth=20.
+    auto p        = make_calibrated_params(/*amin*/ 0.0f, /*amax*/ 1.0f, /*a*/ 2.0f, /*b*/ 1.0f);
+    p.max_depth_m = 20.0f;
+    const float range = p.anchor_max - p.anchor_min;
+    // raw=0.5 → normalized=0.5 → metric_anchored = 0.1 + (20-0.1)*(1-0.5) ≈ 10.05
+    // a*x+b = 2*10.05 + 1 = 21.1 → clamp to 20.
+    EXPECT_NEAR(convert_raw_to_metric(0.5f, range, p), 20.0f, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, Calibrated_ZeroCoefAProducesConstantOutput) {
+    // PR #620 test-quality P2: a=0 reduces the linear fit to `metric = b`
+    // (then clamped).  Defensive: confirms no divide-by-zero or NaN even
+    // though the multiplication is the dangerous step, not a divide.
+    auto        p = make_calibrated_params(/*amin*/ 0.0f, /*amax*/ 1.0f, /*a*/ 0.0f, /*b*/ 5.0f);
+    const float range = p.anchor_max - p.anchor_min;
+    // a=0 → metric = 0*x + 5 = 5 (within [0.1, 20] so no clamp).
+    EXPECT_NEAR(convert_raw_to_metric(0.3f, range, p), 5.0f, 1e-4f);
+    EXPECT_NEAR(convert_raw_to_metric(0.7f, range, p), 5.0f, 1e-4f);
+    EXPECT_NEAR(convert_raw_to_metric(0.0f, range, p), 5.0f, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, Calibrated_OutputClampToMinDepth) {
+    // Linear fit pushes metric below min_depth → output clamps up to min_depth.
+    auto        p = make_calibrated_params(/*amin*/ 0.0f, /*amax*/ 1.0f, /*a*/ 0.5f, /*b*/ -10.0f);
+    const float range = p.anchor_max - p.anchor_min;
+    // raw=1.0 → normalized=1.0 → metric_anchored = min_depth = 0.1
+    // a*x+b = 0.5*0.1 + (-10) = -9.95 → clamp up to min_depth.
+    EXPECT_NEAR(convert_raw_to_metric(1.0f, range, p), p.min_depth_m, 1e-4f);
+}
+
+TEST(DepthAnythingV2MathTest, NaN_FailsClosed_BothPaths) {
+    // Belt-and-braces: NaN guard must fail-closed in BOTH per-frame and
+    // calibrated paths, regardless of coefficients.
+    auto p_per = make_per_frame_params();
+    auto p_cal = make_calibrated_params(/*amin*/ 0.0f, /*amax*/ 1.0f, /*a*/ 100.0f, /*b*/ -50.0f);
+    EXPECT_FLOAT_EQ(convert_raw_to_metric(std::numeric_limits<float>::quiet_NaN(), 1.0f, p_per),
+                    20.0f);
+    EXPECT_FLOAT_EQ(convert_raw_to_metric(std::numeric_limits<float>::quiet_NaN(), 1.0f, p_cal),
+                    20.0f);
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/tests/test_depth_anything_v2.cpp
+++ b/tests/test_depth_anything_v2.cpp
@@ -131,6 +131,111 @@ TEST(DepthAnythingV2Test, ConfigConstruction) {
 
     EXPECT_EQ(estimator.name(), "DepthAnythingV2Estimator");
     EXPECT_FALSE(estimator.is_loaded());  // model doesn't exist
+    // Calibration defaults to off — by-design for backward compat.
+    EXPECT_FALSE(estimator.calibration_enabled());
+}
+
+// ═══════════════════════════════════════════════════════════
+// Calibration (Issue #616) — configuration & fallback logic
+// ═══════════════════════════════════════════════════════════
+
+namespace {
+// Helper: build a throwaway Config with calibration fields set.
+drone::Config make_calibration_cfg(bool enabled, float raw_min, float raw_max, float a = 1.0f,
+                                   float b = 0.0f) {
+    std::string path = "/tmp/test_da_v2_calib_" + std::to_string(::getpid()) + "_" +
+                       std::to_string(rand()) + ".json";
+    {
+        std::ofstream ofs(path);
+        ofs << "{\n"
+            << "  \"perception\": {\n"
+            << "    \"depth_estimator\": {\n"
+            << "      \"backend\": \"depth_anything_v2\",\n"
+            << "      \"model_path\": \"nonexistent.onnx\",\n"
+            << "      \"dav2\": {\n"
+            << "        \"calibration_enabled\": " << (enabled ? "true" : "false") << ",\n"
+            << "        \"raw_min_ref\": " << raw_min << ",\n"
+            << "        \"raw_max_ref\": " << raw_max << ",\n"
+            << "        \"calibration_coef_a\": " << a << ",\n"
+            << "        \"calibration_coef_b\": " << b << "\n"
+            << "      }\n"
+            << "    }\n"
+            << "  }\n"
+            << "}\n";
+    }
+    drone::Config cfg;
+    bool          ok = cfg.load(path);
+    std::remove(path.c_str());
+    EXPECT_TRUE(ok) << "Failed to load test config from " << path;
+    return cfg;
+}
+}  // namespace
+
+TEST(DepthAnythingV2Test, CalibrationEnabledWithValidRefs) {
+    // Real refs (min < max, both finite) → calibration stays enabled.
+    auto cfg = make_calibration_cfg(/*enabled=*/true, /*raw_min=*/0.1f, /*raw_max=*/0.9f);
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_TRUE(estimator.calibration_enabled())
+        << "Valid refs should keep calibration on; got disabled.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationFallbackOnInvalidRefs) {
+    // raw_max <= raw_min → invalid window → fall back to per-frame.  The
+    // estimator must NOT silently produce garbage metres; it should disable
+    // calibration and log a WARN (not asserted here but the fallback is
+    // observable via calibration_enabled()).
+    auto cfg = make_calibration_cfg(/*enabled=*/true, /*raw_min=*/0.5f, /*raw_max=*/0.5f);
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_FALSE(estimator.calibration_enabled())
+        << "Invalid refs (raw_max<=raw_min) should trigger fallback to per-frame.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationFallbackOnMissingRefs) {
+    // `calibration_enabled=true` but no raw_min_ref / raw_max_ref keys in
+    // config → struct defaults (NaN) remain → fall back to per-frame path.
+    // JSON doesn't have a NaN literal; this is the realistic shape of an
+    // operator config mistake: the flag is flipped on but refs were forgotten.
+    std::string path = "/tmp/test_da_v2_nanrefs_" + std::to_string(::getpid()) + ".json";
+    {
+        std::ofstream ofs(path);
+        ofs << R"({
+            "perception": {
+                "depth_estimator": {
+                    "backend": "depth_anything_v2",
+                    "model_path": "nonexistent.onnx",
+                    "dav2": { "calibration_enabled": true }
+                }
+            }
+        })";
+    }
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    std::remove(path.c_str());
+
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_FALSE(estimator.calibration_enabled())
+        << "Missing refs (struct-default NaN) should trigger fallback to per-frame.";
+}
+
+TEST(DepthAnythingV2Test, CalibrationDisabledByDefault) {
+    // No dav2.* keys in config → calibration is off, behaviour is byte-identical
+    // to pre-#616 per-frame normalisation.
+    std::string path = "/tmp/test_da_v2_nocal_" + std::to_string(::getpid()) + ".json";
+    {
+        std::ofstream ofs(path);
+        ofs << R"({
+            "perception": { "depth_estimator": {
+                "backend": "depth_anything_v2",
+                "model_path": "nonexistent.onnx"
+            }}
+        })";
+    }
+    drone::Config cfg;
+    ASSERT_TRUE(cfg.load(path));
+    std::remove(path.c_str());
+
+    DepthAnythingV2Estimator estimator(cfg, "perception.depth_estimator");
+    EXPECT_FALSE(estimator.calibration_enabled());
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/tests/test_semantic_projector.cpp
+++ b/tests/test_semantic_projector.cpp
@@ -316,8 +316,11 @@ TEST(SemanticProjector, TextureGateDefaultDisabled) {
 
 TEST(SemanticProjector, TextureGateRejectsFlatRegion) {
     // Set a threshold high enough to reject the flat half but still accept
-    // the gradient half (step=0.1 → Sobel magnitude ≈ 4 * 0.1 = 0.4 m/px at
-    // the interior of the gradient).  Flat half has gradient 0.
+    // the gradient half. With step=0.1 and the un-normalised 3x3 Sobel
+    // (kernel weights ±1/±2), the magnitude on the interior of the ramp is
+    //   sqrt((-1*(d-Δ) + 1*(d+Δ) + -2*(d-Δ) + 2*(d+Δ) + -1*(d-Δ) + 1*(d+Δ))^2)
+    //   = |8*Δ| = 0.8 (with Δ=0.1).  Flat half has gradient 0.  Threshold
+    //   0.2 is comfortably between the two.
     CpuSemanticProjector proj;
     ASSERT_TRUE(proj.init(make_intrinsics(64, 64)));
     proj.set_texture_gate_threshold(0.2f);
@@ -332,6 +335,19 @@ TEST(SemanticProjector, TextureGateRejectsFlatRegion) {
     EXPECT_EQ(r_flat.value().size(), 0u)
         << "Texture gate should reject the flat-depth bbox centre; got " << r_flat.value().size()
         << " voxels.";
+
+    // Positive control: the same flat-half detection MUST produce a voxel
+    // when the gate is disabled. Proves the rejection above is caused by
+    // the texture gate, not by an unrelated rejection (e.g. depth=0,
+    // out-of-bounds projection, or another preflight check).
+    CpuSemanticProjector proj_open;
+    ASSERT_TRUE(proj_open.init(make_intrinsics(64, 64)));
+    EXPECT_FLOAT_EQ(proj_open.texture_gate_threshold(), 0.0f);
+    auto r_flat_open = proj_open.project(dets_flat, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(r_flat_open.is_ok());
+    EXPECT_EQ(r_flat_open.value().size(), 1u)
+        << "Without the gate, the same flat detection should produce a voxel — "
+           "otherwise the rejection above is not attributable to the gate.";
 
     // Gradient-half detection (x=48) — expected to pass.
     std::vector<InferenceDetection> dets_grad{make_det_at(48, 32)};
@@ -348,4 +364,33 @@ TEST(SemanticProjector, TextureGateNegativeClampedToZero) {
     CpuSemanticProjector proj;
     proj.set_texture_gate_threshold(-1.0f);
     EXPECT_FLOAT_EQ(proj.texture_gate_threshold(), 0.0f);
+}
+
+TEST(SemanticProjector, TextureGateDegenerateDepthMap) {
+    // 3x3 Sobel needs at least 3 rows / cols of usable data.  When the
+    // depth map is smaller than that (e.g. a 2x2 patch from a heavily
+    // letter-boxed source), depth_gradient_magnitude() must fail closed
+    // — return 0 so the gate rejects, rather than read out-of-bounds.
+    // This is the safety-critical default when there's not enough data
+    // to assess texture.
+    CpuSemanticProjector proj;
+    // Intrinsics still 64x64 (source frame) but the DepthMap is 2x2.
+    ASSERT_TRUE(proj.init(make_intrinsics(64, 64)));
+    proj.set_texture_gate_threshold(0.05f);  // tiny threshold
+
+    DepthMap dm;
+    dm.width         = 2;
+    dm.height        = 2;
+    dm.source_width  = 64;
+    dm.source_height = 64;
+    dm.scale         = 32.0f;  // 64 / 2
+    dm.confidence    = 0.9f;
+    dm.data          = {1.0f, 9.0f, 9.0f, 1.0f};  // huge swing — would pass any gate if computed
+
+    std::vector<InferenceDetection> dets{make_det_at(32, 32)};
+    auto                            r = proj.project(dets, dm, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(r.is_ok());
+    EXPECT_EQ(r.value().size(), 0u)
+        << "Degenerate (<3-pixel) DepthMap must fail closed via the texture gate, "
+           "not produce voxels from extrapolated gradient values.";
 }

--- a/tests/test_semantic_projector.cpp
+++ b/tests/test_semantic_projector.cpp
@@ -240,3 +240,112 @@ TEST(SemanticProjector, FactoryUnknownThrows) {
     ASSERT_TRUE(cfg.load(path));
     EXPECT_THROW(drone::hal::create_semantic_projector(cfg), std::runtime_error);
 }
+
+// ═══════════════════════════════════════════════════════════
+// Texture gate (Issue #616)
+// ═══════════════════════════════════════════════════════════
+
+namespace {
+// Helper: depth map with a gradient ramp on one half and flat depth on the
+// other, so we can sample a known "textured" pixel and a "flat" pixel.
+DepthMap make_half_gradient_depth(uint32_t w, uint32_t h, float flat_depth = 5.0f,
+                                  float gradient_step = 0.1f) {
+    DepthMap dm;
+    dm.width         = w;
+    dm.height        = h;
+    dm.source_width  = w;
+    dm.source_height = h;
+    dm.scale         = 1.0f;
+    dm.confidence    = 0.9f;
+    dm.data.resize(static_cast<size_t>(w) * h);
+    // Left half: constant (flat / untextured).  Right half: linear ramp in x.
+    for (uint32_t y = 0; y < h; ++y) {
+        for (uint32_t x = 0; x < w; ++x) {
+            const size_t idx = static_cast<size_t>(y) * w + x;
+            if (x < w / 2) {
+                dm.data[idx] = flat_depth;
+            } else {
+                dm.data[idx] = flat_depth + static_cast<float>(x - w / 2) * gradient_step;
+            }
+        }
+    }
+    return dm;
+}
+
+CameraIntrinsics make_intrinsics(uint32_t w, uint32_t h) {
+    CameraIntrinsics i;
+    i.width  = w;
+    i.height = h;
+    i.fx     = 300.0f;
+    i.fy     = 300.0f;
+    i.cx     = static_cast<float>(w) * 0.5f;
+    i.cy     = static_cast<float>(h) * 0.5f;
+    return i;
+}
+
+InferenceDetection make_det_at(uint32_t cx, uint32_t cy, uint32_t half = 4) {
+    InferenceDetection d;
+    d.bbox.x     = static_cast<int32_t>(cx) - static_cast<int32_t>(half);
+    d.bbox.y     = static_cast<int32_t>(cy) - static_cast<int32_t>(half);
+    d.bbox.w     = static_cast<int32_t>(half * 2);
+    d.bbox.h     = static_cast<int32_t>(half * 2);
+    d.class_id   = 1;
+    d.confidence = 0.9f;
+    return d;
+}
+}  // namespace
+
+TEST(SemanticProjector, TextureGateDefaultDisabled) {
+    // With threshold 0 (default), ALL sampled depths pass through — both the
+    // flat half and the gradient half produce voxels.  Preserves pre-#616
+    // behaviour for Gazebo scenarios that never opt in.
+    CpuSemanticProjector proj;
+    ASSERT_TRUE(proj.init(make_intrinsics(64, 64)));
+    EXPECT_FLOAT_EQ(proj.texture_gate_threshold(), 0.0f);
+
+    auto depth = make_half_gradient_depth(64, 64);
+
+    // One detection in the flat half, one in the gradient half.
+    std::vector<InferenceDetection> dets{make_det_at(16, 32), make_det_at(48, 32)};
+
+    auto result = proj.project(dets, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().size(), 2u)
+        << "With texture gate off, both detections produce voxels.";
+}
+
+TEST(SemanticProjector, TextureGateRejectsFlatRegion) {
+    // Set a threshold high enough to reject the flat half but still accept
+    // the gradient half (step=0.1 → Sobel magnitude ≈ 4 * 0.1 = 0.4 m/px at
+    // the interior of the gradient).  Flat half has gradient 0.
+    CpuSemanticProjector proj;
+    ASSERT_TRUE(proj.init(make_intrinsics(64, 64)));
+    proj.set_texture_gate_threshold(0.2f);
+    EXPECT_FLOAT_EQ(proj.texture_gate_threshold(), 0.2f);
+
+    auto depth = make_half_gradient_depth(64, 64);
+
+    // Flat-half detection (x=16) — expected to be rejected by the gate.
+    std::vector<InferenceDetection> dets_flat{make_det_at(16, 32)};
+    auto r_flat = proj.project(dets_flat, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(r_flat.is_ok());
+    EXPECT_EQ(r_flat.value().size(), 0u)
+        << "Texture gate should reject the flat-depth bbox centre; got " << r_flat.value().size()
+        << " voxels.";
+
+    // Gradient-half detection (x=48) — expected to pass.
+    std::vector<InferenceDetection> dets_grad{make_det_at(48, 32)};
+    auto r_grad = proj.project(dets_grad, depth, Eigen::Affine3f::Identity());
+    ASSERT_TRUE(r_grad.is_ok());
+    EXPECT_EQ(r_grad.value().size(), 1u)
+        << "Texture gate should accept the high-gradient bbox centre; got " << r_grad.value().size()
+        << " voxels.";
+}
+
+TEST(SemanticProjector, TextureGateNegativeClampedToZero) {
+    // set_texture_gate_threshold clamps negative input to zero (a negative
+    // threshold is nonsensical; silently clamping is safer than accepting it).
+    CpuSemanticProjector proj;
+    proj.set_texture_gate_threshold(-1.0f);
+    EXPECT_FLOAT_EQ(proj.texture_gate_threshold(), 0.0f);
+}

--- a/tools/calibrate_depth_anything_v2.py
+++ b/tools/calibrate_depth_anything_v2.py
@@ -79,13 +79,18 @@ def percentile(values: list[float], p: float) -> float:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     ap.add_argument("log_path", type=Path, help="Path to perception.log from a scenario run")
     ap.add_argument(
         "--percentile",
         type=float,
         default=100.0,
         help="Use the N-th percentile of per-frame min/max (default 100 = absolute). "
+             "Applied symmetrically: raw_max_ref uses the N-th percentile of the per-frame "
+             "maxes, raw_min_ref uses the (100-N)-th percentile of the per-frame mins. "
              "Try 99 or 95 to reject one-frame outliers on startup.",
     )
     ap.add_argument(
@@ -109,6 +114,19 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Sample-size sanity check.  The diagnostic is emitted every 30th frame,
+    # so a single match means the run barely exited bootstrap.  Pinning
+    # calibration refs to one sample makes the linear fit fragile —
+    # any startup transient becomes the global anchor.
+    if len(pairs) < 2:
+        print(
+            f"WARNING: only {len(pairs)} DA V2 range sample(s) parsed — calibration "
+            "refs derived from such a small sample are unreliable.  Re-run the "
+            "scenario for at least ~10 seconds (≥ 60 sampled frames) for a "
+            "trustworthy fit.",
+            file=sys.stderr,
+        )
 
     mins = [p[0] for p in pairs]
     maxs = [p[1] for p in pairs]

--- a/tools/calibrate_depth_anything_v2.py
+++ b/tools/calibrate_depth_anything_v2.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+calibrate_depth_anything_v2.py — extract anchored-scale references from a
+Depth Anything V2 scenario run (Issue #616).
+
+Reads the `perception.log` from a scenario run and scans for DA V2 raw-range
+diagnostic lines (emitted every 30th frame by default):
+
+    [DepthAnythingV2] 518x518 depth map in NNms (inv_depth range: [X.XXX, Y.YYY])
+
+Aggregates the per-frame (min, max) pairs across the run and prints the
+recommended `raw_min_ref` / `raw_max_ref` values — plus a ready-to-paste
+`config_overrides` block — for pinning DA V2's anchored-scale mode.
+
+Usage:
+    python3 tools/calibrate_depth_anything_v2.py <path_to_perception.log>
+
+Optional:
+    --percentile 99   Use the N-th percentile instead of absolute min/max
+                      (robustness against one-frame outliers).  Default 100
+                      (absolute min/max).
+    --emit-json PATH  Also write the coefficients as a JSON file for
+                      scripted consumption.
+
+This is a first-pass calibration — anchors the *scale* only.  The linear
+fit (`calibration_coef_a` / `calibration_coef_b`) defaults to identity
+(1.0 / 0.0).  For a true metric fit you need matched
+`(raw_inverse_depth, ground_truth_metres)` pixel pairs from a Cosys
+`DepthCam` stream — tracked as a follow-up issue; not in #616 scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Matches the diagnostic line emitted by DepthAnythingV2Estimator::estimate():
+#   "[DepthAnythingV2] 518x518 depth map in 42ms (inv_depth range: [0.123, 0.987])"
+RANGE_RE = re.compile(
+    r"\[DepthAnythingV2\].*inv_depth range:\s*\[([-+]?\d+(?:\.\d+)?),\s*([-+]?\d+(?:\.\d+)?)\]"
+)
+
+
+def parse_log(path: Path) -> list[tuple[float, float]]:
+    """Return a list of (raw_min, raw_max) pairs from each matching log line."""
+    pairs: list[tuple[float, float]] = []
+    with path.open() as f:
+        for line in f:
+            m = RANGE_RE.search(line)
+            if not m:
+                continue
+            try:
+                lo, hi = float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+            if lo >= hi:
+                # Malformed or flat-scene frame; ignore.
+                continue
+            pairs.append((lo, hi))
+    return pairs
+
+
+def percentile(values: list[float], p: float) -> float:
+    """Linear-interpolation percentile; `p` in [0, 100]."""
+    if not values:
+        raise ValueError("percentile() on empty list")
+    s = sorted(values)
+    if p <= 0:
+        return s[0]
+    if p >= 100:
+        return s[-1]
+    idx = (p / 100.0) * (len(s) - 1)
+    lo, hi = int(idx), min(int(idx) + 1, len(s) - 1)
+    frac = idx - lo
+    return s[lo] + (s[hi] - s[lo]) * frac
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("log_path", type=Path, help="Path to perception.log from a scenario run")
+    ap.add_argument(
+        "--percentile",
+        type=float,
+        default=100.0,
+        help="Use the N-th percentile of per-frame min/max (default 100 = absolute). "
+             "Try 99 or 95 to reject one-frame outliers on startup.",
+    )
+    ap.add_argument(
+        "--emit-json",
+        type=Path,
+        default=None,
+        help="Also write the coefficients as JSON for scripted consumption.",
+    )
+    args = ap.parse_args()
+
+    if not args.log_path.exists():
+        print(f"ERROR: log file not found: {args.log_path}", file=sys.stderr)
+        return 2
+
+    pairs = parse_log(args.log_path)
+    if not pairs:
+        print(f"ERROR: no DA V2 inv_depth range lines found in {args.log_path}", file=sys.stderr)
+        print(
+            "       Expected format: [DepthAnythingV2] WxH depth map in NNms "
+            "(inv_depth range: [X, Y])",
+            file=sys.stderr,
+        )
+        return 1
+
+    mins = [p[0] for p in pairs]
+    maxs = [p[1] for p in pairs]
+
+    if args.percentile >= 100.0:
+        raw_min_ref = min(mins)
+        raw_max_ref = max(maxs)
+        tag = "absolute min/max"
+    else:
+        # Symmetric — lower percentile of mins, upper percentile of maxs.
+        raw_min_ref = percentile(mins, 100.0 - args.percentile)
+        raw_max_ref = percentile(maxs, args.percentile)
+        tag = f"{args.percentile:.0f}th percentile"
+
+    # Report
+    print(f"[calibrate_dav2] Parsed {len(pairs)} frames from {args.log_path}")
+    print(f"[calibrate_dav2] Per-frame min range: [{min(mins):.3f}, {max(mins):.3f}]")
+    print(f"[calibrate_dav2] Per-frame max range: [{min(maxs):.3f}, {max(maxs):.3f}]")
+    print(f"[calibrate_dav2] Using {tag}: raw_min_ref={raw_min_ref:.6f}, "
+          f"raw_max_ref={raw_max_ref:.6f}")
+    print()
+    print("[calibrate_dav2] Paste into your scenario's config_overrides:")
+    print()
+    print("  \"perception\": {")
+    print("    \"depth_estimator\": {")
+    print("      \"dav2\": {")
+    print("        \"calibration_enabled\": true,")
+    print(f"        \"raw_min_ref\": {raw_min_ref:.6f},")
+    print(f"        \"raw_max_ref\": {raw_max_ref:.6f},")
+    print("        \"calibration_coef_a\": 1.0,")
+    print("        \"calibration_coef_b\": 0.0")
+    print("      }")
+    print("    }")
+    print("  }")
+    print()
+    print("[calibrate_dav2] NOTE: coef_a / coef_b are identity passthrough.  For a")
+    print("[calibrate_dav2] true metric fit you need matched (raw, GT) pixel pairs")
+    print("[calibrate_dav2] from a Cosys DepthCam stream — tracked as a follow-up.")
+
+    if args.emit_json:
+        out = {
+            "calibration_enabled": True,
+            "raw_min_ref": raw_min_ref,
+            "raw_max_ref": raw_max_ref,
+            "calibration_coef_a": 1.0,
+            "calibration_coef_b": 0.0,
+            "_meta": {
+                "source_log": str(args.log_path),
+                "frames_parsed": len(pairs),
+                "percentile": args.percentile,
+            },
+        }
+        args.emit_json.parent.mkdir(parents=True, exist_ok=True)
+        args.emit_json.write_text(json.dumps(out, indent=2) + "\n")
+        print(f"[calibrate_dav2] Wrote JSON to {args.emit_json}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/tools/test_calibrate_depth_anything_v2.sh
+++ b/tools/test_calibrate_depth_anything_v2.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Smoke test for tools/calibrate_depth_anything_v2.py (Issue #616).
+#
+# Exercises the end-to-end parsing + fitting pipeline using a synthetic
+# perception.log sample.  Not wired into ctest — this project does not use
+# CMake to drive Python/shell tests — run it manually when touching the
+# calibration script:
+#
+#     bash tools/test_calibrate_depth_anything_v2.sh
+#
+# Exits non-zero on the first failed assertion.  Keeps the test hermetic:
+# all scratch files land in a per-run $TMPDIR that is cleaned up on exit.
+
+set -euo pipefail
+
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/calibrate_depth_anything_v2.py"
+
+if [[ ! -x "${SCRIPT}" && ! -f "${SCRIPT}" ]]; then
+    echo "ERROR: ${SCRIPT} not found" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d -t calib-dav2-test-XXXXXX)"
+trap 'rm -rf "${WORK}"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# ── 1. Happy path: multi-frame log with clear min/max ───────────────────
+LOG="${WORK}/perception.log"
+cat > "${LOG}" <<'EOF'
+2026-04-20 10:00:00 INFO unrelated: boot
+[DepthAnythingV2] 518x518 depth map in 42ms (inv_depth range: [0.100, 0.900])
+[DepthAnythingV2] 518x518 depth map in 39ms (inv_depth range: [0.110, 0.880])
+[DepthAnythingV2] 518x518 depth map in 41ms (inv_depth range: [0.105, 0.910])
+2026-04-20 10:00:01 INFO another unrelated line
+[DepthAnythingV2] 518x518 depth map in 40ms (inv_depth range: [0.120, 0.895])
+EOF
+
+OUT="${WORK}/out.json"
+python3 "${SCRIPT}" "${LOG}" --emit-json "${OUT}" >"${WORK}/stdout.txt" 2>"${WORK}/stderr.txt" \
+    || fail "happy path exited non-zero"
+
+grep -q 'Parsed 4 frames' "${WORK}/stdout.txt" \
+    || fail "expected 'Parsed 4 frames' in stdout"
+grep -q '"raw_min_ref": 0.1' "${OUT}" \
+    || fail "expected raw_min_ref=0.1 in JSON"
+grep -q '"raw_max_ref": 0.91' "${OUT}" \
+    || fail "expected raw_max_ref=0.91 in JSON"
+
+# Single-frame warning MUST NOT fire when we have 4 samples.
+if grep -q 'only .* sample' "${WORK}/stderr.txt"; then
+    fail "single-sample warning fired with 4 samples"
+fi
+
+# ── 2. No matching lines → exit 1 + helpful error ───────────────────────
+BAD="${WORK}/empty.log"
+echo "nothing to parse here" > "${BAD}"
+
+set +e
+python3 "${SCRIPT}" "${BAD}" >/dev/null 2>"${WORK}/stderr_bad.txt"
+rc=$?
+set -e
+[[ ${rc} -eq 1 ]] || fail "empty-log path expected rc=1, got ${rc}"
+grep -q 'no DA V2 inv_depth range lines' "${WORK}/stderr_bad.txt" \
+    || fail "empty-log error message missing"
+
+# ── 3. Missing file → exit 2 ────────────────────────────────────────────
+set +e
+python3 "${SCRIPT}" "${WORK}/does_not_exist.log" >/dev/null 2>/dev/null
+rc=$?
+set -e
+[[ ${rc} -eq 2 ]] || fail "missing-file path expected rc=2, got ${rc}"
+
+# ── 4. Single-frame log → warning on stderr ─────────────────────────────
+SINGLE="${WORK}/single.log"
+echo '[DepthAnythingV2] 518x518 depth map in 42ms (inv_depth range: [0.100, 0.900])' \
+    > "${SINGLE}"
+python3 "${SCRIPT}" "${SINGLE}" >/dev/null 2>"${WORK}/stderr_single.txt" \
+    || fail "single-frame path exited non-zero (should still succeed)"
+grep -q 'only 1 DA V2 range sample' "${WORK}/stderr_single.txt" \
+    || fail "single-frame warning missing on stderr"
+
+# ── 5. Percentile flag shifts refs inward ───────────────────────────────
+OUT_P="${WORK}/out_p.json"
+python3 "${SCRIPT}" "${LOG}" --percentile 75 --emit-json "${OUT_P}" \
+    >/dev/null 2>&1 || fail "--percentile 75 exited non-zero"
+# Parse both JSON files and assert the percentile fit has a strictly
+# tighter range (higher min, lower max) than the absolute fit.
+python3 - <<PY
+import json, sys
+p100 = json.load(open("${OUT}"))
+p75  = json.load(open("${OUT_P}"))
+assert p75["raw_min_ref"] > p100["raw_min_ref"], \
+    f"p75 min {p75['raw_min_ref']} not > p100 min {p100['raw_min_ref']}"
+assert p75["raw_max_ref"] < p100["raw_max_ref"], \
+    f"p75 max {p75['raw_max_ref']} not < p100 max {p100['raw_max_ref']}"
+PY
+
+echo "OK — all 5 calibration-script checks passed"


### PR DESCRIPTION
## Summary

Closes #616.

Depth Anything V2 outputs relative inverse depth. Today the estimator normalises per-frame (min/max recomputed every frame), producing a metric scale that shifts between frames based on scene content — looking at a near cube vs a distant horizon remaps identical raw values to different metres. That drift is the dominant cause of voxel-position instability in PATH A (see Fix #55 context / #612 diagnostic).

This PR adds **two independent, opt-in** mechanisms to fix that without changing behaviour for any existing scenario.

### 1. Anchored-scale calibration (`DepthAnythingV2Estimator`)

Two conversion paths, selectable via config:

- **Per-frame (default, pre-#616)**: unchanged.
- **Calibrated**: use fitted `(raw_min_ref, raw_max_ref)` to anchor normalisation across frames, then apply linear fit `metric = a × metric_anchored + b`.

**Graceful fallback**: if `calibration_enabled=true` but refs are NaN or `raw_max <= raw_min`, the estimator logs a WARN and falls back to per-frame. Never silently emits garbage metres.

### 2. Texture-gated sampling (`CpuSemanticProjector`)

Sobel magnitude check on the depth map at each sampled pixel. Rejects samples in low-gradient regions — flat depth corresponds to DA V2's weakest failure mode (cube faces, sky, textureless walls), where the network has no features to latch onto and output is effectively noise.

Disabled by default; threshold in metres-per-pixel, tuned per scenario.

### 3. Calibration helper (`tools/calibrate_depth_anything_v2.py`)

Reads `perception.log` for DA V2 `inv_depth range` diagnostic lines, aggregates across a run, prints recommended `raw_min_ref` / `raw_max_ref` + a ready-to-paste `config_overrides` block. Supports `--percentile` for outlier-robust fitting. Identity linear fit; metric-accurate `a`/`b` require Cosys `DepthCam` GT pairs (separate follow-up, not in this PR).

### 4. `docs/tracking/PRODUCTION_READINESS.md` (new section)

Sim-to-Real Transition Map enumerating what changes between Cosys and Jetson deploy. #616 is flagged as shipping the config machinery the real deploy needs — calibration coefficients cannot be baked into the binary because they change per-environment.

## New config keys (all defaults preserve pre-#616 behaviour)

```
perception.depth_estimator.dav2.calibration_enabled       bool  (false)
perception.depth_estimator.dav2.raw_min_ref               float (NaN)
perception.depth_estimator.dav2.raw_max_ref               float (NaN)
perception.depth_estimator.dav2.calibration_coef_a        float (1.0 — identity)
perception.depth_estimator.dav2.calibration_coef_b        float (0.0 — identity)
perception.semantic_projector.texture_gate_threshold      float (0.0 = disabled)
```

## Test plan

- [x] `test_depth_anything_v2.cpp` — 4 new tests + 1 updated (calibration enable/fallback paths)
- [x] `test_semantic_projector.cpp` — 3 new tests (texture gate on/off + clamp)
- [x] 13/13 DA V2 non-model tests pass
- [x] 17/17 projector tests pass
- [x] 1850 total tests pass
- [x] clang-format-18 clean
- [x] `tools/calibrate_depth_anything_v2.py` smoke-tested with synthetic input
- [ ] Scenario 33 Cosys run with calibration enabled — needs desktop GPU; will run after CI passes
- [ ] `check_voxel_on_target.py` reports improved ratio — same scenario-33 run

## Scope notes — what this PR does NOT do

- **True per-pixel regression against Cosys `DepthCam`**. The issue body called this out as the "real" calibration; it requires dumping matched `(RGB, DepthCam)` frames during a dedicated calibration run + fitting `(a, b)` offline. That's meaningful extra infrastructure (~2 days). The anchored-scale + identity-fit path in this PR gets most of the way there with operator-tunable coefficients; a proper regression tool is tracked as follow-up.
- **Changing any default**. All keys default to the pre-#616 behaviour. Scenarios opt in individually.

## Related

- #393 (parent survey — implements Section 3.1)
- #449 (downstream consumer — this is its prerequisite)
- #612 / #614 (diagnostic infrastructure used for calibration data + voxel-on-target check that measures impact)
- #615 (queued next — collision reflex; independent)
- #619 (filed today — voxel-aware avoider, complementary architectural work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
