### PR TITLE
feat(#638): Phase 1 — voxel clustering (per-frame instance IDs)

### DIFF
--- a/common/hal/include/hal/ivolumetric_map.h
+++ b/common/hal/include/hal/ivolumetric_map.h
@@ -44,6 +44,11 @@ struct VoxelUpdate {
     uint8_t         semantic_label{0};
     float           confidence{0.5f};
     uint64_t        timestamp_ns{0};
+    // Issue #638 Phase 1 — per-frame cluster ID assigned by P2's
+    // voxel_clusterer between MaskDepthProjector::project() and the
+    // SemanticVoxelBatch publish.  0 = unclustered noise; >=1 = cluster.
+    // Carried through to SemanticVoxel.instance_id in the IPC message.
+    uint32_t instance_id{0};
 };
 
 /// Abstract volumetric map interface.

--- a/common/ipc/include/ipc/ipc_types.h
+++ b/common/ipc/include/ipc/ipc_types.h
@@ -137,6 +137,15 @@ struct SemanticVoxel {
     ObjectClass semantic_label{ObjectClass::UNKNOWN};  // class label from MaskClassAssigner
     uint8_t     _pad_label[3]{0, 0, 0};                // keep 8-byte alignment before timestamp_ns
     uint64_t    timestamp_ns{0};                       // source-frame capture time
+    // Issue #638 Phase 1 — per-frame cluster ID assigned by P2's
+    // voxel_clusterer before publishing.  0 = unclustered noise (a voxel
+    // that didn't reach min_pts in its connected component); ≥1 = member
+    // of a distinct 3D cluster.  Cluster IDs are *frame-local* — Phase 2
+    // (cross-frame instance tracker) will replace these with stable
+    // tracked-instance IDs.  Until Phase 3 wires the consumer side,
+    // OccupancyGrid3D ignores this field and behaviour is unchanged.
+    uint32_t instance_id{0};
+    uint32_t _pad_instance{0};  // keep 8-byte struct alignment
 
     [[nodiscard]] bool validate() const {
         // Enum-range check — senders write a raw byte over Zenoh, so guard
@@ -181,14 +190,19 @@ static_assert(std::is_standard_layout_v<SemanticVoxelBatch>,
               "SemanticVoxelBatch must be standard layout");
 
 // Wire-format ABI guards — catch silent field reorder / resize on future edits.
-static_assert(sizeof(SemanticVoxel) == 32,
-              "SemanticVoxel wire size must be 32 B; update wire consumers if this changes");
+// Issue #638 Phase 1 grew the struct from 32 → 40 B by adding instance_id +
+// 4-byte trailing pad.  Wire format is in lock-step between P2 and P4 (both
+// rebuild from this header), so the size bump is safe within one deployment.
+static_assert(sizeof(SemanticVoxel) == 40,
+              "SemanticVoxel wire size must be 40 B; update wire consumers if this changes");
 static_assert(offsetof(SemanticVoxel, position_x) == 0, "position_x must start at offset 0");
 static_assert(offsetof(SemanticVoxel, occupancy) == 12, "occupancy must follow position_{x,y,z}");
 static_assert(offsetof(SemanticVoxel, semantic_label) == 20,
               "semantic_label must follow occupancy+confidence");
 static_assert(offsetof(SemanticVoxel, timestamp_ns) == 24,
               "timestamp_ns must be 8-byte aligned at offset 24");
+static_assert(offsetof(SemanticVoxel, instance_id) == 32,
+              "instance_id must be 4-byte aligned at offset 32 (Issue #638 Phase 1)");
 static_assert(offsetof(SemanticVoxelBatch, num_voxels) == 16,
               "num_voxels must follow timestamp_ns + frame_sequence");
 static_assert(offsetof(SemanticVoxelBatch, voxels) == 24,

--- a/common/util/include/util/config_keys.h
+++ b/common/util/include/util/config_keys.h
@@ -244,6 +244,18 @@ inline constexpr const char* MASK_CLASS_IOU_THRESHOLD =
 // voxels actually land vs scene-object ground truth.
 inline constexpr const char* DIAG_TRACE_VOXELS = "perception.path_a.diag.trace_voxels";
 inline constexpr const char* DIAG_TRACE_PATH   = "perception.path_a.diag.trace_path";
+
+// Issue #638 Phase 1 — voxel clustering (3D Union-Find on grid hash) runs
+// after MaskDepthProjector::project() and before SemanticVoxelBatch
+// publish.  Voxels in clusters of <CLUSTER_MIN_PTS members get
+// instance_id=0 (noise); larger components get unique per-frame IDs.
+//
+// CLUSTER_EPS_M = 0  → clustering disabled (every voxel id=0,
+//                       backwards-compatible default).
+// Recommended: CLUSTER_EPS_M ≈ OccupancyGrid3D resolution (0.5–2 m);
+// CLUSTER_MIN_PTS ≈ 3–5 (rejects single-frame depth artefacts).
+inline constexpr const char* CLUSTER_EPS_M   = "perception.path_a.cluster.eps_m";
+inline constexpr const char* CLUSTER_MIN_PTS = "perception.path_a.cluster.min_pts";
 }  // namespace path_a
 
 // Shutdown drain behaviour (Issue #446)

--- a/process2_perception/include/perception/voxel_clusterer.h
+++ b/process2_perception/include/perception/voxel_clusterer.h
@@ -1,0 +1,181 @@
+// process2_perception/include/perception/voxel_clusterer.h
+//
+// Issue #638 — Voxel clustering Phase 1: assign per-frame cluster IDs to a
+// batch of `hal::VoxelUpdate`s based on 3D spatial proximity.
+//
+// Algorithm: Union-Find on a uniform grid hash.  Each voxel is binned into
+// a `eps_m`-sided cell; voxels in adjacent cells (Chebyshev distance ≤ 1)
+// are linked.  After all unions, connected components are walked; clusters
+// with ≥ `min_pts` members get a unique non-zero ID, smaller components
+// get id=0 (treated as noise downstream).
+//
+// Why Union-Find on a grid (not DBSCAN proper):
+//   * Deterministic and order-independent — DBSCAN's cluster IDs depend on
+//     iteration order; Union-Find produces the same partitioning regardless.
+//   * O(N) for the bin pass + O(N · α(N)) for the unions — much cheaper than
+//     DBSCAN's O(N²) worst case at our typical N (~5 k voxels/frame).
+//   * No kd-tree or distance-metric setup; all comparisons are integer cell
+//     index lookups.
+//   * Per-frame-only — Phase 2 will add cross-frame instance tracking on top
+//     of these stable per-frame IDs.
+//
+// NOT thread-safe — caller is the single P2 mask_projection_thread, runs
+// once per voxel batch.  Self-contained: no class state, no allocations
+// outside the local scratch maps (which can be passed in via Scratch to
+// amortise across frames if profiling shows it matters).
+//
+// Behaviour when cluster list is empty (eps_m <= 0 or min_pts <= 0):
+// every voxel keeps instance_id = 0 (clustering effectively disabled).
+#pragma once
+
+#include "hal/isemantic_projector.h"  // for VoxelUpdate
+
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include <Eigen/Geometry>
+
+namespace drone::perception {
+
+/// Optional scratch buffers — pass the same Scratch instance across frames
+/// to amortise the inner unordered_map allocations.  All members are reset
+/// at the start of each `assign_instance_ids()` call.
+struct VoxelClusterScratch {
+    /// Cell index → first voxel index that occupies it.  Used to find
+    /// neighbours during the union pass.
+    std::unordered_map<uint64_t, int> cell_to_voxel;
+    /// Union-Find parent table sized to voxel count.
+    std::vector<int> parent;
+    /// Per-component voxel count, indexed by representative root.
+    std::unordered_map<int, int> root_size;
+    /// Representative root → final emitted instance_id (0 = noise).
+    std::unordered_map<int, uint32_t> root_to_id;
+};
+
+namespace detail {
+
+/// Pack three int16 cell indices into one 64-bit key.  Cell indices come
+/// from `floor(world_coord / eps_m)`; ±32k cells covers a 32-km cube at
+/// any practical eps_m so int16 is plenty.
+[[nodiscard]] inline uint64_t pack_cell_key(int x, int y, int z) noexcept {
+    return (static_cast<uint64_t>(static_cast<uint32_t>(x) & 0xFFFFu) << 32) |
+           (static_cast<uint64_t>(static_cast<uint32_t>(y) & 0xFFFFu) << 16) |
+           static_cast<uint64_t>(static_cast<uint32_t>(z) & 0xFFFFu);
+}
+
+/// Path-compressed Union-Find find().
+[[nodiscard]] inline int uf_find(std::vector<int>& parent, int x) noexcept {
+    while (parent[x] != x) {
+        parent[x] = parent[parent[x]];  // halving
+        x         = parent[x];
+    }
+    return x;
+}
+
+/// Union-by-rank-free union — caller has already done find() on both args.
+inline void uf_union(std::vector<int>& parent, int rx, int ry) noexcept {
+    if (rx != ry) parent[rx] = ry;
+}
+
+}  // namespace detail
+
+/// Assign per-frame cluster IDs to `voxels` based on 3D spatial proximity.
+///
+/// Each voxel's `instance_id` is set in-place.  Voxels in clusters of
+/// fewer than `min_pts` members get id=0 (noise — Phase 3's
+/// `OccupancyGrid3D::insert_voxels()` will skip promotion for these).
+/// Cluster IDs start at 1; the highest emitted ID equals the number of
+/// non-noise clusters.
+///
+/// @param voxels    voxel batch from `MaskDepthProjector::project()`
+/// @param eps_m     spatial bin size (m) — voxels in adjacent eps-cells
+///                  link into one cluster.  A reasonable default is the
+///                  grid resolution of OccupancyGrid3D (e.g. 0.5–1.0 m).
+/// @param min_pts   minimum voxel count for a connected component to be
+///                  considered a real cluster.  Smaller components get
+///                  id=0.  3–5 is typical for noise rejection.
+/// @param scratch   optional pre-allocated scratch buffers; pass the same
+///                  instance across frames to avoid hashmap reallocation.
+inline void assign_instance_ids(std::vector<drone::hal::VoxelUpdate>& voxels, float eps_m,
+                                int min_pts, VoxelClusterScratch* scratch = nullptr) {
+    // Disabled (or pathological config) → leave every voxel as noise.
+    if (voxels.empty() || eps_m <= 0.0f || min_pts <= 0) {
+        for (auto& v : voxels) v.instance_id = 0;
+        return;
+    }
+
+    // Use either caller-provided scratch or a stack-local one.
+    VoxelClusterScratch  local;
+    VoxelClusterScratch& s = scratch != nullptr ? *scratch : local;
+    s.cell_to_voxel.clear();
+    s.parent.assign(voxels.size(), 0);
+    for (int i = 0; i < static_cast<int>(voxels.size()); ++i) s.parent[i] = i;
+    s.root_size.clear();
+    s.root_to_id.clear();
+
+    const float inv_eps = 1.0f / eps_m;
+
+    // Pass 1 — bin every voxel and union it with the *first* voxel in
+    // each of the 27 adjacent cells (Chebyshev ≤ 1 — face/edge/corner).
+    // Linking only to the first occupant of each neighbour cell is enough
+    // for transitive closure: every voxel later landing in a neighbour
+    // cell unions with that same first occupant, joining the component.
+    for (int i = 0; i < static_cast<int>(voxels.size()); ++i) {
+        const auto& v  = voxels[i];
+        const int   cx = static_cast<int>(std::floor(v.position_m.x() * inv_eps));
+        const int   cy = static_cast<int>(std::floor(v.position_m.y() * inv_eps));
+        const int   cz = static_cast<int>(std::floor(v.position_m.z() * inv_eps));
+
+        for (int dz = -1; dz <= 1; ++dz) {
+            for (int dy = -1; dy <= 1; ++dy) {
+                for (int dx = -1; dx <= 1; ++dx) {
+                    auto it =
+                        s.cell_to_voxel.find(detail::pack_cell_key(cx + dx, cy + dy, cz + dz));
+                    if (it == s.cell_to_voxel.end()) continue;
+                    const int rx = detail::uf_find(s.parent, i);
+                    const int ry = detail::uf_find(s.parent, it->second);
+                    detail::uf_union(s.parent, rx, ry);
+                }
+            }
+        }
+        // Record this voxel as the first occupant of its own cell (only
+        // if no earlier voxel claimed it — earlier voxels stay
+        // authoritative so this voxel was already unioned to them).
+        s.cell_to_voxel.emplace(detail::pack_cell_key(cx, cy, cz), i);
+    }
+
+    // Pass 2 — count component sizes.
+    for (int i = 0; i < static_cast<int>(voxels.size()); ++i) {
+        const int r = detail::uf_find(s.parent, i);
+        ++s.root_size[r];
+    }
+
+    // Pass 3 — assign IDs to qualifying components, write back to voxels.
+    uint32_t next_id = 1;
+    for (int i = 0; i < static_cast<int>(voxels.size()); ++i) {
+        const int r = detail::uf_find(s.parent, i);
+        if (s.root_size[r] < min_pts) {
+            voxels[i].instance_id = 0;
+            continue;
+        }
+        auto [it, inserted] = s.root_to_id.try_emplace(r, next_id);
+        if (inserted) ++next_id;
+        voxels[i].instance_id = it->second;
+    }
+}
+
+/// Convenience accessor — returns the number of distinct non-noise
+/// clusters present in `voxels` (assumes `assign_instance_ids` already
+/// ran).  Useful for diagnostic logs.
+[[nodiscard]] inline uint32_t count_clusters(
+    const std::vector<drone::hal::VoxelUpdate>& voxels) noexcept {
+    uint32_t max_id = 0;
+    for (const auto& v : voxels) {
+        if (v.instance_id > max_id) max_id = v.instance_id;
+    }
+    return max_id;
+}
+
+}  // namespace drone::perception

--- a/process2_perception/src/main.cpp
+++ b/process2_perception/src/main.cpp
@@ -18,6 +18,7 @@
 #include "perception/mask_depth_projector.h"
 #include "perception/types.h"
 #include "perception/ukf_fusion_engine.h"
+#include "perception/voxel_clusterer.h"
 #include "util/config_keys.h"
 #include "util/diagnostic.h"
 #include "util/latency_profiler.h"
@@ -219,7 +220,11 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
                                    drone::ipc::IPublisher<drone::ipc::SemanticVoxelBatch>& voxel_pub,
                                    std::atomic<int>&                      shutdown_phase,
                                    drone::perception::MaskDepthProjector& projector,
-                                   drone::util::PathATrace*               trace) {
+                                   drone::util::PathATrace*               trace,
+                                   // Issue #638 Phase 1 — voxel clustering params.
+                                   // eps_m == 0 disables clustering (every voxel
+                                   // gets instance_id=0, current default).
+                                   float cluster_eps_m, int cluster_min_pts) {
     DRONE_LOG_INFO("[MaskProj] Thread started — publishing to {}",
                    drone::ipc::topics::SEMANTIC_VOXELS);
 
@@ -231,6 +236,10 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
     std::optional<drone::ipc::Pose>     latest_pose;
     std::optional<drone::hal::DepthMap> latest_depth;
     std::optional<Detection2DList>      latest_dets;
+    // Issue #638 Phase 1 — reusable scratch for the per-frame cluster pass.
+    // Keeping the maps + parent vector across frames avoids per-frame
+    // hashmap reallocation; the clusterer clears them at entry.
+    drone::perception::VoxelClusterScratch cluster_scratch;
 
     while (shutdown_phase.load(std::memory_order_acquire) < 2) {
         drone::util::ThreadHeartbeatRegistry::instance().touch(hb.handle());
@@ -317,9 +326,24 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
             }
             continue;
         }
-        const auto voxels = std::move(proj).value();
+        auto voxels = std::move(proj).value();
         if (voxels.empty()) {
             continue;
+        }
+
+        // Issue #638 Phase 1 — assign per-frame cluster IDs in-place.
+        // Voxels in clusters of <cluster_min_pts get instance_id=0
+        // (downstream Phase 3 will skip promotion for those).  Disabled
+        // when cluster_eps_m == 0; today P4 ignores instance_id so the
+        // field is published-only until Phase 3 lands.
+        drone::perception::assign_instance_ids(voxels, cluster_eps_m, cluster_min_pts,
+                                               &cluster_scratch);
+        const uint32_t n_clusters = drone::perception::count_clusters(voxels);
+        if (cluster_eps_m > 0.0f && tick_count % 100 == 1) {
+            DRONE_LOG_INFO("[VoxelCluster] frame_seq={}: {} voxels → {} clusters "
+                           "(eps={:.2f}m, min_pts={})",
+                           masks_opt->frame_sequence, voxels.size(), n_clusters, cluster_eps_m,
+                           cluster_min_pts);
         }
 
         // Pack VoxelUpdate[] -> SemanticVoxelBatch.  Truncate by descending
@@ -345,6 +369,7 @@ static void mask_projection_thread(drone::TripleBuffer<Masks2DList>&          ma
                 static_cast<uint8_t>(drone::ipc::ObjectClass::GEOMETRIC_OBSTACLE));
             out.semantic_label = static_cast<drone::ipc::ObjectClass>(label_byte);
             out.timestamp_ns   = v.timestamp_ns;
+            out.instance_id    = v.instance_id;
         }
         voxel_pub.publish(*batch);
         ++published_count;
@@ -1229,12 +1254,25 @@ int main(int argc, char* argv[]) {
                                      "drone_logs/path_a_voxel_trace.jsonl");
         path_a_trace = std::make_unique<drone::util::PathATrace>(trace_enabled, trace_path);
 
+        // Issue #638 Phase 1 — voxel clustering knobs.  eps_m == 0 disables
+        // (default), preserving today's behaviour.  Scenarios that opt in
+        // override perception.path_a.cluster.eps_m / .min_pts.
+        const float cluster_eps_m =
+            ctx.cfg.get<float>(drone::cfg_key::perception::path_a::CLUSTER_EPS_M, 0.0f);
+        const int cluster_min_pts =
+            ctx.cfg.get<int>(drone::cfg_key::perception::path_a::CLUSTER_MIN_PTS, 3);
+        if (cluster_eps_m > 0.0f) {
+            DRONE_LOG_INFO("[VoxelCluster] enabled: eps={:.2f}m min_pts={}", cluster_eps_m,
+                           cluster_min_pts);
+        }
+
         t_sam       = std::thread(sam_thread, std::ref(*sam_video_sub), std::ref(sam_to_projection),
                                   std::ref(g_shutdown_phase), std::ref(*sam_backend));
-        t_mask_proj = std::thread(
-            mask_projection_thread, std::ref(sam_to_projection), std::ref(inference_to_projection),
-            std::ref(depth_to_projection), std::ref(*pathA_pose_sub), std::ref(*voxel_pub),
-            std::ref(g_shutdown_phase), std::ref(*mask_projector), path_a_trace.get());
+        t_mask_proj = std::thread(mask_projection_thread, std::ref(sam_to_projection),
+                                  std::ref(inference_to_projection), std::ref(depth_to_projection),
+                                  std::ref(*pathA_pose_sub), std::ref(*voxel_pub),
+                                  std::ref(g_shutdown_phase), std::ref(*mask_projector),
+                                  path_a_trace.get(), cluster_eps_m, cluster_min_pts);
     }
 
     // ── Thread watchdog + health publisher ──────────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -167,6 +167,8 @@ add_drone_test(test_yolo_seg_backend     test_yolo_seg_backend.cpp
 endif()
 add_drone_test(test_detector_switcher    test_detector_switcher.cpp)
 add_drone_test(test_mask_depth_projector test_mask_depth_projector.cpp)
+# Issue #638 Phase 1 — voxel clustering
+add_drone_test(test_voxel_clusterer      test_voxel_clusterer.cpp)
 
 # ── MavlinkFCLink tests ─────────────────────────────────────
 add_drone_test(test_mavlink_fc_link test_mavlink_fc_link.cpp)

--- a/tests/test_voxel_clusterer.cpp
+++ b/tests/test_voxel_clusterer.cpp
@@ -1,0 +1,164 @@
+// tests/test_voxel_clusterer.cpp
+// Unit tests for the voxel clusterer (Issue #638 Phase 1).
+//
+// Tests cover the truth table that downstream Phase 3 will rely on:
+//   - empty input is a no-op
+//   - clustering disabled (eps==0 or min_pts==0) leaves every voxel id=0
+//   - one tight cluster gets one non-zero ID
+//   - sparse noise (every voxel >2*eps from every other) stays id=0
+//   - two distant clusters get distinct IDs
+//   - cluster spanning multiple eps-cells unions transitively
+//   - small components below min_pts get id=0
+//   - scratch buffer can be reused across calls without state leakage
+
+#include "perception/voxel_clusterer.h"
+
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+using drone::hal::VoxelUpdate;
+using drone::perception::assign_instance_ids;
+using drone::perception::count_clusters;
+using drone::perception::VoxelClusterScratch;
+
+namespace {
+
+VoxelUpdate make_voxel(float x, float y, float z) {
+    VoxelUpdate v;
+    v.position_m = Eigen::Vector3f(x, y, z);
+    v.confidence = 0.9f;
+    v.occupancy  = 1.0f;
+    return v;
+}
+
+// Returns the set of distinct non-zero instance IDs present in voxels.
+std::unordered_set<uint32_t> distinct_ids(const std::vector<VoxelUpdate>& voxels) {
+    std::unordered_set<uint32_t> ids;
+    for (const auto& v : voxels) {
+        if (v.instance_id != 0) ids.insert(v.instance_id);
+    }
+    return ids;
+}
+
+}  // namespace
+
+TEST(VoxelClusterer, EmptyInputIsNoop) {
+    std::vector<VoxelUpdate> voxels;
+    assign_instance_ids(voxels, 1.0f, 3);
+    EXPECT_TRUE(voxels.empty());
+    EXPECT_EQ(count_clusters(voxels), 0u);
+}
+
+TEST(VoxelClusterer, DisabledByZeroEps) {
+    // 10 tightly-packed voxels — would form one cluster at any positive eps.
+    // eps_m == 0 disables clustering, every voxel must keep id=0.
+    std::vector<VoxelUpdate> voxels;
+    for (int i = 0; i < 10; ++i) voxels.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/0.0f, /*min_pts=*/3);
+    for (const auto& v : voxels) EXPECT_EQ(v.instance_id, 0u);
+    EXPECT_EQ(count_clusters(voxels), 0u);
+}
+
+TEST(VoxelClusterer, DisabledByZeroMinPts) {
+    std::vector<VoxelUpdate> voxels;
+    for (int i = 0; i < 10; ++i) voxels.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/1.0f, /*min_pts=*/0);
+    for (const auto& v : voxels) EXPECT_EQ(v.instance_id, 0u);
+}
+
+TEST(VoxelClusterer, OneTightClusterGetsOneId) {
+    // 8 voxels packed into a 1m cube, eps=1m → all in one cluster.
+    std::vector<VoxelUpdate> voxels;
+    for (int i = 0; i < 8; ++i) voxels.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/1.0f, /*min_pts=*/3);
+    auto ids = distinct_ids(voxels);
+    EXPECT_EQ(ids.size(), 1u);
+    EXPECT_EQ(*ids.begin(), 1u);  // first non-zero ID
+    for (const auto& v : voxels) EXPECT_EQ(v.instance_id, 1u);
+}
+
+TEST(VoxelClusterer, SparseNoiseStaysUnclustered) {
+    // 6 voxels each ≥10m from every other — no neighbourhoods touch.
+    std::vector<VoxelUpdate> voxels = {
+        make_voxel(0.0f, 0.0f, 0.0f),   make_voxel(20.0f, 0.0f, 0.0f),
+        make_voxel(0.0f, 20.0f, 0.0f),  make_voxel(0.0f, 0.0f, 20.0f),
+        make_voxel(20.0f, 20.0f, 0.0f), make_voxel(-20.0f, -20.0f, -20.0f),
+    };
+
+    assign_instance_ids(voxels, /*eps_m=*/1.0f, /*min_pts=*/3);
+    for (const auto& v : voxels) EXPECT_EQ(v.instance_id, 0u);
+    EXPECT_EQ(count_clusters(voxels), 0u);
+}
+
+TEST(VoxelClusterer, TwoDistantClustersGetDistinctIds) {
+    // Cluster A around origin, cluster B around (50, 0, 0).  Distance
+    // between clusters is >>eps; within each cluster voxels are <eps apart.
+    std::vector<VoxelUpdate> voxels;
+    for (int i = 0; i < 5; ++i) voxels.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+    for (int i = 0; i < 5; ++i) voxels.push_back(make_voxel(50.0f + 0.1f * i, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/1.0f, /*min_pts=*/3);
+    auto ids = distinct_ids(voxels);
+    EXPECT_EQ(ids.size(), 2u);
+
+    // First five voxels share an ID; last five share a different ID.
+    for (int i = 1; i < 5; ++i) EXPECT_EQ(voxels[0].instance_id, voxels[i].instance_id);
+    for (int i = 6; i < 10; ++i) EXPECT_EQ(voxels[5].instance_id, voxels[i].instance_id);
+    EXPECT_NE(voxels[0].instance_id, voxels[5].instance_id);
+}
+
+TEST(VoxelClusterer, ChainedClusterUnionsTransitively) {
+    // Voxels at x = 0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0 with eps=0.6.
+    // Each pair (i, i+1) is within eps, so the whole chain becomes one
+    // cluster even though endpoints are 3 m apart.
+    std::vector<VoxelUpdate> voxels;
+    for (float x = 0.0f; x <= 3.0f; x += 0.5f) voxels.push_back(make_voxel(x, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/0.6f, /*min_pts=*/3);
+    auto ids = distinct_ids(voxels);
+    EXPECT_EQ(ids.size(), 1u) << "transitive union should merge the chain into one component";
+    for (const auto& v : voxels) EXPECT_NE(v.instance_id, 0u);
+}
+
+TEST(VoxelClusterer, SmallComponentBelowMinPtsBecomesNoise) {
+    // Cluster A: 5 voxels (>= min_pts) → real cluster
+    // Cluster B: 2 voxels (< min_pts) → noise (id=0)
+    std::vector<VoxelUpdate> voxels;
+    for (int i = 0; i < 5; ++i) voxels.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+    voxels.push_back(make_voxel(50.0f, 0.0f, 0.0f));
+    voxels.push_back(make_voxel(50.1f, 0.0f, 0.0f));
+
+    assign_instance_ids(voxels, /*eps_m=*/1.0f, /*min_pts=*/3);
+
+    // First 5 voxels share a non-zero ID.
+    EXPECT_NE(voxels[0].instance_id, 0u);
+    for (int i = 1; i < 5; ++i) EXPECT_EQ(voxels[0].instance_id, voxels[i].instance_id);
+    // Last 2 voxels are below min_pts → noise.
+    EXPECT_EQ(voxels[5].instance_id, 0u);
+    EXPECT_EQ(voxels[6].instance_id, 0u);
+}
+
+TEST(VoxelClusterer, ScratchReuseIsClean) {
+    // A scratch buffer reused across calls must produce the same result
+    // as a fresh buffer.  Catches state-leakage bugs (forgotten clear()).
+    VoxelClusterScratch scratch;
+
+    std::vector<VoxelUpdate> a;
+    for (int i = 0; i < 5; ++i) a.push_back(make_voxel(0.1f * i, 0.0f, 0.0f));
+    assign_instance_ids(a, 1.0f, 3, &scratch);
+    for (const auto& v : a) EXPECT_EQ(v.instance_id, 1u);
+
+    // Now run the same input again with the same scratch.  Without proper
+    // clear(), the parent vector / cell_to_voxel map would carry stale
+    // entries from the first call and could mis-cluster.
+    std::vector<VoxelUpdate> b;
+    for (int i = 0; i < 5; ++i) b.push_back(make_voxel(100.0f + 0.1f * i, 0.0f, 0.0f));
+    assign_instance_ids(b, 1.0f, 3, &scratch);
+    auto ids_b = distinct_ids(b);
+    EXPECT_EQ(ids_b.size(), 1u);
+    EXPECT_EQ(*ids_b.begin(), 1u) << "second call must restart IDs from 1, not continue from prior";
+}


### PR DESCRIPTION
## Summary

First phase of the architectural fix that **PR #636's empirical journey proved is required**.  Per-cell promotion can't distinguish noise voxels from real-obstacle voxels — three scenario-33 runs across TTL ∈ {8, 15, 30}s and cap ∈ {500, 2000} all failed at different points in the same way.  Option B = promote at the *instance* level: cluster voxels first, track instances across frames, only promote whole tracked instances.  Phase 1 adds clustering only.

This PR is **purely additive** — clustering is disabled by default (`cluster.eps_m == 0`), so consumer behaviour is unchanged.  The IPC `SemanticVoxel` struct grows by 8 B (32 → 40 B) for the new `instance_id` field plus alignment padding.

## What lands

| Component | Change |
|---|---|
| **`SemanticVoxel`** (IPC) | + `uint32_t instance_id` + 4 B pad. Wire size 32→40 B. Static asserts updated. |
| **`hal::VoxelUpdate`** | + `uint32_t instance_id` mirror so projector→clusterer→publish path is type-stable. |
| **`voxel_clusterer.h`** (new, header-only) | `assign_instance_ids(voxels, eps_m, min_pts, scratch?)` — Union-Find on grid hash. O(N·α(N)). Deterministic. |
| **P2 `mask_projection_thread`** | Calls clusterer in-place after `MaskDepthProjector::project()`, before publish. Persistent scratch buffer reused across frames. |
| **Config** | `perception.path_a.cluster.eps_m` (default 0) and `.cluster.min_pts` (default 3). |
| **Tests** | 9 new GTests (`test_voxel_clusterer.cpp`). |

## Algorithm choice — why Union-Find on a grid hash, not DBSCAN

| Property | Union-Find on grid | DBSCAN |
|---|---|---|
| Determinism | Order-independent | IDs depend on iteration order |
| Worst-case complexity | O(N·α(N)) | O(N²) |
| Setup | One hashmap | kd-tree + distance metric |
| At N = 5000 (scenario-33 typical) | ~1 ms | ~10–100 ms |

Same correctness for our use case (spatial connectivity at fixed eps), much cheaper.

## What this does NOT yet do

- **No consumer change** — `OccupancyGrid3D::insert_voxels()` ignores `instance_id`.  P4 behaviour unchanged.  Phase 3 wires consumption.
- **No cross-frame tracking** — cluster IDs are frame-local, regenerated each frame. Phase 2 adds the tracker.
- **No scenario change** — `cluster.eps_m == 0` default keeps every scenario at today's behaviour.

## Coordination with PR #636

PR #636 is still open and lands the infrastructure (`OccupancyGrid3D` TTL plumbing, voxel-path cap enforcement, side-table, radar realism).  That work is *preserved and reused* — Phase 3 of #638 builds on top of #636's `insert_voxels()` and keys promotion off `instance_id`.  Recommended merge order: #636 → this → Phase 2 → Phase 3.

## Verification

- Build: clean (zero warnings, `-Werror -Wall -Wextra`).
- Tests: **1902 / 1902 pass** (one `PerceptionDrainTest` parallel-ctest flake passed on rerun, same recurring noise as PR #637/#636).
- 9 / 9 voxel-clusterer tests green.
- Format: clang-format-18 clean on all touched files.

## Test plan

- [ ] Re-run Pass 1 + Pass 2 review agents.
- [ ] Verify scenario 33 still passes its existing pass criteria with clustering DISABLED (default) — proves no regression.
- [ ] Once #636 merges + Phase 3 lands, scenario 33 should pass with clustering enabled (real fix, no per-cell tuning).

Closes part of #638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)