### PR TITLE
fix(#625): scenario runners preflight every model_path before launch

### DIFF
--- a/docs/guides/DEVELOPMENT_WORKFLOW.md
+++ b/docs/guides/DEVELOPMENT_WORKFLOW.md
@@ -355,6 +355,20 @@ bash tests/test_zenoh_e2e.sh
 - Mark simulation-dependent tests with a GTest filter tag: `TEST(Integration, ...)`
 - Document any required environment setup in the PR description
 
+##### Tier-3 / Cosys-AirSim model preflight (Issue #625)
+
+`tests/run_scenario_cosys.sh` and `tests/run_scenario_gazebo.sh` both run a preflight check that verifies every `model_path` referenced in the merged scenario config exists on disk **before** launching any companion process. Missing models otherwise produce silent in-process degradation (e.g. `[OpenCvYoloDetector] Failed to load model`) that looks identical to genuine logic bugs and burns 30+ minutes per scenario debug.
+
+If the runner reports `✗ Preflight failed: missing model file(s)` it will list each missing file with the exact download script to run, e.g.:
+
+```
+config key:  perception.detector.model_path
+expected at: /path/to/models/yolov8n.onnx
+→ run: bash models/download_yolov8n.sh
+```
+
+The `models/` directory is gitignored — every fresh checkout / new dev machine needs the relevant download scripts run once before scenario testing works.
+
 #### Step 5: Create Pull Request
 
 1. Push branch: `git push origin feature/issue-XX-description`

--- a/tests/run_scenario_cosys.sh
+++ b/tests/run_scenario_cosys.sh
@@ -544,6 +544,59 @@ if [[ -z "$EFFECTIVE_IPC" ]]; then
     EFFECTIVE_IPC=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('ipc_backend','zenoh'))" "$MERGED_CONFIG" 2>/dev/null || echo "zenoh")
 fi
 
+# ── Preflight: every model_path in the merged config must exist (Issue #625) ──
+# Without this check, a missing ONNX file produces a silent in-process error
+# (e.g. `[OpenCvYoloDetector] Failed to load model`) and the scenario runs to
+# completion with the affected stage degraded.  The pass_criteria failures look
+# identical to genuine logic bugs, so debugging takes 30+ minutes per missing
+# file.  Fail fast here instead, with a pointer to the right download script.
+MISSING_MODELS=$(python3 - "$MERGED_CONFIG" "$PROJECT_DIR" <<'PYEOF'
+import json, os, sys, pathlib
+cfg_path, project_root = sys.argv[1], pathlib.Path(sys.argv[2])
+cfg = json.load(open(cfg_path))
+missing = []
+def walk(obj, path=""):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            child = f"{path}.{k}" if path else k
+            if k == "model_path" and isinstance(v, str) and v:
+                p = pathlib.Path(v)
+                if not p.is_absolute():
+                    p = (project_root / p)
+                if not p.exists():
+                    missing.append((child, str(p)))
+            walk(v, child)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            walk(item, f"{path}[{i}]")
+walk(cfg)
+for key, path in missing:
+    print(f"{key}\t{path}")
+PYEOF
+)
+if [[ -n "$MISSING_MODELS" ]]; then
+    echo -e "  ${RED}✗ Preflight failed: missing model file(s) referenced by scenario config${NC}" >&2
+    echo "" >&2
+    echo "$MISSING_MODELS" | while IFS=$'\t' read -r key path; do
+        echo "    config key:  $key" >&2
+        echo "    expected at: $path" >&2
+        case "$path" in
+            *yolov8n*)             echo "    → run: bash models/download_yolov8n.sh"          >&2 ;;
+            *yolov8s*)             echo "    → run: bash models/download_yolov8n.sh # use 'n' variant" >&2 ;;
+            *yolov8*visdrone*)     echo "    → run: bash models/download_yolov8n_visdrone.sh"  >&2 ;;
+            *fastsam*)             echo "    → run: bash models/download_fastsam.sh"           >&2 ;;
+            *depth_anything_v2*)   echo "    → run: bash models/download_depth_anything_v2.sh" >&2 ;;
+            *)                     echo "    → no known download script; check models/ for the matching .sh" >&2 ;;
+        esac
+        echo "" >&2
+    done
+    echo -e "  ${YELLOW}Tip:${NC} models/ is gitignored — every fresh checkout needs the download scripts run." >&2
+    echo "" >&2
+    SCENARIO_LOG_DIR=$(abort_run_dir "$SCENARIO_LOG_DIR")
+    exit 1
+fi
+echo -e "  ${GREEN}✓${NC} Preflight: all referenced model files present"
+
 # ── Dry run ───────────────────────────────────────────────────
 if [[ "$DRY_RUN" == "true" ]]; then
     echo ""

--- a/tests/run_scenario_gazebo.sh
+++ b/tests/run_scenario_gazebo.sh
@@ -409,6 +409,57 @@ if [[ -z "$EFFECTIVE_IPC" ]]; then
     EFFECTIVE_IPC=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('ipc_backend','shm'))" "$MERGED_CONFIG" 2>/dev/null || echo "shm")
 fi
 
+# ── Preflight: every model_path in the merged config must exist (Issue #625) ──
+# Mirrors the same check in run_scenario_cosys.sh — see comments there for the
+# rationale (silent in-process model-load failure → looks identical to logic
+# bugs → 30+ minute debug per missing file).  Fail fast here instead.
+MISSING_MODELS=$(python3 - "$MERGED_CONFIG" "$PROJECT_DIR" <<'PYEOF'
+import json, os, sys, pathlib
+cfg_path, project_root = sys.argv[1], pathlib.Path(sys.argv[2])
+cfg = json.load(open(cfg_path))
+missing = []
+def walk(obj, path=""):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            child = f"{path}.{k}" if path else k
+            if k == "model_path" and isinstance(v, str) and v:
+                p = pathlib.Path(v)
+                if not p.is_absolute():
+                    p = (project_root / p)
+                if not p.exists():
+                    missing.append((child, str(p)))
+            walk(v, child)
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            walk(item, f"{path}[{i}]")
+walk(cfg)
+for key, path in missing:
+    print(f"{key}\t{path}")
+PYEOF
+)
+if [[ -n "$MISSING_MODELS" ]]; then
+    echo -e "  ${RED}✗ Preflight failed: missing model file(s) referenced by scenario config${NC}" >&2
+    echo "" >&2
+    echo "$MISSING_MODELS" | while IFS=$'\t' read -r key path; do
+        echo "    config key:  $key" >&2
+        echo "    expected at: $path" >&2
+        case "$path" in
+            *yolov8n*)             echo "    → run: bash models/download_yolov8n.sh"          >&2 ;;
+            *yolov8s*)             echo "    → run: bash models/download_yolov8n.sh # use 'n' variant" >&2 ;;
+            *yolov8*visdrone*)     echo "    → run: bash models/download_yolov8n_visdrone.sh"  >&2 ;;
+            *fastsam*)             echo "    → run: bash models/download_fastsam.sh"           >&2 ;;
+            *depth_anything_v2*)   echo "    → run: bash models/download_depth_anything_v2.sh" >&2 ;;
+            *)                     echo "    → no known download script; check models/ for the matching .sh" >&2 ;;
+        esac
+        echo "" >&2
+    done
+    echo -e "  ${YELLOW}Tip:${NC} models/ is gitignored — every fresh checkout needs the download scripts run." >&2
+    echo "" >&2
+    SCENARIO_LOG_DIR=$(abort_run_dir "$SCENARIO_LOG_DIR")
+    exit 1
+fi
+echo -e "  ${GREEN}✓${NC} Preflight: all referenced model files present"
+
 # ── Dry run ───────────────────────────────────────────────────
 if [[ "$DRY_RUN" == "true" ]]; then
     echo ""


### PR DESCRIPTION
## Summary

Scenario runners now verify every `model_path` referenced in the merged config exists on disk **before** launching any companion process. When a model is missing, they fail fast with a per-file pointer to the exact download script to run, instead of letting the scenario run to completion with silently degraded in-process behaviour.

Closes #625.

## Motivation — real failure observed 2026-04-24

Scenario 33 was failing with the drone plowing into a TemplateCube; collision count 237. Investigation went down frame conventions, yaw-velocity hooks, post-avoider sequencing, SLAM pose error, DA V2 calibration. **~2 hours.** Actual root cause: `models/yolov8n.onnx` had never been downloaded on this machine. After running `bash models/download_yolov8n.sh` (30 seconds), the same scenario went from collision count 237 to 0 and the drone successfully routed around the cube.

Every time `models/` is wiped — new checkout, new dev machine, fresh CI runner — this trap is re-armed. The preflight removes it.

## How it works

After the merged config is built (Phase 1), before any companion process launches (Phase 3), walk the config recursively, find every `model_path` key, check `file.exists()`. Missing files print:

```
✗ Preflight failed: missing model file(s) referenced by scenario config

    config key:  perception.detector.model_path
    expected at: /…/models/yolov8n.onnx
    → run: bash models/download_yolov8n.sh

Tip: models/ is gitignored — every fresh checkout needs the download scripts run.
```

Download-script mapping handles `yolov8n`, `yolov8s`, `yolov8*visdrone*`, `fastsam*`, `depth_anything_v2*`. Unknown filenames get a generic "check models/" hint.

## Test plan

- [x] `bash -n` syntax check on both runners
- [x] Hide `models/yolov8n.onnx` → scenario 33 preflight fails with the listed config key + correct download-script hint
- [x] Restore → preflight passes silently, runner continues to dry-run
- [x] Both runners get the identical check (copy-pasted, same behaviour)
- [x] Doc note added in `docs/guides/DEVELOPMENT_WORKFLOW.md` Step 4f
- [ ] CI

## Scope

Bash + Python heredoc only. No C++ changes. No behaviour change when all models are present. Matches the single-concern PR guideline.

## Related follow-ups (separate issues)

- #626 — `perception.depth_estimator.use_cuda` config flag is silently ignored (dead config key)
- #627 — `perception.depth_estimator.input_width` / `input_height` keys are silently ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)